### PR TITLE
chore: update github path for hourglass/task template

### DIFF
--- a/config/templates.yml
+++ b/config/templates.yml
@@ -2,7 +2,7 @@ architectures:
   task:
     languages:
       go:
-        template: "https://github.com/Layr-Labs/hourglass-avs-template/tree/sm-templateExample"
+        template: "https://github.com/Layr-Labs/hourglass-avs-template"
       ts:
         template: ""
       rust:


### PR DESCRIPTION
**Motivation**
Earlier hourglass template was on a private branch

**Modification**
This commits uses their master branch now

**Result**
Use latest hourglass template