### PR TITLE
feat: implement project creation with templates

### DIFF
--- a/cmd/devkit/main.go
+++ b/cmd/devkit/main.go
@@ -12,12 +12,11 @@ import (
 
 func main() {
 	app := &cli.App{
-		Name:  "devkit",
-		Usage: "EigenLayer Development Kit",
-		Flags: common.GlobalFlags,
-		Commands: []*cli.Command{
-			commands.AVSCommand,
-		},
+		Name:                   "devkit",
+		Usage:                  "EigenLayer Development Kit",
+		Flags:                  common.GlobalFlags,
+		Commands:               []*cli.Command{commands.AVSCommand},
+		UseShortOptionHandling: true,
 	}
 
 	if err := app.Run(os.Args); err != nil {

--- a/config/templates.yml
+++ b/config/templates.yml
@@ -1,0 +1,17 @@
+architectures:
+  hourglass:
+    languages:
+      go:
+        template: "https://github.com/Layr-Labs/hourglass-avs-template/tree/sm-templateExample"
+      ts:
+        template: ""
+      rust:
+        template: ""
+  teal:
+    languages:
+      go:
+        template: "https://github.com/Layr-Labs/teal"
+      ts:
+        template: ""
+      rust:
+        template: ""

--- a/config/templates.yml
+++ b/config/templates.yml
@@ -7,10 +7,10 @@ architectures:
         template: ""
       rust:
         template: ""
-  teal:
+  hello-world-avs:
     languages:
       go:
-        template: "https://github.com/Layr-Labs/teal"
+        template: "https://github.com/Layr-Labs/hello-world-avs"
       ts:
         template: ""
       rust:

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,10 @@ module devkit-cli
 
 go 1.23.2
 
-require github.com/urfave/cli/v2 v2.27.6
+require (
+	github.com/urfave/cli/v2 v2.27.6
+	gopkg.in/yaml.v3 v3.0.1
+)
 
 require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,3 +6,7 @@ github.com/urfave/cli/v2 v2.27.6 h1:VdRdS98FNhKZ8/Az8B7MTyGQmpIr36O1EHybx/LaZ4g=
 github.com/urfave/cli/v2 v2.27.6/go.mod h1:3Sevf16NykTbInEnD0yKkjDAeZDS0A6bzhBH5hrMvTQ=
 github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 h1:gEOO8jv9F4OT7lGCjxCBTO/36wtF6j2nSip77qHd4x4=
 github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1/go.mod h1:Ohn+xnUBiLI6FVj/9LpzZWtj1/D6lUovWYBkxHVV3aM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/commands/avs.go
+++ b/pkg/commands/avs.go
@@ -1,13 +1,16 @@
 package commands
 
 import (
+	"devkit-cli/pkg/common"
+
 	"github.com/urfave/cli/v2"
 )
 
 // AVSCommand defines the top-level "avs" command
 var AVSCommand = &cli.Command{
 	Name:  "avs",
-	Usage: "Manage EigenLayer AVS (Actively Validated Services) projects",
+	Usage: "Manage EigenLayer AVS (Autonomous Verifiable Services) projects",
+	Flags: common.GlobalFlags,
 	Subcommands: []*cli.Command{
 		CreateCommand,
 		ConfigCommand,

--- a/pkg/commands/build.go
+++ b/pkg/commands/build.go
@@ -3,6 +3,8 @@ package commands
 import (
 	"devkit-cli/pkg/common"
 	"log"
+	"os"
+	"os/exec"
 
 	"github.com/urfave/cli/v2"
 )
@@ -12,20 +14,25 @@ var BuildCommand = &cli.Command{
 	Name:  "build",
 	Usage: "Compiles AVS components (smart contracts via Foundry, Go binaries for operators/aggregators)",
 	Flags: append([]cli.Flag{
-		&cli.BoolFlag{
+		// TBD: Release flag will be implemented in future
+		/*&cli.BoolFlag{
 			Name:  "release",
 			Usage: "Produce production-optimized artifacts",
-		},
+		},*/
 	}, common.GlobalFlags...),
 	Action: func(cCtx *cli.Context) error {
 		if cCtx.Bool("verbose") {
 			log.Printf("Building AVS components...")
-			if cCtx.Bool("release") {
-				log.Printf("Building in release mode...")
-			}
 		}
 
-		// Placeholder for future implementation
+		// Execute make build with Makefile.Devkit
+		cmd := exec.Command("make", "-f", "Makefile.Devkit", "build")
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			return err
+		}
+
 		log.Printf("Build completed successfully")
 		return nil
 	},

--- a/pkg/commands/build.go
+++ b/pkg/commands/build.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"devkit-cli/pkg/common"
 	"log"
 
 	"github.com/urfave/cli/v2"
@@ -10,12 +11,12 @@ import (
 var BuildCommand = &cli.Command{
 	Name:  "build",
 	Usage: "Compiles AVS components (smart contracts via Foundry, Go binaries for operators/aggregators)",
-	Flags: []cli.Flag{
+	Flags: append([]cli.Flag{
 		&cli.BoolFlag{
 			Name:  "release",
 			Usage: "Produce production-optimized artifacts",
 		},
-	},
+	}, common.GlobalFlags...),
 	Action: func(cCtx *cli.Context) error {
 		if cCtx.Bool("verbose") {
 			log.Printf("Building AVS components...")

--- a/pkg/commands/build_test.go
+++ b/pkg/commands/build_test.go
@@ -1,0 +1,42 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/urfave/cli/v2"
+)
+
+func TestBuildCommand(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create a mock Makefile.Devkit
+	mockMakefile := `
+.PHONY: build
+build:
+	@echo "Mock build executed"
+	`
+	if err := os.WriteFile(filepath.Join(tmpDir, "Makefile.Devkit"), []byte(mockMakefile), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Run from temp directory
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(oldWd)
+
+	app := &cli.App{
+		Name:     "test",
+		Commands: []*cli.Command{BuildCommand},
+	}
+
+	if err := app.Run([]string{"app", "build"}); err != nil {
+		t.Errorf("Failed to execute build command: %v", err)
+	}
+}

--- a/pkg/commands/build_test.go
+++ b/pkg/commands/build_test.go
@@ -29,7 +29,11 @@ build:
 	if err := os.Chdir(tmpDir); err != nil {
 		t.Fatal(err)
 	}
-	defer os.Chdir(oldWd)
+	defer func() {
+		if err := os.Chdir(oldWd); err != nil {
+			t.Logf("Failed to change back to original directory: %v", err)
+		}
+	}()
 
 	app := &cli.App{
 		Name:     "test",

--- a/pkg/commands/config.go
+++ b/pkg/commands/config.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"devkit-cli/pkg/common"
 	"log"
 
 	"github.com/urfave/cli/v2"
@@ -10,7 +11,7 @@ import (
 var ConfigCommand = &cli.Command{
 	Name:  "config",
 	Usage: "Views or manages project-specific configuration (stored in eigen.toml)",
-	Flags: []cli.Flag{
+	Flags: append([]cli.Flag{
 		&cli.BoolFlag{
 			Name:  "list",
 			Usage: "Display all current project configuration settings",
@@ -19,7 +20,7 @@ var ConfigCommand = &cli.Command{
 			Name:  "set",
 			Usage: "Set or update a specific configuration key in eigen.toml",
 		},
-	},
+	}, common.GlobalFlags...),
 	Action: func(cCtx *cli.Context) error {
 		if cCtx.Bool("verbose") {
 			log.Printf("Managing project configuration...")

--- a/pkg/commands/create.go
+++ b/pkg/commands/create.go
@@ -3,6 +3,11 @@ package commands
 import (
 	"fmt"
 	"log"
+	"os"
+	"path/filepath"
+
+	"devkit-cli/pkg/common"
+	"devkit-cli/pkg/template"
 
 	"github.com/urfave/cli/v2"
 )
@@ -12,11 +17,11 @@ var CreateCommand = &cli.Command{
 	Name:      "create",
 	Usage:     "Initializes a new AVS project scaffold (Hourglass model)",
 	ArgsUsage: "<project-name>",
-	Flags: []cli.Flag{
+	Flags: append([]cli.Flag{
 		&cli.StringFlag{
 			Name:  "dir",
 			Usage: "Set output directory for the new project",
-			Value: "./output",
+			Value: filepath.Join(os.Getenv("HOME"), "avs"),
 		},
 		&cli.StringFlag{
 			Name:  "lang",
@@ -28,6 +33,10 @@ var CreateCommand = &cli.Command{
 			Usage: "Specifies AVS architecture (task-based/hourglass, epoch-based, etc.)",
 			Value: "task",
 		},
+		&cli.StringFlag{
+			Name:  "template-path",
+			Usage: "Direct GitHub URL to use as template (overrides templates.yml)",
+		},
 		&cli.BoolFlag{
 			Name:  "no-telemetry",
 			Usage: "Opt out of anonymous telemetry collection",
@@ -37,12 +46,17 @@ var CreateCommand = &cli.Command{
 			Usage: "Chooses the environment (local, testnet, mainnet)",
 			Value: "local",
 		},
-	},
+		&cli.BoolFlag{
+			Name:  "overwrite",
+			Usage: "Force overwrite if project directory already exists",
+		},
+	}, common.GlobalFlags...),
 	Action: func(cCtx *cli.Context) error {
 		if cCtx.NArg() == 0 {
 			return fmt.Errorf("project name is required\nUsage: avs create <project-name> [flags]")
 		}
 		projectName := cCtx.Args().First()
+		targetDir := filepath.Join(cCtx.String("dir"), projectName)
 
 		if cCtx.Bool("verbose") {
 			log.Printf("Creating new AVS project: %s", projectName)
@@ -50,6 +64,9 @@ var CreateCommand = &cli.Command{
 			log.Printf("Language: %s", cCtx.String("lang"))
 			log.Printf("Architecture: %s", cCtx.String("arch"))
 			log.Printf("Environment: %s", cCtx.String("env"))
+			if cCtx.String("template-path") != "" {
+				log.Printf("Template Path: %s", cCtx.String("template-path"))
+			}
 			if cCtx.Bool("no-telemetry") {
 				log.Printf("Telemetry: disabled")
 			} else {
@@ -57,8 +74,65 @@ var CreateCommand = &cli.Command{
 			}
 		}
 
-		// Placeholder for future implementation
-		log.Printf("Project %s created successfully in %s", projectName, cCtx.String("dir"))
+		if err := createProjectDir(targetDir, cCtx.Bool("overwrite"), cCtx.Bool("verbose")); err != nil {
+			return err
+		}
+
+		templateURL, err := getTemplateURL(cCtx)
+		if err != nil {
+			return err
+		}
+
+		if cCtx.Bool("verbose") {
+			log.Printf("Using template: %s", templateURL)
+		}
+
+		// Fetch template
+		fetcher := &template.GitFetcher{}
+		if err := fetcher.Fetch(templateURL, targetDir); err != nil {
+			return fmt.Errorf("failed to fetch template from %s: %w", templateURL, err)
+		}
+
+		log.Printf("Project %s created successfully in %s. Run 'cd %s' to get started.", projectName, targetDir, targetDir)
 		return nil
 	},
+}
+
+func getTemplateURL(cCtx *cli.Context) (string, error) {
+	if templatePath := cCtx.String("template-path"); templatePath != "" {
+		return templatePath, nil
+	}
+
+	arch := cCtx.String("arch")
+
+	config, err := template.LoadConfig()
+	if err != nil {
+		return "", fmt.Errorf("failed to load templates config: %w", err)
+	}
+
+	url, err := template.GetTemplateURL(config, arch, cCtx.String("lang"))
+	if err != nil {
+		return "", fmt.Errorf("failed to get template URL: %w", err)
+	}
+
+	if url == "" {
+		return "", fmt.Errorf("no template found for architecture %s and language %s", arch, cCtx.String("lang"))
+	}
+
+	return url, nil
+}
+
+func createProjectDir(targetDir string, overwrite, verbose bool) error {
+	if _, err := os.Stat(targetDir); !os.IsNotExist(err) {
+		if !overwrite {
+			return fmt.Errorf("directory %s already exists. Use --overwrite flag to force overwrite", targetDir)
+		}
+		if err := os.RemoveAll(targetDir); err != nil {
+			return fmt.Errorf("failed to remove existing directory: %w", err)
+		}
+		if verbose {
+			log.Printf("Removed existing directory: %s", targetDir)
+		}
+	}
+	return os.MkdirAll(targetDir, 0755)
 }

--- a/pkg/commands/create_test.go
+++ b/pkg/commands/create_test.go
@@ -1,0 +1,47 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/urfave/cli/v2"
+)
+
+func TestCreateCommand(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Override default directory
+	origCmd := CreateCommand
+	tmpCmd := *CreateCommand
+	tmpCmd.Flags = []cli.Flag{
+		&cli.StringFlag{
+			Name:  "dir",
+			Value: tmpDir,
+		},
+		&cli.StringFlag{
+			Name:  "template-path",
+			Value: "https://github.com/Layr-Labs/teal",
+		},
+	}
+	CreateCommand = &tmpCmd
+	defer func() { CreateCommand = origCmd }()
+
+	app := &cli.App{
+		Name:     "test",
+		Commands: []*cli.Command{&tmpCmd},
+	}
+
+	// Test 1: Missing project name
+	if err := app.Run([]string{"app", "create"}); err == nil {
+		t.Error("Expected error for missing project name")
+	}
+
+	// Test 2: Basic project creation
+	if err := app.Run([]string{"app", "create", "test-project"}); err != nil {
+		t.Errorf("Failed to create project: %v", err)
+	}
+
+	// Test 3: Project exists (trying to create same project again)
+	if err := app.Run([]string{"app", "create", "test-project"}); err == nil {
+		t.Error("Expected error when creating existing project")
+	}
+}

--- a/pkg/commands/create_test.go
+++ b/pkg/commands/create_test.go
@@ -68,7 +68,11 @@ build:
 	if err := os.Chdir(projectPath); err != nil {
 		t.Fatal(err)
 	}
-	defer os.Chdir(oldWd)
+	defer func() {
+		if err := os.Chdir(oldWd); err != nil {
+			t.Logf("Failed to change back to original directory: %v", err)
+		}
+	}()
 
 	buildApp := &cli.App{
 		Name:     "test",

--- a/pkg/commands/devnet.go
+++ b/pkg/commands/devnet.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"devkit-cli/pkg/common"
 	"log"
 
 	"github.com/urfave/cli/v2"
@@ -14,7 +15,7 @@ var DevnetCommand = &cli.Command{
 		{
 			Name:  "start",
 			Usage: "Starts Docker containers and deploys local contracts",
-			Flags: []cli.Flag{
+			Flags: append([]cli.Flag{
 				&cli.BoolFlag{
 					Name:  "reset",
 					Usage: "Wipe and restart the devnet from scratch",
@@ -32,7 +33,7 @@ var DevnetCommand = &cli.Command{
 					Usage: "Specify a custom port for local devnet",
 					Value: 8545,
 				},
-			},
+			}, common.GlobalFlags...),
 			Action: func(cCtx *cli.Context) error {
 				if cCtx.Bool("verbose") {
 					log.Printf("Starting devnet...")
@@ -54,6 +55,7 @@ var DevnetCommand = &cli.Command{
 		{
 			Name:  "stop",
 			Usage: "Stops and removes all containers and resources",
+			Flags: append([]cli.Flag{}, common.GlobalFlags...),
 			Action: func(cCtx *cli.Context) error {
 				if cCtx.Bool("verbose") {
 					log.Printf("Stopping devnet...")

--- a/pkg/commands/release.go
+++ b/pkg/commands/release.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"devkit-cli/pkg/common"
 	"log"
 
 	"github.com/urfave/cli/v2"
@@ -10,7 +11,7 @@ import (
 var ReleaseCommand = &cli.Command{
 	Name:  "release",
 	Usage: "Packages and publishes AVS artifacts to a registry or channel",
-	Flags: []cli.Flag{
+	Flags: append([]cli.Flag{
 		&cli.StringFlag{
 			Name:  "tag",
 			Usage: "Tag the release (e.g. v0.1, beta, mainnet)",
@@ -24,7 +25,7 @@ var ReleaseCommand = &cli.Command{
 			Name:  "sign",
 			Usage: "Sign the release artifacts with a local key",
 		},
-	},
+	}, common.GlobalFlags...),
 	Action: func(cCtx *cli.Context) error {
 		if cCtx.Bool("verbose") {
 			log.Printf("Preparing release...")

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"devkit-cli/pkg/common"
 	"log"
 
 	"github.com/urfave/cli/v2"
@@ -10,6 +11,7 @@ import (
 var RunCommand = &cli.Command{
 	Name:  "run",
 	Usage: "Submits tasks to the local devnet, triggers off-chain execution, and aggregates results",
+	Flags: append([]cli.Flag{}, common.GlobalFlags...),
 	Action: func(cCtx *cli.Context) error {
 		if cCtx.Bool("verbose") {
 			log.Printf("Running AVS tasks...")

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -3,6 +3,8 @@ package commands
 import (
 	"devkit-cli/pkg/common"
 	"log"
+	"os"
+	"os/exec"
 
 	"github.com/urfave/cli/v2"
 )
@@ -17,7 +19,14 @@ var RunCommand = &cli.Command{
 			log.Printf("Running AVS tasks...")
 		}
 
-		// Placeholder for future implementation
+		// Execute make run with Makefile.Devkit
+		cmd := exec.Command("make", "-f", "Makefile.Devkit", "run")
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			return err
+		}
+
 		log.Printf("Task execution completed successfully")
 		return nil
 	},

--- a/pkg/commands/run_test.go
+++ b/pkg/commands/run_test.go
@@ -29,7 +29,11 @@ run:
 	if err := os.Chdir(tmpDir); err != nil {
 		t.Fatal(err)
 	}
-	defer os.Chdir(oldWd)
+	defer func() {
+		if err := os.Chdir(oldWd); err != nil {
+			t.Logf("Failed to change back to original directory: %v", err)
+		}
+	}()
 
 	app := &cli.App{
 		Name:     "test",

--- a/pkg/commands/run_test.go
+++ b/pkg/commands/run_test.go
@@ -1,0 +1,42 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/urfave/cli/v2"
+)
+
+func TestRunCommand(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create a mock Makefile.Devkit
+	mockMakefile := `
+.PHONY: run
+run:
+	@echo "Mock run executed"
+	`
+	if err := os.WriteFile(filepath.Join(tmpDir, "Makefile.Devkit"), []byte(mockMakefile), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Run from temp directory
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(oldWd)
+
+	app := &cli.App{
+		Name:     "test",
+		Commands: []*cli.Command{RunCommand},
+	}
+
+	if err := app.Run([]string{"app", "run"}); err != nil {
+		t.Errorf("Failed to execute run command: %v", err)
+	}
+}

--- a/pkg/template/config.go
+++ b/pkg/template/config.go
@@ -1,0 +1,54 @@
+package template
+
+import (
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+var configPath = filepath.Join("config", "templates.yml")
+
+type Config struct {
+	Architectures map[string]Architecture `yaml:"architectures"`
+}
+
+type Architecture struct {
+	Languages map[string]Language `yaml:"languages"`
+}
+
+type Language struct {
+	Template string `yaml:"template"`
+}
+
+func LoadConfig() (*Config, error) {
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return nil, err
+	}
+
+	var config Config
+	if err := yaml.Unmarshal(data, &config); err != nil {
+		return nil, err
+	}
+
+	return &config, nil
+}
+
+func GetTemplateURL(config *Config, arch, lang string) (string, error) {
+	archConfig, exists := config.Architectures[arch]
+	if !exists {
+		return "", nil
+	}
+
+	langConfig, exists := archConfig.Languages[lang]
+	if !exists {
+		return "", nil
+	}
+
+	if langConfig.Template == "" {
+		return "", nil
+	}
+
+	return langConfig.Template, nil
+}

--- a/pkg/template/config_test.go
+++ b/pkg/template/config_test.go
@@ -1,0 +1,52 @@
+package template
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadConfig(t *testing.T) {
+	// Create a temporary config file
+	tempDir := t.TempDir()
+	testConfigPath := filepath.Join(tempDir, "templates.yml")
+	configContent := `
+architectures:
+  hourglass:
+    languages:
+      go:
+        template: "https://github.com/Layr-Labs/hourglass-avs-template"
+`
+
+	if err := os.WriteFile(testConfigPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("Failed to write test config: %v", err)
+	}
+
+	// Override the config path for testing
+	oldConfigPath := configPath
+	configPath = testConfigPath
+	defer func() { configPath = oldConfigPath }()
+
+	config, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("Failed to load config: %v", err)
+	}
+
+	// Test template URL lookup
+	url, err := GetTemplateURL(config, "hourglass", "go")
+	if err != nil {
+		t.Fatalf("Failed to get template URL: %v", err)
+	}
+	if url != "https://github.com/Layr-Labs/hourglass-avs-template" {
+		t.Errorf("Unexpected template URL: got %s, want %s", url, "https://github.com/Layr-Labs/hourglass-avs-template")
+	}
+
+	// Test non-existent architecture
+	url, err = GetTemplateURL(config, "nonexistent", "go")
+	if err != nil {
+		t.Fatalf("Failed to get template URL: %v", err)
+	}
+	if url != "" {
+		t.Errorf("Expected empty URL for nonexistent architecture, got %s", url)
+	}
+}

--- a/pkg/template/fetcher.go
+++ b/pkg/template/fetcher.go
@@ -1,0 +1,52 @@
+package template
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+type Fetcher interface {
+	Fetch(templateURL, targetDir string) error
+}
+
+type GitFetcher struct{}
+
+func parseGitHubURL(url string) (repoURL, branch string) {
+	// Handle GitHub tree URLs (e.g., https://github.com/user/repo/tree/branch)
+	if strings.Contains(url, "/tree/") {
+		parts := strings.Split(url, "/tree/")
+		if len(parts) == 2 {
+			repoURL = parts[0] + ".git"
+			branch = parts[1]
+			return
+		}
+	}
+	// Handle regular Git URLs
+	return url, ""
+}
+
+func (g *GitFetcher) Fetch(templateURL, targetDir string) error {
+	repoURL, branch := parseGitHubURL(templateURL)
+
+	args := []string{"clone", "--depth=1"}
+	if branch != "" {
+		args = append(args, "-b", branch)
+	}
+	args = append(args, repoURL, targetDir)
+
+	cmd := exec.Command("git", args...)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to clone template: %w", err)
+	}
+
+	// Cleanup .git directory
+	gitDir := filepath.Join(targetDir, ".git")
+	if err := os.RemoveAll(gitDir); err != nil {
+		return fmt.Errorf("failed to remove .git directory: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/template/fetcher_test.go
+++ b/pkg/template/fetcher_test.go
@@ -1,0 +1,24 @@
+package template
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestGitFetcher(t *testing.T) {
+	fetcher := &GitFetcher{}
+	tempDir := t.TempDir()
+
+	// Test with an invalid URL (should fail)
+	err := fetcher.Fetch("invalid-url", tempDir)
+	if err == nil {
+		t.Error("Expected error for invalid URL")
+	}
+
+	// Verify .git directory is not present (since Fetch failed)
+	gitDir := filepath.Join(tempDir, ".git")
+	if _, err := os.Stat(gitDir); !os.IsNotExist(err) {
+		t.Error("Expected no .git directory after failed fetch")
+	}
+}


### PR DESCRIPTION
**Motivation:**
Implement core CLI functionality for creating, and demo-able funcationality for building, and running AVS projects

**Modifications:**
- Add template-based project scaffolding from git repos
- Add --template-path and --overwrite flags
- Support multiple architectures and languages via templates.yml
- Set default project dir to ~/avs
- Basic build/run hooks

**Result:**
Users can create new AVS projects with devkit avs create/build/run

**Open questions:**
Telemetry feature will be added later
