### PR TITLE
feat: add pre-commit hook for golangci-lint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+default_stages: [pre-commit,pre-push]
+
+repos:
+  - repo: https://github.com/golangci/golangci-lint
+    rev: v1.64.8
+    hooks:
+      - id: golangci-lint
+        name: golangci-lint
+        entry: golangci-lint run
+        types: [go]
+        pass_filenames: false
+        args: ["--timeout=1m"]

--- a/README.md
+++ b/README.md
@@ -19,15 +19,6 @@ go build -o devkit ./cmd/devkit
 devkit --help
 ```
 
-## Core Commands (under devkit)
-
-- `avs create` - Scaffold new AVS projects
-- `avs config` - Manage project configuration
-- `avs build` - Compile contracts and binaries
-- `avs devnet` - Run local development network
-- `avs run` - Execute and simulate tasks
-- `avs release` - Package for deployment
-
 ## Development
 
 ```bash
@@ -35,7 +26,19 @@ make help      # Show all commands
 make build     # Build binary
 make tests     # Run tests
 make lint      # Run linter
+
+# Install pre-commit hooks
+pre-commit install
 ```
+
+## Core Commands
+
+- `devkit avs create` - Scaffold new AVS projects
+- `devkit avs config` - Manage project configuration
+- `devkit avs build` - Compile contracts and binaries
+- `devkit avs devnet` - Run local development network
+- `devkit avs run` - Execute and simulate tasks
+- `devkit avs release` - Package for deployment
 
 ## Options
 


### PR DESCRIPTION
**Motivation**
Provide immediate lint feedback during development, reducing delays caused by PR review.

**Modifications**
Added a pre-commit hook to run `golangci-lint` locally before commits and before push.

**Result**
Developers get instant linting feedback, improving code quality and speeding up the review process.