### PR TITLE
refactor: rename "hourglass" to "task" architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ A CLI tool for developing and managing EigenLayer AVS (Autonomous Verifiable Ser
 
 ```bash
 # Clone and build
-git clone <repository-url>
-cd devkit
+git clone https://github.com/Layr-Labs/devkit-cli
+cd devkit-cli
 
 # Build using make
 make install
@@ -17,6 +17,26 @@ go build -o devkit ./cmd/devkit
 
 # Get started
 devkit --help
+```
+
+# Demo flow
+```bash
+# If not already, clone it
+git clone https://github.com/Layr-Labs/devkit-cli
+cd devkit-cli
+
+# If not already, pull the latest commit
+git pull origin main
+
+# Note that you have to run the create command from repository directory
+devkit avs create my-hourglass-project  # by default pick task arch and go lang
+OR
+devkit avs create --overwrite my-existing-hourglass-project
+
+# Once you have a project directory, following commands should be run from the project directory you created.
+devkit avs build
+
+devkit avs run
 ```
 
 ## Development

--- a/config/templates.yml
+++ b/config/templates.yml
@@ -1,5 +1,5 @@
 architectures:
-  hourglass:
+  task:
     languages:
       go:
         template: "https://github.com/Layr-Labs/hourglass-avs-template/tree/sm-templateExample"

--- a/pkg/template/config_test.go
+++ b/pkg/template/config_test.go
@@ -12,7 +12,7 @@ func TestLoadConfig(t *testing.T) {
 	testConfigPath := filepath.Join(tempDir, "templates.yml")
 	configContent := `
 architectures:
-  hourglass:
+  task:
     languages:
       go:
         template: "https://github.com/Layr-Labs/hourglass-avs-template"
@@ -33,7 +33,7 @@ architectures:
 	}
 
 	// Test template URL lookup
-	url, err := GetTemplateURL(config, "hourglass", "go")
+	url, err := GetTemplateURL(config, "task", "go")
 	if err != nil {
 		t.Fatalf("Failed to get template URL: %v", err)
 	}


### PR DESCRIPTION
**Motivation**
- simplify demo
- default to task arch and go lang

**Modifications**
- updated architecture name in configs and tests
- improved README demo instructions

**Result**
- consistent usage of task architecture instead of hourglass