### PR TITLE
feat: add contracts directory support

### DIFF
--- a/config/templates.yml
+++ b/config/templates.yml
@@ -7,6 +7,12 @@ architectures:
         template: ""
       rust:
         template: ""
+    contracts:
+      languages:
+        solidity:
+          template: "https://github.com/Layr-Labs/hourglass-contracts-template"
+        viper:
+          template: ""
   hello-world-avs:
     languages:
       go:

--- a/pkg/commands/build.go
+++ b/pkg/commands/build.go
@@ -2,9 +2,11 @@ package commands
 
 import (
 	"devkit-cli/pkg/common"
+	"fmt"
 	"log"
 	"os"
 	"os/exec"
+	"path/filepath"
 
 	"github.com/urfave/cli/v2"
 )
@@ -44,14 +46,38 @@ var BuildCommand = &cli.Command{
 		}
 
 		// Execute make build with Makefile.Devkit
-		cmd := exec.Command("make", "-f", "Makefile.Devkit", "build")
+		cmd := exec.Command("make", "-f", common.DevkitMakefile, "build")
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		if err := cmd.Run(); err != nil {
 			return err
 		}
 
+		// Build contracts if available
+		if err := buildContractsIfAvailable(); err != nil {
+			return err
+		}
+
 		log.Printf("Build completed successfully")
 		return nil
 	},
+}
+
+// buildContractsIfAvailable builds the contracts if the contracts directory exists
+func buildContractsIfAvailable() error {
+	contractsDir := common.ContractsDir
+	if _, err := os.Stat(contractsDir); os.IsNotExist(err) {
+		return nil
+	}
+
+	makefilePath := filepath.Join(contractsDir, common.DevkitMakefile)
+	if _, err := os.Stat(makefilePath); os.IsNotExist(err) {
+		return fmt.Errorf("contracts directory exists but no %s found", common.DevkitMakefile)
+	}
+
+	cmd := exec.Command("make", "-f", common.DevkitMakefile, "build")
+	cmd.Dir = contractsDir
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
 }

--- a/pkg/commands/build_test.go
+++ b/pkg/commands/build_test.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"devkit-cli/pkg/common"
 	"os"
 	"path/filepath"
 	"testing"
