### PR TITLE
feat(config): Add --set config to update TOML config in terminal

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/holiman/uint256 v1.3.2 // indirect
 	github.com/mmcloughlin/addchain v0.4.0 // indirect
+	github.com/naoina/go-stringutil v0.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/shirou/gopsutil v3.21.4-0.20210419000835-c7a38de76ee5+incompatible // indirect
 	github.com/supranational/blst v0.3.14 // indirect
@@ -37,9 +38,9 @@ require (
 )
 
 require (
-	github.com/BurntSushi/toml v1.5.0
 	github.com/cpuguy83/go-md2man/v2 v2.0.5 // indirect
 	github.com/ethereum/go-ethereum v1.15.9
+	github.com/naoina/toml v0.1.2-0.20170918210437-9fafd6967416
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/stretchr/testify v1.10.0
 	github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/BurntSushi/toml v1.5.0 h1:W5quZX/G/csjUnuI8SUYlsHs9M38FC7znL0lIO+DvMg=
-github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/DataDog/zstd v1.4.5 h1:EndNeuB0l9syBZhut0wns3gV1hL8zX8LIu6ZiVHWLIQ=
 github.com/DataDog/zstd v1.4.5/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
@@ -107,6 +105,10 @@ github.com/mitchellh/pointerstructure v1.2.0/go.mod h1:BRAsLI5zgXmw97Lf6s25bs8oh
 github.com/mmcloughlin/addchain v0.4.0 h1:SobOdjm2xLj1KkXN5/n0xTIWyZA2+s99UCY1iPfkHRY=
 github.com/mmcloughlin/addchain v0.4.0/go.mod h1:A86O+tHqZLMNO4w6ZZ4FlVQEadcoqkyU72HC5wJ4RlU=
 github.com/mmcloughlin/profile v0.1.1/go.mod h1:IhHD7q1ooxgwTgjxQYkACGA77oFTDdFVejUS1/tS/qU=
+github.com/naoina/go-stringutil v0.1.0 h1:rCUeRUHjBjGTSHl0VC00jUPLz8/F9dDzYI70Hzifhks=
+github.com/naoina/go-stringutil v0.1.0/go.mod h1:XJ2SJL9jCtBh+P9q5btrd/Ylo8XwT/h1USek5+NqSA0=
+github.com/naoina/toml v0.1.2-0.20170918210437-9fafd6967416 h1:shk/vn9oCoOTmwcouEdwIeOtOGA/ELRUw/GwvxwfT+0=
+github.com/naoina/toml v0.1.2-0.20170918210437-9fafd6967416/go.mod h1:NBIhNtsFMo3G2szEBne+bO4gS192HuIYRqfvOWb4i1E=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/pion/dtls/v2 v2.2.7 h1:cSUBsETxepsCSFSxC3mc/aDo14qQLMSL+O6IjG28yV8=

--- a/pkg/commands/config.go
+++ b/pkg/commands/config.go
@@ -36,38 +36,37 @@ var ConfigCommand = &cli.Command{
 
 		if setValue := cCtx.String("set"); setValue != "" {
 			log.Printf("Setting configuration: %s", setValue)
-		
+
 			parts := strings.SplitN(setValue, "=", 2)
 			if len(parts) != 2 {
 				return fmt.Errorf("invalid format for --set. Expected key=value")
 			}
 			keyPath := parts[0]
 			rawValue := parts[1]
-		
+
 			var value interface{}
 			if strings.Contains(rawValue, ",") {
 				value = strings.Split(rawValue, ",")
 			} else {
 				value = rawValue
 			}
-		
+
 			tree, err := common.LoadEigenTree()
 			if err != nil {
 				return err
 			}
-		
+
 			if err := common.SetKey(tree, keyPath, value); err != nil {
 				return err
 			}
-		
+
 			if err := common.SaveEigenTree(tree); err != nil {
 				return err
 			}
-		
+
 			log.Printf("✅ Updated %s in eigen.toml", keyPath)
 			return nil
 		}
-		
 
 		// If no flags are provided, show current config
 		log.Printf("Displaying current configuration...")

--- a/pkg/commands/config.go
+++ b/pkg/commands/config.go
@@ -2,7 +2,9 @@ package commands
 
 import (
 	"devkit-cli/pkg/common"
+	"fmt"
 	"log"
+	"strings"
 
 	"github.com/urfave/cli/v2"
 )
@@ -34,9 +36,38 @@ var ConfigCommand = &cli.Command{
 
 		if setValue := cCtx.String("set"); setValue != "" {
 			log.Printf("Setting configuration: %s", setValue)
-			// Placeholder for future implementation
+		
+			parts := strings.SplitN(setValue, "=", 2)
+			if len(parts) != 2 {
+				return fmt.Errorf("invalid format for --set. Expected key=value")
+			}
+			keyPath := parts[0]
+			rawValue := parts[1]
+		
+			var value interface{}
+			if strings.Contains(rawValue, ",") {
+				value = strings.Split(rawValue, ",")
+			} else {
+				value = rawValue
+			}
+		
+			tree, err := common.LoadEigenTree()
+			if err != nil {
+				return err
+			}
+		
+			if err := common.SetKey(tree, keyPath, value); err != nil {
+				return err
+			}
+		
+			if err := common.SaveEigenTree(tree); err != nil {
+				return err
+			}
+		
+			log.Printf("✅ Updated %s in eigen.toml", keyPath)
 			return nil
 		}
+		
 
 		// If no flags are provided, show current config
 		log.Printf("Displaying current configuration...")

--- a/pkg/commands/config_test.go
+++ b/pkg/commands/config_test.go
@@ -1,0 +1,84 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/urfave/cli/v2"
+)
+
+func TestConfigCommand_Set(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create a minimal eigen.toml
+	mockToml := `
+[project]
+name = "my-avs"
+version = "0.1.0"
+
+[operator]
+image = "eigen/ponos-client:v1.0"
+keys = ["ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"] # Default Anvil key (index 0)
+total_stake = "1000ETH" # keeping this as constant for all operators in above keys array
+`
+	if err := os.WriteFile(filepath.Join(tmpDir, "eigen.toml"), []byte(mockToml), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Change working directory to temp dir
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := os.Chdir(oldWd); err != nil {
+			t.Logf("Failed to revert working directory: %v", err)
+		}
+	}()
+
+	app := &cli.App{
+		Name:     "test",
+		Commands: []*cli.Command{ConfigCommand},
+	}
+
+	// Test 1: Update a simple key
+	if err := app.Run([]string{"app", "config", "--set", "project.name=new-avs-name"}); err != nil {
+		t.Fatalf("Failed to update project name: %v", err)
+	}
+
+	// Verify updated eigen.toml
+	data, err := os.ReadFile("eigen.toml")
+	if err != nil {
+		t.Fatalf("Failed to read eigen.toml: %v", err)
+	}
+
+	content := string(data)
+	if !contains(content, `name = "new-avs-name"`) {
+		t.Errorf("Expected updated project name in eigen.toml, got:\n%s", content)
+	}
+
+	// Test 2: Update array
+	if err := app.Run([]string{"app", "config", "--set", "operator.keys=key1,key2,key3"}); err != nil {
+		t.Fatalf("Failed to update operator keys: %v", err)
+	}
+
+	data, err = os.ReadFile("eigen.toml")
+	if err != nil {
+		t.Fatalf("Failed to re-read eigen.toml: %v", err)
+	}
+
+	content = string(data)
+	if !contains(content, `keys = ["key1", "key2", "key3"]`) {
+		t.Errorf("Expected updated operator keys array in eigen.toml, got:\n%s", content)
+	}
+}
+
+// contains is a helper like strings.Contains but trims whitespace noise
+func contains(content, substring string) bool {
+	return strings.Contains(strings.ReplaceAll(content, " ", ""), strings.ReplaceAll(substring, " ", ""))
+}

--- a/pkg/common/config_test.go
+++ b/pkg/common/config_test.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/BurntSushi/toml"
+	"github.com/naoina/toml"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -81,8 +81,14 @@ func TestLoadEigenConfig_FromCopiedTempFile(t *testing.T) {
 }
 
 func LoadEigenConfigFromPath(path string) (*common.EigenConfig, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
 	var config common.EigenConfig
-	if _, err := toml.DecodeFile(path, &config); err != nil {
+	if err := toml.NewDecoder(f).Decode(&config); err != nil {
 		return nil, err
 	}
 	return &config, nil


### PR DESCRIPTION
**Motivation:**

Developers can use  Example: `devkit avs config --set project.avs="New-project-name"` to change TOML config . Of course they can also do it manually. We are just giving an option.


**Modifications:**

- Added `-set` functionality in config.go and added a test in config_test.go.

**Result:**

- `--set` implementation is completed.

**Open questions:**
