### PR TITLE
chore: remove deprecated --set flag from avs config command

### DIFF
--- a/pkg/commands/config.go
+++ b/pkg/commands/config.go
@@ -19,10 +19,6 @@ var ConfigCommand = &cli.Command{
 			Name:  "list",
 			Usage: "Display all current project configuration settings",
 		},
-		&cli.StringFlag{
-			Name:  "set",
-			Usage: "Set or update a specific configuration key in eigen.toml",
-		},
 		&cli.BoolFlag{
 			Name:  "edit",
 			Usage: "Open eigen.toml in a text editor for manual editing",


### PR DESCRIPTION
**Motivation**
--edit flag was recently added to allow users to directly edit configuration files through "devkit avs config --edit", making the --set flag redundant.

**Modifications**
Removed the --set flag definition from config command

**Result**
Instead of --set, we should just use --edit