### PR TITLE
refactor: config loading and add eigen.toml template generation

### DIFF
--- a/pkg/commands/avs.go
+++ b/pkg/commands/avs.go
@@ -1,28 +1,12 @@
 package commands
 
 import (
-	"context"
-	"devkit-cli/pkg/common"
-	"fmt"
 	"github.com/urfave/cli/v2"
 )
-
-type ctxKey string
-
-const ConfigContextKey ctxKey = "eigenConfig"
 
 var AVSCommand = &cli.Command{
 	Name:  "avs",
 	Usage: "Manage EigenLayer AVS (Autonomous Verifiable Services) projects",
-	Before: func(cCtx *cli.Context) error {
-		cfg, err := common.LoadEigenConfig()
-		if err != nil {
-			return fmt.Errorf("failed to load eigen.toml: %w", err)
-		}
-		ctx := context.WithValue(cCtx.Context, ConfigContextKey, cfg)
-		cCtx.Context = ctx
-		return nil
-	},
 	Subcommands: []*cli.Command{
 		CreateCommand,
 		ConfigCommand,

--- a/pkg/commands/build.go
+++ b/pkg/commands/build.go
@@ -21,7 +21,20 @@ var BuildCommand = &cli.Command{
 		},*/
 	}, common.GlobalFlags...),
 	Action: func(cCtx *cli.Context) error {
-		cfg := cCtx.Context.Value(ConfigContextKey).(*common.EigenConfig)
+		var cfg *common.EigenConfig
+
+		// First check if config is in context (for testing)
+		if cfgValue := cCtx.Context.Value(ConfigContextKey); cfgValue != nil {
+			cfg = cfgValue.(*common.EigenConfig)
+		} else {
+			// Load from file if not in context
+			var err error
+			cfg, err = common.LoadEigenConfig()
+			if err != nil {
+				return err
+			}
+		}
+
 		if cCtx.Bool("verbose") {
 			log.Printf("Project Name: %s", cfg.Project.Name)
 			log.Printf("Building AVS components...")

--- a/pkg/commands/devnet_actions.go
+++ b/pkg/commands/devnet_actions.go
@@ -13,8 +13,12 @@ import (
 )
 
 func StartDevnetAction(cCtx *cli.Context) error {
-	// Load
-	config := cCtx.Context.Value(ConfigContextKey).(*common.EigenConfig)
+	// Load config
+	config, err := common.LoadEigenConfig()
+	if err != nil {
+		return err
+	}
+
 	port := cCtx.Int("port")
 	chain_image := devnet.GetDevnetChainImageOrDefault(config)
 	chain_args := devnet.GetDevnetChainArgsOrDefault(config)
@@ -60,8 +64,12 @@ func StartDevnetAction(cCtx *cli.Context) error {
 }
 
 func StopDevnetAction(cCtx *cli.Context) error {
-	// Load
-	config := cCtx.Context.Value(ConfigContextKey).(*common.EigenConfig)
+	// Load config
+	config, err := common.LoadEigenConfig()
+	if err != nil {
+		return err
+	}
+
 	port := cCtx.Int("port")
 
 	if cCtx.Bool("verbose") {

--- a/pkg/commands/testutils.go
+++ b/pkg/commands/testutils.go
@@ -3,8 +3,14 @@ package commands
 import (
 	"context"
 	"devkit-cli/pkg/common"
+
 	"github.com/urfave/cli/v2"
 )
+
+type ctxKey string
+
+// ConfigContextKey identifies the eigenConfig in context
+const ConfigContextKey ctxKey = "eigenConfig"
 
 func WithTestConfig(cmd *cli.Command) *cli.Command {
 	cmd.Before = func(cCtx *cli.Context) error {

--- a/pkg/common/config.go
+++ b/pkg/common/config.go
@@ -1,6 +1,8 @@
 package common
 
 import (
+	"fmt"
+
 	"github.com/BurntSushi/toml"
 )
 
@@ -69,7 +71,7 @@ func LoadEigenConfig() (*EigenConfig, error) {
 
 	var config EigenConfig
 	if _, err := toml.DecodeFile(defaultPath, &config); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("eigen.toml not found. Are you running this command from your project directory?")
 	}
 	return &config, nil
 }


### PR DESCRIPTION
**Motivation:**
Project commands generated confusing errors when eigen.toml was missing, especially with help flags and unimplemented commands.

**Modifications:**
- Removed config loading from global Before hook
- Moved config loading to individual commands that need it
- Added project-specific eigen.toml generation during project creation
- Improved error messages for missing configuration

**Result:**
Help commands work without eigen.toml, create command properly initializes config, and each command handles its own configuration needs independently, resulting in a more intuitive CLI experience.