@@ -11,12 +12,28 @@ import (
 func TestBuildCommand(t *testing.T) {
 	tmpDir := t.TempDir()
 
+	// Create mock Makefile.Devkit in main directory
 	mockMakefile := `
 .PHONY: build
 build:
 	@echo "Mock build executed"
 	`
-	if err := os.WriteFile(filepath.Join(tmpDir, "Makefile.Devkit"), []byte(mockMakefile), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(tmpDir, common.DevkitMakefile), []byte(mockMakefile), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create contracts directory and its Makefile.Devkit
+	contractsDir := filepath.Join(tmpDir, common.ContractsDir)
+	if err := os.MkdirAll(contractsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	mockContractsMakefile := `
+.PHONY: build
+build:
+	@echo "Mock contracts build executed"
+	`
+	if err := os.WriteFile(filepath.Join(contractsDir, common.DevkitMakefile), []byte(mockContractsMakefile), 0644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -40,5 +57,86 @@ build:
 
 	if err := app.Run([]string{"app", "build"}); err != nil {
 		t.Errorf("Failed to execute build command: %v", err)
+	}
+}
+
+// Test the case where contracts directory doesn't exist
+func TestBuildCommand_NoContracts(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create only main Makefile.Devkit
+	mockMakefile := `
+.PHONY: build
+build:
+	@echo "Mock build executed"
+	`
+	if err := os.WriteFile(filepath.Join(tmpDir, common.DevkitMakefile), []byte(mockMakefile), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := os.Chdir(oldWd); err != nil {
+			t.Logf("Failed to restore original directory: %v", err)
+		}
+	}()
+
+	app := &cli.App{
+		Name:     "test",
+		Commands: []*cli.Command{WithTestConfig(BuildCommand)},
+	}
+
+	if err := app.Run([]string{"app", "build"}); err != nil {
+		t.Errorf("Failed to execute build command: %v", err)
+	}
+}
+
+// Test the case where contracts directory exists but has no Makefile
+func TestBuildCommand_ContractsNoMakefile(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create mock Makefile.Devkit in main directory
+	mockMakefile := `
+.PHONY: build
+build:
+	@echo "Mock build executed"
+	`
+	if err := os.WriteFile(filepath.Join(tmpDir, common.DevkitMakefile), []byte(mockMakefile), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create contracts directory but no Makefile
+	contractsDir := filepath.Join(tmpDir, common.ContractsDir)
+	if err := os.MkdirAll(contractsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := os.Chdir(oldWd); err != nil {
+			t.Logf("Failed to restore original directory: %v", err)
+		}
+	}()
+
+	app := &cli.App{
+		Name:     "test",
+		Commands: []*cli.Command{WithTestConfig(BuildCommand)},
+	}
+
+	// This should fail because contracts dir exists but has no Makefile
+	if err := app.Run([]string{"app", "build"}); err == nil {
+		t.Errorf("Expected build to fail due to missing contracts Makefile, but it succeeded")
 	}
 }

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -20,7 +20,7 @@ var RunCommand = &cli.Command{
 		}
 
 		// Execute make run with Makefile.Devkit
-		cmd := exec.Command("make", "-f", "Makefile.Devkit", "run")
+		cmd := exec.Command("make", "-f", common.DevkitMakefile, "run")
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		if err := cmd.Run(); err != nil {

--- a/pkg/commands/run_test.go
+++ b/pkg/commands/run_test.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"devkit-cli/pkg/common"
 	"os"
 	"path/filepath"
 	"testing"
@@ -17,7 +18,7 @@ func TestRunCommand(t *testing.T) {
 run:
 	@echo "Mock run executed"
 	`
-	if err := os.WriteFile(filepath.Join(tmpDir, "Makefile.Devkit"), []byte(mockMakefile), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(tmpDir, common.DevkitMakefile), []byte(mockMakefile), 0644); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -1,0 +1,10 @@
+package common
+
+// Project structure constants
+const (
+	// ContractsDir is the subdirectory name for contract components
+	ContractsDir = "contracts"
+
+	// DevkitMakefile is the name of the makefile used for devkit operations
+	DevkitMakefile = "Makefile.Devkit"
+)

--- a/pkg/template/config_test.go
+++ b/pkg/template/config_test.go
@@ -33,7 +33,7 @@ architectures:
 	}
 
 	// Test template URL lookup
-	url, err := GetTemplateURL(config, "task", "go")
+	url, _, err := GetTemplateURLs(config, "task", "go")
 	if err != nil {
 		t.Fatalf("Failed to get template URL: %v", err)
 	}
@@ -42,7 +42,7 @@ architectures:
 	}
 
 	// Test non-existent architecture
-	url, err = GetTemplateURL(config, "nonexistent", "go")
+	url, _, err = GetTemplateURLs(config, "nonexistent", "go")
 	if err != nil {
 		t.Fatalf("Failed to get template URL: %v", err)
 	}

--- a/pkg/template/fetcher.go
+++ b/pkg/template/fetcher.go
@@ -38,11 +38,13 @@ func (g *GitFetcher) Fetch(templateURL, targetDir string) error {
 	args = append(args, repoURL, targetDir)
 
 	cmd := exec.Command("git", args...)
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to clone template: %w", err)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to clone template: %w\nOutput: %s", err, string(output))
 	}
 
 	// Cleanup .git directory
+	// TODO: In future, we might want to do git init after this step based on a flag?
 	gitDir := filepath.Join(targetDir, ".git")
 	if err := os.RemoveAll(gitDir); err != nil {
 		return fmt.Errorf("failed to remove .git directory: %w", err)


### PR DESCRIPTION
**Motivation**
AVS projects need smart contract repositories alongside application code.

**Modifications**
- Added contracts section in templates.yml
- Created directory structure constants
- Enhanced build command to handle contracts
- Updated create command to fetch contract templates

**Result**
We can now create and build AVS projects with dedicated contracts directories using separate templates.

**Open Questions**
config/templates.yaml schema changes are forward looking and only added because requests have been made for them in quite a few meetings. 