### PR TITLE
feat: add editor for configuration files

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/posthog/posthog-go v1.4.10
 	github.com/urfave/cli/v2 v2.27.6
+	golang.org/x/text v0.22.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/pkg/commands/config.go
+++ b/pkg/commands/config.go
@@ -29,7 +29,13 @@ var ConfigCommand = &cli.Command{
 		},
 	}, common.GlobalFlags...),
 	Action: func(cCtx *cli.Context) error {
-		if cCtx.Bool("verbose") {
+		// Load config
+		config, err := common.LoadEigenConfig()
+		if err != nil {
+			return err
+		}
+
+		if common.IsVerboseEnabled(cCtx, config) {
 			log.Printf("Managing project configuration...")
 		}
 
@@ -38,8 +44,7 @@ var ConfigCommand = &cli.Command{
 			return editConfig(cCtx)
 		}
 
-		// load by default , if no flags are provided
-		// dev: If any other subcommand needs to be added in ConfigCommand apart from set and list, handle it above this line.
+		// list by default, if no flags are provided
 		log.Println("Displaying current configuration...")
 		projectSetting, err := common.LoadProjectSettings()
 		if err != nil {

--- a/pkg/commands/config.go
+++ b/pkg/commands/config.go
@@ -3,11 +3,12 @@ package commands
 import (
 	"devkit-cli/pkg/common"
 	"fmt"
-	"github.com/naoina/toml"
-	"github.com/urfave/cli/v2"
 	"log"
 	"os"
 	"strings"
+
+	"github.com/naoina/toml"
+	"github.com/urfave/cli/v2"
 )
 
 var ConfigCommand = &cli.Command{
@@ -22,19 +23,22 @@ var ConfigCommand = &cli.Command{
 			Name:  "set",
 			Usage: "Set or update a specific configuration key in eigen.toml",
 		},
+		&cli.BoolFlag{
+			Name:  "edit",
+			Usage: "Open eigen.toml in a text editor for manual editing",
+		},
 	}, common.GlobalFlags...),
 	Action: func(cCtx *cli.Context) error {
-		// Load config
-		config, err := common.LoadEigenConfig()
-		if err != nil {
-			return err
-		}
-
-		if common.IsVerboseEnabled(cCtx, config) {
+		if cCtx.Bool("verbose") {
 			log.Printf("Managing project configuration...")
 		}
 
-		// load by default , if --set is not provided
+		if cCtx.Bool("edit") {
+			log.Printf("Opening config file for editing...")
+			return editConfig(cCtx)
+		}
+
+		// load by default , if no flags are provided
 		// dev: If any other subcommand needs to be added in ConfigCommand apart from set and list, handle it above this line.
 		log.Println("Displaying current configuration...")
 		projectSetting, err := common.LoadProjectSettings()

--- a/pkg/commands/config_edit.go
+++ b/pkg/commands/config_edit.go
@@ -1,0 +1,451 @@
+package commands
+
+import (
+	"context"
+	"devkit-cli/pkg/common"
+	"devkit-cli/pkg/hooks"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"reflect"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+	"github.com/urfave/cli/v2"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
+
+const (
+	defaultConfigPath = "eigen.toml"
+)
+
+// editConfig is the main entry point for the edit config functionality
+func editConfig(cCtx *cli.Context) error {
+	// Find an available editor
+	editor, err := findEditor()
+	if err != nil {
+		return err
+	}
+
+	// Create a backup of the current config
+	originalConfig, backupData, err := backupConfig()
+	if err != nil {
+		return err
+	}
+
+	// Open the editor and wait for it to close
+	if err := openEditor(editor, defaultConfigPath); err != nil {
+		return err
+	}
+
+	// Validate the edited config
+	newConfig, err := validateConfig()
+	if err != nil {
+		log.Printf("Error validating config: %v", err)
+		log.Printf("Reverting changes...")
+		if restoreErr := restoreBackup(backupData); restoreErr != nil {
+			return fmt.Errorf("failed to restore backup after validation error: %w", restoreErr)
+		}
+		return err
+	}
+
+	// Track changes
+	changes := collectConfigChanges(originalConfig, newConfig)
+
+	// Log changes
+	logConfigChanges(changes)
+
+	// Send telemetry
+	sendConfigChangeTelemetry(cCtx.Context, changes)
+
+	log.Printf("Config file updated successfully.")
+	return nil
+}
+
+// findEditor looks for available text editors
+func findEditor() (string, error) {
+	// Try to use the EDITOR environment variable
+	if editor := os.Getenv("EDITOR"); editor != "" {
+		if _, err := exec.LookPath(editor); err == nil {
+			return editor, nil
+		}
+	}
+
+	// Try common editors in order of preference
+	for _, editor := range []string{"nano", "vi", "vim"} {
+		if path, err := exec.LookPath(editor); err == nil {
+			return path, nil
+		}
+	}
+
+	return "", fmt.Errorf("no suitable text editor found. Please install nano or vi, or set the EDITOR environment variable")
+}
+
+// backupConfig creates a backup of the current config
+func backupConfig() (*common.EigenConfig, []byte, error) {
+	// Load the current config to compare later
+	currentConfig, err := common.LoadEigenConfig()
+	if err != nil {
+		return nil, nil, fmt.Errorf("error loading current config: %w", err)
+	}
+
+	// Read the raw file data
+	file, err := os.Open(defaultConfigPath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error opening config file: %w", err)
+	}
+	defer file.Close()
+
+	backupData, err := io.ReadAll(file)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error reading config file: %w", err)
+	}
+
+	return currentConfig, backupData, nil
+}
+
+// openEditor launches the editor for the config file
+func openEditor(editorPath, filePath string) error {
+	log.Printf("Opening config file in %s...", editorPath)
+
+	cmd := exec.Command(editorPath, filePath)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	return cmd.Run()
+}
+
+// validateConfig checks if the edited config file is valid
+func validateConfig() (*common.EigenConfig, error) {
+	var config common.EigenConfig
+	if _, err := toml.DecodeFile(defaultConfigPath, &config); err != nil {
+		return nil, fmt.Errorf("invalid TOML syntax: %w", err)
+	}
+	return &config, nil
+}
+
+// restoreBackup restores the original file content
+func restoreBackup(backupData []byte) error {
+	return os.WriteFile(defaultConfigPath, backupData, 0644)
+}
+
+// ConfigChange represents a change in a configuration field
+type ConfigChange struct {
+	Path     string
+	OldValue interface{}
+	NewValue interface{}
+}
+
+// collectConfigChanges collects all changes between two configs
+func collectConfigChanges(originalConfig, newConfig *common.EigenConfig) []ConfigChange {
+	changes := []ConfigChange{}
+
+	// Collect all changes from different sections
+	changes = append(changes, getFieldChangesDetailed("project", originalConfig.Project, newConfig.Project)...)
+
+	// Operator basic fields
+	changes = append(changes, getFieldChangesDetailed("operator", originalConfig.Operator, newConfig.Operator)...)
+
+	// Handle nested operator allocations separately
+	if !reflect.DeepEqual(originalConfig.Operator.Allocations, newConfig.Operator.Allocations) {
+		// Add allocation changes
+		changes = append(changes, compareArraysDetailed("operator.allocations.strategies",
+			originalConfig.Operator.Allocations["strategies"],
+			newConfig.Operator.Allocations["strategies"])...)
+
+		changes = append(changes, compareArraysDetailed("operator.allocations.task-executors",
+			originalConfig.Operator.Allocations["task-executors"],
+			newConfig.Operator.Allocations["task-executors"])...)
+
+		changes = append(changes, compareArraysDetailed("operator.allocations.aggregators",
+			originalConfig.Operator.Allocations["aggregators"],
+			newConfig.Operator.Allocations["aggregators"])...)
+	}
+
+	// Environment changes
+	for envName := range originalConfig.Env {
+		if _, exists := newConfig.Env[envName]; !exists {
+			changes = append(changes, ConfigChange{
+				Path:     fmt.Sprintf("env.%s", envName),
+				OldValue: "exists",
+				NewValue: "removed",
+			})
+		}
+	}
+
+	for envName, newEnv := range newConfig.Env {
+		if oldEnv, exists := originalConfig.Env[envName]; exists {
+			if !reflect.DeepEqual(oldEnv, newEnv) {
+				changes = append(changes, getFieldChangesDetailed(fmt.Sprintf("env.%s", envName), oldEnv, newEnv)...)
+			}
+		} else {
+			changes = append(changes, ConfigChange{
+				Path:     fmt.Sprintf("env.%s", envName),
+				OldValue: "not_exists",
+				NewValue: "added",
+			})
+		}
+	}
+
+	// Operator sets changes
+	for setName := range originalConfig.OperatorSets {
+		if _, exists := newConfig.OperatorSets[setName]; !exists {
+			changes = append(changes, ConfigChange{
+				Path:     fmt.Sprintf("operatorsets.%s", setName),
+				OldValue: "exists",
+				NewValue: "removed",
+			})
+		}
+	}
+
+	for setName, newSet := range newConfig.OperatorSets {
+		if oldSet, exists := originalConfig.OperatorSets[setName]; exists {
+			if !reflect.DeepEqual(oldSet, newSet) {
+				changes = append(changes, ConfigChange{
+					Path:     fmt.Sprintf("operatorsets.%s", setName),
+					OldValue: "unchanged",
+					NewValue: "modified",
+				})
+			}
+		} else {
+			changes = append(changes, ConfigChange{
+				Path:     fmt.Sprintf("operatorsets.%s", setName),
+				OldValue: "not_exists",
+				NewValue: "added",
+			})
+		}
+	}
+
+	// Aliases changes
+	changes = append(changes, getFieldChangesDetailed("aliases", originalConfig.Aliases, newConfig.Aliases)...)
+
+	// Release changes
+	changes = append(changes, getFieldChangesDetailed("release", originalConfig.Release, newConfig.Release)...)
+
+	return changes
+}
+
+// getFieldChangesDetailed returns detailed field changes between two structs
+func getFieldChangesDetailed(prefix string, old, new interface{}) []ConfigChange {
+	changes := []ConfigChange{}
+
+	// Use reflection to compare struct fields
+	oldVal := reflect.ValueOf(old)
+	newVal := reflect.ValueOf(new)
+
+	// Handle nil values
+	if !oldVal.IsValid() || !newVal.IsValid() {
+		return changes
+	}
+
+	// Handle different types
+	if oldVal.Type() != newVal.Type() {
+		return changes
+	}
+
+	// Only handle struct types
+	if oldVal.Kind() != reflect.Struct {
+		return changes
+	}
+
+	// Compare all fields
+	for i := 0; i < oldVal.NumField(); i++ {
+		fieldName := oldVal.Type().Field(i).Name
+		tomlTag := strings.Split(oldVal.Type().Field(i).Tag.Get("toml"), ",")[0]
+		if tomlTag == "" {
+			tomlTag = strings.ToLower(fieldName)
+		}
+
+		oldField := oldVal.Field(i)
+		newField := newVal.Field(i)
+
+		// Skip unexported fields
+		if !oldField.CanInterface() {
+			continue
+		}
+
+		// Skip complex nested structures (they'll be handled separately)
+		if oldField.Kind() == reflect.Struct || oldField.Kind() == reflect.Map ||
+			(oldField.Kind() == reflect.Slice && oldField.Type().Elem().Kind() != reflect.String) {
+			continue
+		}
+
+		// Compare values
+		if !reflect.DeepEqual(oldField.Interface(), newField.Interface()) {
+			fieldPath := fmt.Sprintf("%s.%s", prefix, tomlTag)
+			changes = append(changes, ConfigChange{
+				Path:     fieldPath,
+				OldValue: oldField.Interface(),
+				NewValue: newField.Interface(),
+			})
+		}
+	}
+
+	return changes
+}
+
+// compareArraysDetailed compares two string arrays and returns detailed changes
+func compareArraysDetailed(prefix string, oldArr, newArr []string) []ConfigChange {
+	changes := []ConfigChange{}
+
+	// Find items that were removed
+	for _, oldItem := range oldArr {
+		found := false
+		for _, newItem := range newArr {
+			if oldItem == newItem {
+				found = true
+				break
+			}
+		}
+		if !found {
+			changes = append(changes, ConfigChange{
+				Path:     prefix,
+				OldValue: oldItem,
+				NewValue: "removed",
+			})
+		}
+	}
+
+	// Find items that were added
+	for _, newItem := range newArr {
+		found := false
+		for _, oldItem := range oldArr {
+			if newItem == oldItem {
+				found = true
+				break
+			}
+		}
+		if !found {
+			changes = append(changes, ConfigChange{
+				Path:     prefix,
+				OldValue: "not_exists",
+				NewValue: newItem,
+			})
+		}
+	}
+
+	return changes
+}
+
+// logConfigChanges logs the configuration changes
+func logConfigChanges(changes []ConfigChange) {
+	if len(changes) == 0 {
+		log.Println("No changes detected in configuration.")
+		return
+	}
+
+	// Group changes by section
+	sections := make(map[string][]ConfigChange)
+	for _, change := range changes {
+		section := strings.Split(change.Path, ".")[0]
+		sections[section] = append(sections[section], change)
+	}
+
+	// Create a title caser
+	titleCaser := cases.Title(language.English)
+
+	// Log changes by section
+	for section, sectionChanges := range sections {
+		log.Printf("%s changes:", titleCaser.String(section))
+		for _, change := range sectionChanges {
+			formatAndLogChange(change)
+		}
+	}
+}
+
+// formatAndLogChange formats and logs a single change
+func formatAndLogChange(change ConfigChange) {
+	var changeMsg string
+
+	// Format based on change type
+	switch oldVal := change.OldValue.(type) {
+	case string:
+		if newVal, ok := change.NewValue.(string); ok && newVal != "removed" && newVal != "added" {
+			changeMsg = fmt.Sprintf("%s changed from '%v' to '%v'", change.Path, oldVal, newVal)
+		} else if newVal == "removed" {
+			changeMsg = fmt.Sprintf("%s removed", change.Path)
+		} else {
+			changeMsg = fmt.Sprintf("%s changed", change.Path)
+		}
+	case bool:
+		if newVal, ok := change.NewValue.(bool); ok {
+			changeMsg = fmt.Sprintf("%s changed from %v to %v", change.Path, oldVal, newVal)
+		} else {
+			changeMsg = fmt.Sprintf("%s changed", change.Path)
+		}
+	case int, int8, int16, int32, int64:
+		changeMsg = fmt.Sprintf("%s changed from %v to %v", change.Path, oldVal, change.NewValue)
+	default:
+		if change.NewValue == "added" {
+			changeMsg = fmt.Sprintf("%s added", change.Path)
+		} else if change.NewValue == "removed" {
+			changeMsg = fmt.Sprintf("%s removed", change.Path)
+		} else if change.NewValue == "modified" {
+			changeMsg = fmt.Sprintf("%s modified", change.Path)
+		} else {
+			changeMsg = fmt.Sprintf("%s changed", change.Path)
+		}
+	}
+
+	log.Printf("  - %s", changeMsg)
+}
+
+// sendConfigChangeTelemetry sends telemetry data for config changes
+func sendConfigChangeTelemetry(ctx context.Context, changes []ConfigChange) {
+	if len(changes) == 0 {
+		return
+	}
+
+	// Create properties map for telemetry
+	props := make(map[string]interface{})
+
+	// Add change count
+	props["change_count"] = len(changes)
+
+	// Add section change counts
+	sectionCounts := make(map[string]int)
+	for _, change := range changes {
+		section := strings.Split(change.Path, ".")[0]
+		sectionCounts[section]++
+	}
+
+	for section, count := range sectionCounts {
+		props[fmt.Sprintf("%s_changes", section)] = count
+	}
+
+	// Add individual changes (up to a reasonable limit)
+	maxChangesToInclude := 20 // Avoid sending too much data
+	for i, change := range changes {
+		if i >= maxChangesToInclude {
+			break
+		}
+
+		fieldPath := fmt.Sprintf("changed_%d_path", i)
+		props[fieldPath] = change.Path
+
+		// Only include primitive values that can be reasonably serialized
+		oldValueStr := fmt.Sprintf("%v", change.OldValue)
+		newValueStr := fmt.Sprintf("%v", change.NewValue)
+
+		// Truncate long values
+		const maxValueLen = 50
+		if len(oldValueStr) > maxValueLen {
+			oldValueStr = oldValueStr[:maxValueLen] + "..."
+		}
+		if len(newValueStr) > maxValueLen {
+			newValueStr = newValueStr[:maxValueLen] + "..."
+		}
+
+		props[fmt.Sprintf("changed_%d_from", i)] = oldValueStr
+		props[fmt.Sprintf("changed_%d_to", i)] = newValueStr
+	}
+
+	// Send the telemetry event
+	eventName := hooks.FormatCustomMetric(ctx, "config.edit_changes")
+	// Ignore returned error as per other telemetry calls in the codebase
+	_ = hooks.Track(ctx, eventName, props)
+}

--- a/pkg/commands/config_edit_test.go
+++ b/pkg/commands/config_edit_test.go
@@ -1,0 +1,173 @@
+package commands
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestEditorDetection tests the logic of detecting available editors
+func TestEditorDetection(t *testing.T) {
+	// Test with environment variable set
+	os.Setenv("EDITOR", "test-editor")
+	editor := os.Getenv("EDITOR")
+	if editor != "test-editor" {
+		t.Errorf("Failed to set EDITOR environment variable")
+	}
+
+	// Test editor detection logic
+	commonEditors := []string{"nano", "vi", "vim"}
+	found := false
+
+	for _, ed := range commonEditors {
+		if path, err := exec.LookPath(ed); err == nil {
+			found = true
+			t.Logf("Found editor: %s at %s", ed, path)
+			break
+		}
+	}
+
+	// This is informational, not a failure condition
+	if !found {
+		t.Logf("No common editors found on this system")
+	}
+}
+
+// TestBackupAndRestore tests the logic of backing up and restoring files
+func TestBackupAndRestore(t *testing.T) {
+	// Create a temporary file
+	tempDir := t.TempDir()
+	testConfigPath := filepath.Join(tempDir, "config.toml")
+
+	// Write test content
+	originalContent := "original content"
+	err := os.WriteFile(testConfigPath, []byte(originalContent), 0644)
+	if err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+
+	// Create backup
+	backupData, err := os.ReadFile(testConfigPath)
+	if err != nil {
+		t.Fatalf("Failed to read test file: %v", err)
+	}
+
+	// Modify the file
+	modifiedContent := "modified content"
+	err = os.WriteFile(testConfigPath, []byte(modifiedContent), 0644)
+	if err != nil {
+		t.Fatalf("Failed to modify test file: %v", err)
+	}
+
+	// Restore from backup
+	err = os.WriteFile(testConfigPath, backupData, 0644)
+	if err != nil {
+		t.Fatalf("Failed to restore test file: %v", err)
+	}
+
+	// Verify restoration
+	restoredData, err := os.ReadFile(testConfigPath)
+	if err != nil {
+		t.Fatalf("Failed to read restored file: %v", err)
+	}
+
+	if string(restoredData) != originalContent {
+		t.Errorf("Restore failed. Expected: %s, Got: %s", originalContent, string(restoredData))
+	}
+}
+
+// TestTomlValidation tests the TOML validation logic
+func TestTomlValidation(t *testing.T) {
+	// Valid TOML
+	validToml := `
+[section]
+key = "value"
+`
+	// Invalid TOML
+	invalidToml := `
+[section
+key = "value"
+`
+	// Create test files
+	tempDir := t.TempDir()
+	validPath := filepath.Join(tempDir, "valid.toml")
+	invalidPath := filepath.Join(tempDir, "invalid.toml")
+
+	err := os.WriteFile(validPath, []byte(validToml), 0644)
+	if err != nil {
+		t.Fatalf("Failed to create valid TOML file: %v", err)
+	}
+
+	err = os.WriteFile(invalidPath, []byte(invalidToml), 0644)
+	if err != nil {
+		t.Fatalf("Failed to create invalid TOML file: %v", err)
+	}
+
+	// Test validation with external command
+	cmd := exec.Command("bash", "-c", "type toml &>/dev/null && toml validate "+validPath+" &>/dev/null")
+	err = cmd.Run()
+	if err != nil {
+		// Skip test if toml command is not available
+		t.Logf("Skipping TOML validation test: toml command not available")
+	} else {
+		// Test valid TOML
+		validCmd := exec.Command("toml", "validate", validPath)
+		err = validCmd.Run()
+		if err != nil {
+			t.Errorf("Failed to validate valid TOML: %v", err)
+		}
+
+		// Test invalid TOML
+		invalidCmd := exec.Command("toml", "validate", invalidPath)
+		err = invalidCmd.Run()
+		if err == nil {
+			t.Errorf("Invalid TOML was incorrectly validated as valid")
+		}
+	}
+}
+
+// TestEditorLaunching tests the logic of launching an editor
+func TestEditorLaunching(t *testing.T) {
+	// Test with a mock editor (echo)
+	editor := "echo"
+	if _, err := exec.LookPath(editor); err != nil {
+		t.Skip("echo command not available, skipping test")
+	}
+
+	tempDir := t.TempDir()
+	testFile := filepath.Join(tempDir, "test-file.txt")
+
+	// Create test file
+	err := os.WriteFile(testFile, []byte("initial content"), 0644)
+	if err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+
+	// Create a command that would simulate an editor (echo appends to the file)
+	cmd := exec.Command(editor, "edited content", ">", testFile)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	// Test with shell to handle redirection
+	shellCmd := exec.Command("bash", "-c", editor+" 'edited content' > "+testFile)
+	err = shellCmd.Run()
+	if err != nil {
+		t.Errorf("Failed to run mock editor command: %v", err)
+		t.Logf("Stderr: %s", stderr.String())
+		return
+	}
+
+	// Check if the file was modified (this doesn't test waiting for editor to close)
+	content, err := os.ReadFile(testFile)
+	if err != nil {
+		t.Fatalf("Failed to read test file after edit: %v", err)
+	}
+
+	if strings.TrimSpace(string(content)) != "edited content" {
+		t.Errorf("Editor didn't modify file as expected. Got: %s", string(content))
+	}
+}

--- a/pkg/commands/create.go
+++ b/pkg/commands/create.go
@@ -54,19 +54,13 @@ var CreateCommand = &cli.Command{
 		},
 	}, common.GlobalFlags...),
 	Action: func(cCtx *cli.Context) error {
-		// Load config
-		config, err := common.LoadEigenConfig()
-		if err != nil {
-			return err
-		}
-
 		if cCtx.NArg() == 0 {
 			return fmt.Errorf("project name is required\nUsage: avs create <project-name> [flags]")
 		}
 		projectName := cCtx.Args().First()
 		targetDir := filepath.Join(cCtx.String("dir"), projectName)
 
-		if common.IsVerboseEnabled(cCtx, config) {
+		if cCtx.Bool("verbose") {
 			log.Printf("Creating new AVS project: %s", projectName)
 			log.Printf("Directory: %s", cCtx.String("dir"))
 			log.Printf("Language: %s", cCtx.String("lang"))
@@ -98,7 +92,7 @@ var CreateCommand = &cli.Command{
 			return err
 		}
 
-		if common.IsVerboseEnabled(cCtx, config) {
+		if cCtx.Bool("verbose") {
 			log.Printf("Using template: %s", templateURL)
 		}
 


### PR DESCRIPTION
**Motivation**
Users needed a way to directly edit their eigen.toml configuration files with validation and change tracking.

**Modifications**
- Add --edit flag to the config command
- Implement automatic editor detection (EDITOR env var, nano, vi, vim. e.g. export EDITOR=/usr/bin/vi)
- Track and display changes made to the configuration

**Result**
Users can now edit eigen.toml directly with their preferred editor.