### PR TITLE
feat: add progress reports for template and submodule clones

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ Thumbs.db
 .idea/
 *.swp
 
+# DevKit level git cache
+.git-template-cache
+.git-submodule-cache

--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ cd devkit-cli
 git pull origin main
 
 # Note that you have to run the create command from repository directory
-devkit avs create --verbose my-hourglass-project  # by default pick task arch and go lang
+devkit avs create my-hourglass-project  # by default pick task arch and go lang
 OR
-devkit avs create --verbose --overwrite my-existing-hourglass-project
+devkit avs create --overwrite my-existing-hourglass-project
 
 # Once you have a project directory, following commands should be run from the project directory you created.
 devkit avs build

--- a/config/templates.yml
+++ b/config/templates.yml
@@ -11,7 +11,7 @@ architectures:
       languages:
         solidity:
           template: "https://github.com/Layr-Labs/hourglass-contracts-template"
-        viper:
+        vyper:
           template: ""
   hello-world-avs:
     languages:

--- a/pkg/commands/create.go
+++ b/pkg/commands/create.go
@@ -104,23 +104,19 @@ var CreateCommand = &cli.Command{
 
 		// Fetch main template
 		fetcher := &template.GitFetcher{}
-		if err := fetcher.Fetch(mainURL, targetDir); err != nil {
+		if err := fetcher.Fetch(mainURL, targetDir, cCtx.Bool("verbose")); err != nil {
 			return fmt.Errorf("failed to fetch template from %s: %w", mainURL, err)
 		}
 
-		// Check for contracts template and fetch if available
+		// Check for contracts template and fetch if missing
 		if contractsURL != "" {
 			contractsDir := filepath.Join(targetDir, common.ContractsDir)
 
-			// Remove the contracts directory if it exists
-			if _, err := os.Stat(contractsDir); !os.IsNotExist(err) {
-				if err := os.RemoveAll(contractsDir); err != nil {
-					log.Printf("Warning: Failed to remove existing contracts directory: %v", err)
+			// Fetch the contracts directory if it does not exist in the template
+			if _, err := os.Stat(contractsDir); os.IsNotExist(err) {
+				if err := fetcher.Fetch(contractsURL, contractsDir, cCtx.Bool("verbose")); err != nil {
+					log.Printf("Warning: Failed to fetch contracts template: %v", err)
 				}
-			}
-
-			if err := fetcher.Fetch(contractsURL, contractsDir); err != nil {
-				log.Printf("Warning: Failed to fetch contracts template: %v", err)
 			}
 		}
 
@@ -223,48 +219,10 @@ func initGitRepo(targetDir string, verbose bool) error {
 	if err != nil {
 		return fmt.Errorf("git init failed: %w\nOutput: %s", err, string(output))
 	}
-	// Initialize submodules in the project directory
-	if err := initSubmodules(targetDir, verbose); err != nil {
-		log.Printf("Warning: Failed to initialize Submodules repository in %s: %v", targetDir, err)
-	}
 	if verbose {
 		log.Printf("Git repository initialized successfully.")
 		if len(output) > 0 {
 			log.Printf("Git init output:\n%s", string(output))
-		}
-	}
-	return nil
-}
-
-// initSubmodules initializes a submodules in the target directory.
-func initSubmodules(targetDir string, verbose bool) error {
-	submodules := []string{
-		"contracts/lib/forge-std",
-		"contracts/lib/hourglass-monorepo",
-	}
-	for _, dir := range submodules {
-		fullPath := filepath.Join(targetDir, dir)
-		if err := os.RemoveAll(fullPath); err != nil && !os.IsNotExist(err) {
-			log.Printf("Warning: Failed to remove %s: %v", fullPath, err)
-		}
-	}
-	cmds := [][]string{
-		{"git", "submodule", "add", "https://github.com/foundry-rs/forge-std", "contracts/lib/forge-std"},
-		{"git", "submodule", "add", "https://github.com/Layr-Labs/hourglass-monorepo", "contracts/lib/hourglass-monorepo"},
-		{"git", "submodule", "update", "--init", "--recursive", "--depth=1"},
-	}
-	for _, args := range cmds {
-		if verbose {
-			log.Printf("Running: %s", strings.Join(args, " "))
-		}
-		cmd := exec.Command(args[0], args[1:]...)
-		cmd.Dir = targetDir
-		if verbose {
-			cmd.Stdout = os.Stdout
-			cmd.Stderr = os.Stderr
-		}
-		if err := cmd.Run(); err != nil {
-			return fmt.Errorf("cmd %v failed: %w", args, err)
 		}
 	}
 	return nil

--- a/pkg/template/fetcher.go
+++ b/pkg/template/fetcher.go
@@ -179,9 +179,9 @@ func getRemoteHEADCommit(repoURL, branch string) (string, error) {
 	} else {
 		args = append(args, "HEAD")
 	}
-	out, err := exec.Command("git", args...).Output()
+	out, err := exec.Command("git", args...).CombinedOutput()
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("git ls-remote failed: %w\nOutput:\n%s", err, out)
 	}
 	fields := strings.Fields(string(out))
 	if len(fields) < 1 {

--- a/pkg/template/fetcher.go
+++ b/pkg/template/fetcher.go
@@ -450,7 +450,8 @@ func cloneSubmodules(repoURL string, repoName string, repoDir string, noCache bo
 				printLog("failed to get commit for %s: %v\n", mod.Path, err)
 				return
 			}
-			cacheName := fmt.Sprintf("%s-%s.git", mod.Name, commitHash)
+			baseName := filepath.Base(mod.Name)
+			cacheName := fmt.Sprintf("%s-%s.git", baseName, commitHash)
 			cachePath := filepath.Join(cacheDir, cacheName)
 			workingCopyPath := filepath.Join(repoDir, mod.Path)
 

--- a/pkg/template/fetcher.go
+++ b/pkg/template/fetcher.go
@@ -328,6 +328,11 @@ func copyFromCache(mirrorPath, destPath string, updateProgress func(int)) error 
 }
 
 func runClone(repoURL, branch string, args []string, dest string, updateProgress func(int)) error {
+	// lock whilst this clone takes place
+	lock := lockForRepo(dest)
+	lock.Lock()
+	defer lock.Unlock()
+
 	// clone with --progress to update progress report
 	args = append([]string{"clone", "--progress"}, args...)
 	if branch != "" {

--- a/pkg/template/fetcher.go
+++ b/pkg/template/fetcher.go
@@ -1,18 +1,162 @@
 package template
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
+	"sync"
 )
 
 type Fetcher interface {
-	Fetch(templateURL, targetDir string) error
+	Fetch(templateURL, targetDir string, verbose bool) error
 }
 
-type GitFetcher struct{}
+type GitFetcher struct {
+	MaxDepth int
+}
+
+type Submodule struct {
+	Name   string
+	Path   string
+	URL    string
+	Branch string
+}
+
+type ProgressGrid struct {
+	order    []string
+	progress map[string]int
+	lines    int
+	frozen   bool
+}
+
+var (
+	outputMu          sync.Mutex
+	repoLocksMu       sync.Mutex
+	visitMu           sync.Mutex
+	repoLocks         = map[string]*sync.Mutex{}
+	visitedSubmodules = map[string]struct{}{}
+	receivingRegex    = regexp.MustCompile(`Receiving objects:\s+(\d+)%`)
+)
+
+func shouldVisit(path string) bool {
+	visitMu.Lock()
+	defer visitMu.Unlock()
+	if _, ok := visitedSubmodules[path]; ok {
+		return false
+	}
+	visitedSubmodules[path] = struct{}{}
+	return true
+}
+
+func lockForRepo(repo string) *sync.Mutex {
+	repoLocksMu.Lock()
+	defer repoLocksMu.Unlock()
+	mu, ok := repoLocks[repo]
+	if !ok {
+		mu = &sync.Mutex{}
+		repoLocks[repo] = mu
+	}
+	return mu
+}
+
+func printLog(format string, args ...any) {
+	outputMu.Lock()
+	defer outputMu.Unlock()
+
+	output := fmt.Sprintf(format, args...)
+	if !strings.HasSuffix(output, "\n") {
+		output += "\n"
+	}
+	fmt.Print(output)
+}
+
+func printError(format string, args ...any) {
+	outputMu.Lock()
+	defer outputMu.Unlock()
+
+	msg := fmt.Sprintf(format, args...)
+	if !strings.HasSuffix(msg, "\n") {
+		msg += "\n"
+	}
+
+	// ANSI red: \033[31m ... \033[0m
+	fmt.Fprintf(os.Stderr, "\033[31m%s\033[0m", msg)
+}
+
+func printGitError(grid *ProgressGrid, mu *sync.Mutex, modPath, reason string, err error) {
+	// freeze the progressGrid before printing error
+	mu.Lock()
+	renderProgressGrid(grid)
+	grid.frozen = true
+	mu.Unlock()
+
+	// print log with ANSI red formatting wrapper
+	printError("\n❌ %s for %s: %v\n", reason, modPath, err)
+}
+
+func percentToInt(s string) int {
+	var i int
+	fmt.Sscanf(s, "%d", &i)
+	return i
+}
+
+func buildBar(pct int) string {
+	total := 20
+	if pct < 0 {
+		pct = 0
+	}
+	if pct > 100 {
+		pct = 100
+	}
+	filled := pct * total / 100
+	unfilled := total - filled
+	if unfilled > 0 {
+		unfilled--
+	}
+	return fmt.Sprintf("[%s>%s]", strings.Repeat("=", filled), strings.Repeat(" ", unfilled))
+}
+
+func updateProgress(grid *ProgressGrid, name string, pct int) {
+	outputMu.Lock()
+	defer outputMu.Unlock()
+	// prevent progress moving backwards
+	if grid != nil && grid.progress[name] < pct {
+		grid.progress[name] = pct
+	}
+}
+
+func renderProgressGrid(grid *ProgressGrid) {
+	outputMu.Lock()
+	defer outputMu.Unlock()
+
+	if grid == nil || len(grid.order) == 0 || grid.frozen {
+		return
+	}
+	if grid.lines > 0 {
+		fmt.Printf("\033[%dA", grid.lines)
+	}
+	grid.lines = len(grid.order)
+
+	for _, name := range grid.order {
+		pct := grid.progress[name]
+		bar := buildBar(pct)
+		fmt.Printf("\r\033[K%s %3d%%   %s\n", bar, pct, name)
+	}
+}
+
+func completeGrid(grid *ProgressGrid) {
+	if grid == nil {
+		return
+	}
+	for _, name := range grid.order {
+		grid.progress[name] = 100
+	}
+	renderProgressGrid(grid)
+}
 
 func parseGitHubURL(url string) (repoURL, branch string) {
 	// Handle GitHub tree URLs (e.g., https://github.com/user/repo/tree/branch)
@@ -28,37 +172,368 @@ func parseGitHubURL(url string) (repoURL, branch string) {
 	return url, ""
 }
 
-func (g *GitFetcher) Fetch(templateURL, targetDir string, verbose bool) error {
-	repoURL, branch := parseGitHubURL(templateURL)
-
-	args := []string{"clone", "--recurse-submodules", "-j8", "--depth=1"}
+func getRemoteHEADCommit(repoURL, branch string) (string, error) {
+	args := []string{"ls-remote", repoURL}
 	if branch != "" {
-		args = append(args, "-b", branch)
-	}
-	args = append(args, repoURL, targetDir)
-	cmd := exec.Command("git", args...)
-	cmd.Dir = targetDir
-
-	if verbose {
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		err := cmd.Run()
-		if err != nil {
-			return fmt.Errorf("failed to clone template: %w", err)
-		}
+		args = append(args, branch)
 	} else {
-		output, err := cmd.CombinedOutput()
+		args = append(args, "HEAD")
+	}
+	out, err := exec.Command("git", args...).Output()
+	if err != nil {
+		return "", err
+	}
+	fields := strings.Fields(string(out))
+	if len(fields) < 1 {
+		return "", fmt.Errorf("unexpected ls-remote output: %q", out)
+	}
+	return fields[0], nil
+}
+
+func listSubmodules(repoDir string) ([]Submodule, error) {
+	cmd := exec.Command("git", "config", "-f", ".gitmodules", "--get-regexp", "^submodule\\..*\\.path$")
+	cmd.Dir = repoDir
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("read .gitmodules: %w", err)
+	}
+
+	lines := strings.Split(string(out), "\n")
+	var subs []Submodule
+	for _, line := range lines {
+		fields := strings.Fields(line)
+		if len(fields) != 2 {
+			continue
+		}
+		name := strings.TrimPrefix(fields[0], "submodule.")
+		name = strings.TrimSuffix(name, ".path")
+		path := fields[1]
+
+		urlCmd := exec.Command("git", "config", "-f", ".gitmodules", "--get", fmt.Sprintf("submodule.%s.url", name))
+		urlCmd.Dir = repoDir
+		urlOut, err := urlCmd.Output()
 		if err != nil {
-			return fmt.Errorf("failed to clone template: %w\nOutput: %s", err, string(output))
+			return nil, fmt.Errorf("failed to clone template: %w", err)
+		}
+
+		branchCmd := exec.Command("git", "config", "-f", ".gitmodules", "--get", fmt.Sprintf("submodule.%s.branch", name))
+		branchCmd.Dir = repoDir
+		branchOut, err := branchCmd.Output()
+		branch := ""
+		if err == nil {
+			branch = strings.TrimSpace(string(branchOut))
+		}
+
+		subs = append(subs, Submodule{
+			Name:   name,
+			Path:   path,
+			URL:    strings.TrimSpace(string(urlOut)),
+			Branch: branch,
+		})
+	}
+	return subs, nil
+}
+
+func getSubmoduleCommit(repoDir, subPath string) (string, error) {
+	cmd := exec.Command("git", "ls-tree", "HEAD", subPath)
+	cmd.Dir = repoDir
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("ls-tree for %s: %w", subPath, err)
+	}
+	fields := strings.Fields(string(out))
+	if len(fields) < 3 {
+		return "", fmt.Errorf("unexpected ls-tree output: %s", out)
+	}
+	return fields[2], nil // object SHA
+}
+
+func checkoutCommit(repoDir, commitHash string) error {
+	cmd := exec.Command("git", "checkout", commitHash)
+	cmd.Dir = repoDir
+	return cmd.Run()
+}
+
+func stageSubmodule(repoDir, path, sha string) error {
+	cmd := exec.Command("git", "update-index", "--add", "--cacheinfo", "160000", sha, path)
+	cmd.Dir = repoDir
+	return cmd.Run()
+}
+
+func setSubmoduleURL(repoDir, name, url string) error {
+	cmd := exec.Command("git", "config", "--local", fmt.Sprintf("submodule.%s.url", name), url)
+	cmd.Dir = repoDir
+	return cmd.Run()
+}
+
+func activateSubmodule(repoDir, name string) error {
+	cmd := exec.Command("git", "config", "--local", fmt.Sprintf("submodule.%s.active", name), "true")
+	cmd.Dir = repoDir
+	return cmd.Run()
+}
+
+func absorbGitDirs(repoDir string) error {
+	cmd := exec.Command("git", "submodule", "absorbgitdirs")
+	cmd.Dir = repoDir
+	return cmd.Run()
+}
+
+func notExists(path string) bool {
+	_, err := os.Stat(path)
+	return os.IsNotExist(err)
+}
+
+func copyFromCache(mirrorPath, destPath string, updateProgress func(int)) error {
+	// lock the destination path
+	lock := lockForRepo(destPath)
+	lock.Lock()
+	defer lock.Unlock()
+
+	// proactively clean up before cloning
+	_ = os.RemoveAll(destPath)
+
+	// perform a clone from the cache to the workingDir
+	cmd := exec.Command("git", "clone", "--progress", mirrorPath, destPath)
+
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return err
+	}
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+
+	// track progress by scanning stderr for Receiving objects msgs
+	scanner := bufio.NewScanner(stderr)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if match := receivingRegex.FindStringSubmatch(line); match != nil {
+			pct := percentToInt(match[1])
+			updateProgress(pct)
 		}
 	}
 
-	// Cleanup .git directory
-	// TODO: In future, we might want to do git init after this step based on a flag?
-	gitDir := filepath.Join(targetDir, ".git")
-	if err := os.RemoveAll(gitDir); err != nil {
-		return fmt.Errorf("failed to remove .git directory: %w", err)
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("stderr scan error: %w", err)
 	}
 
+	if err := cmd.Wait(); err != nil {
+		_ = os.RemoveAll(destPath)
+		return err
+	}
+
+	updateProgress(100)
+	return nil
+}
+
+func cloneWithCache(repoURL, branch, cachePath, destPath string, noCache bool, updateProgress func(int)) error {
+	// only pull the repo if cache is missing or noCache is provided
+	if noCache || notExists(cachePath) {
+		if !notExists(cachePath) {
+			_ = os.RemoveAll(cachePath)
+		}
+
+		// clone with --bare to keep cache tree clean
+		args := []string{"clone", "--bare", "--progress"}
+		if branch != "" {
+			args = append(args, "-b", branch)
+		}
+		args = append(args, repoURL, cachePath)
+
+		cmd := exec.Command("git", args...)
+		stderr, err := cmd.StderrPipe()
+		if err != nil {
+			return fmt.Errorf("stderr pipe: %w", err)
+		}
+		if err := cmd.Start(); err != nil {
+			return fmt.Errorf("clone start: %w", err)
+		}
+		scanner := bufio.NewScanner(stderr)
+		for scanner.Scan() {
+			line := scanner.Text()
+			if match := receivingRegex.FindStringSubmatch(line); match != nil {
+				updateProgress(percentToInt(match[1]))
+			}
+		}
+		if err := cmd.Wait(); err != nil {
+			return fmt.Errorf("clone failed: %s: %w", repoURL, err)
+		}
+	}
+
+	// copy the cached copy to destPath
+	return copyFromCache(cachePath, destPath, updateProgress)
+}
+
+func cloneSubmodules(repoURL string, repoName string, repoDir string, noCache bool, depth int, maxDepth int) error {
+	// exit early if the maxDepth is exceeded
+	if maxDepth != -1 && depth >= maxDepth {
+		return nil
+	}
+
+	// pull the submodules for this repo
+	submodules, err := listSubmodules(repoDir)
+	if err != nil {
+		return fmt.Errorf("list submodules: %w", err)
+	}
+	if len(submodules) == 0 {
+		return nil
+	}
+
+	// create the submodule cache if it is missing
+	cacheDir := filepath.Join(".", ".git-submodule-cache")
+	if err := os.MkdirAll(cacheDir, 0755); err != nil {
+		return fmt.Errorf("create cache dir: %w", err)
+	}
+
+	// set up a new grid to hold progress
+	grid := &ProgressGrid{
+		order:    []string{},
+		progress: map[string]int{},
+	}
+
+	// print discoveries
+	printLog("\nDiscovered submodules in %s (%s):\n", repoName, repoURL)
+	for _, mod := range submodules {
+		printLog(" - %s → %s (%s)\n", mod.Name, mod.Path, mod.URL)
+		grid.order = append(grid.order, mod.Path)
+	}
+	printLog("")
+
+	// set up a waitGroup to perform a concurrent fanout and join
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+
+	// for each submodule, perform cloneWithCache and copy to workingCopyPath
+	for _, mod := range submodules {
+		// shadow to avoid race
+		mod := mod
+		// mark that we're waiting on this routine
+		wg.Add(1)
+		// define the routine
+		go func() {
+			// wait for this goroutine to finish
+			defer wg.Done()
+
+			commitHash, err := getSubmoduleCommit(repoDir, mod.Path)
+			if err != nil {
+				printLog("failed to get commit for %s: %v\n", mod.Path, err)
+				return
+			}
+			cacheName := fmt.Sprintf("%s-%s.git", mod.Name, commitHash)
+			cachePath := filepath.Join(cacheDir, cacheName)
+			workingCopyPath := filepath.Join(repoDir, mod.Path)
+
+			// we do not clone from Branch because we immediately checkout the commit ref'd in parents submodule
+			// passing in the Branch could move us to a tree without the commit we want, we can safely ignore it
+			err = cloneWithCache(mod.URL, "", cachePath, workingCopyPath, noCache, func(pct int) {
+				mu.Lock()
+				updateProgress(grid, mod.Path, pct)
+				renderProgressGrid(grid)
+				mu.Unlock()
+			})
+			if err != nil {
+				printGitError(grid, &mu, mod.Path, "clone failed", err)
+				return
+			}
+
+			// lock before modifying shared repo state
+			lock := lockForRepo(repoDir)
+			lock.Lock()
+			defer lock.Unlock()
+
+			// checkout the submodule on the referenced commitHash
+			if err := checkoutCommit(workingCopyPath, commitHash); err != nil {
+				printGitError(grid, &mu, mod.Path, "checkout failed", err)
+				return
+			}
+
+			// stage the submodule in the parent index at the correct SHA
+			if err := stageSubmodule(workingCopyPath, mod.Path, commitHash); err != nil {
+				printGitError(grid, &mu, mod.Path, "stage submodule failed", err)
+				return
+			}
+
+			// set the submodules url in local git config
+			if err := setSubmoduleURL(repoDir, mod.Name, mod.URL); err != nil {
+				printGitError(grid, &mu, mod.Path, "set submodule URL failed", err)
+				return
+			}
+
+			// mark submodule as active in local config
+			if err := activateSubmodule(repoDir, mod.Name); err != nil {
+				printGitError(grid, &mu, mod.Path, "activate submodule failed", err)
+				return
+			}
+
+			// absorb .git directories into the parent repo
+			if err := absorbGitDirs(repoDir); err != nil {
+				printGitError(grid, &mu, mod.Path, "absorb git dirs failed", err)
+				return
+			}
+		}()
+	}
+	// block until all goroutines call Done()
+	wg.Wait()
+
+	// complete this grid
+	completeGrid(grid)
+
+	// guard against duplicate submodules with same name but different paths
+	for _, mod := range submodules {
+		nestedPath := filepath.Join(repoDir, mod.Path)
+		if shouldVisit(nestedPath) {
+			_ = cloneSubmodules(mod.URL, mod.Name, nestedPath, noCache, depth+1, maxDepth)
+		}
+	}
+
+	return nil
+}
+
+func (g *GitFetcher) Fetch(templateURL, targetDir string, verbose bool, noCache bool) error {
+	// parse the provided templateURL
+	repoURL, branch := parseGitHubURL(templateURL)
+	printLog("Cloning template repo: %s → %s\n\n", repoURL, targetDir)
+
+	// set up a new grid to hold progress
+	grid := &ProgressGrid{
+		order:    []string{targetDir},
+		progress: map[string]int{targetDir: 0},
+	}
+	renderProgressGrid(grid)
+
+	// create the .git-template-cache dir if missing
+	cacheDir := filepath.Join(".", ".git-template-cache")
+	if err := os.MkdirAll(cacheDir, 0755); err != nil {
+		return fmt.Errorf("create template cache dir: %w", err)
+	}
+
+	// get HEAD commit from remote to id the clone we're about to make
+	commitHash, err := getRemoteHEADCommit(repoURL, branch)
+	if err != nil {
+		return fmt.Errorf("get remote HEAD commit failed: %w", err)
+	}
+	templateName := filepath.Base(strings.TrimSuffix(repoURL, ".git"))
+	cacheName := fmt.Sprintf("%s-%s.git", templateName, commitHash)
+	cachePath := filepath.Join(cacheDir, cacheName)
+
+	// clone into cache if needed
+	err = cloneWithCache(repoURL, branch, cachePath, targetDir, noCache, func(pct int) {
+		grid.progress[targetDir] = pct
+		renderProgressGrid(grid)
+	})
+	if err != nil {
+		return fmt.Errorf("clone with cache failed: %w", err)
+	}
+
+	// complete progress in the grid
+	completeGrid(grid)
+
+	// recurse into submodules
+	if err := cloneSubmodules(repoURL, templateName, targetDir, noCache, 0, g.MaxDepth); err != nil {
+		return fmt.Errorf("submodule clone with cache failed: %w", err)
+	}
+
+	// notify that all cloning is done
+	printLog("\nClone complete.\n")
 	return nil
 }

--- a/pkg/template/fetcher.go
+++ b/pkg/template/fetcher.go
@@ -100,7 +100,9 @@ func printGitError(grid *ProgressGrid, mu *sync.Mutex, modPath, reason string, e
 
 func percentToInt(s string) int {
 	var i int
-	fmt.Sscanf(s, "%d", &i)
+	if _, err := fmt.Sscanf(s, "%d", &i); err != nil {
+		return 0
+	}
 	return i
 }
 

--- a/pkg/template/fetcher.go
+++ b/pkg/template/fetcher.go
@@ -314,16 +314,15 @@ func copyFromCache(mirrorPath, destPath string, updateProgress func(int)) error 
 			updateProgress(pct)
 		}
 	}
-
 	if err := scanner.Err(); err != nil {
 		return fmt.Errorf("stderr scan error: %w", err)
 	}
-
 	if err := cmd.Wait(); err != nil {
 		_ = os.RemoveAll(destPath)
 		return err
 	}
 
+	// mark progress as 100 before moving on
 	updateProgress(100)
 	return nil
 }
@@ -530,6 +529,7 @@ func (g *GitFetcher) Fetch(templateURL, targetDir string, verbose bool, noCache 
 	// get name from the repoUrl
 	templateName := filepath.Base(strings.TrimSuffix(repoURL, ".git"))
 
+	// if we can useCache then cloneWithCache
 	if useCache {
 		cacheDir := filepath.Join(".", ".git-template-cache")
 		if err := os.MkdirAll(cacheDir, 0755); err != nil {
@@ -548,6 +548,7 @@ func (g *GitFetcher) Fetch(templateURL, targetDir string, verbose bool, noCache 
 			return fmt.Errorf("clone with cache failed: %w", err)
 		}
 	} else {
+		// clone fresh directly to the targetDir
 		err = runClone(repoURL, branch, []string{"--depth=1", "--recurse-submodules=0"}, targetDir, func(pct int) {
 			grid.progress[targetDir] = pct
 			renderProgressGrid(grid)

--- a/pkg/template/fetcher_test.go
+++ b/pkg/template/fetcher_test.go
@@ -11,7 +11,7 @@ func TestGitFetcher(t *testing.T) {
 	tempDir := t.TempDir()
 
 	// Test with an invalid URL (should fail)
-	err := fetcher.Fetch("invalid-url", tempDir)
+	err := fetcher.Fetch("invalid-url", tempDir, false)
 	if err == nil {
 		t.Error("Expected error for invalid URL")
 	}

--- a/pkg/template/fetcher_test.go
+++ b/pkg/template/fetcher_test.go
@@ -6,19 +6,90 @@ import (
 	"testing"
 )
 
-func TestGitFetcher(t *testing.T) {
+func TestGitFetcher_InvalidURL(t *testing.T) {
 	fetcher := &GitFetcher{}
 	tempDir := t.TempDir()
 
 	// Test with an invalid URL (should fail)
-	err := fetcher.Fetch("invalid-url", tempDir, false)
+	err := fetcher.Fetch("invalid-url", tempDir, false, true)
 	if err == nil {
-		t.Error("Expected error for invalid URL")
+		t.Error("expected error for invalid URL")
 	}
 
 	// Verify .git directory is not present (since Fetch failed)
 	gitDir := filepath.Join(tempDir, ".git")
 	if _, err := os.Stat(gitDir); !os.IsNotExist(err) {
-		t.Error("Expected no .git directory after failed fetch")
+		t.Error("expected no .git directory after failed fetch")
+	}
+}
+
+func TestGitFetcher_ValidRepo(t *testing.T) {
+	fetcher := &GitFetcher{}
+	tempDir := t.TempDir()
+
+	repo := "https://github.com/Layr-Labs/hourglass-avs-template"
+
+	err := fetcher.Fetch(repo, tempDir, false, true)
+	if err != nil {
+		t.Fatalf("unexpected error fetching repo: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(tempDir, ".git")); err != nil {
+		t.Errorf(".git not found after clone: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(tempDir, "README.md")); err != nil {
+		t.Log("README file not found — still valid but may have changed")
+	}
+}
+
+func TestGitFetcher_Submodules(t *testing.T) {
+	fetcher := &GitFetcher{MaxDepth: 1}
+	tempDir := t.TempDir()
+
+	// Includes submodules: simple example with known submodule
+	repo := "https://github.com/Layr-Labs/hourglass-avs-template"
+
+	err := fetcher.Fetch(repo, tempDir, false, true)
+	if err != nil {
+		t.Fatalf("unexpected error cloning repo with submodules: %v", err)
+	}
+
+	// Example path — verify at least one known submodule folder exists
+	expectedSubmodule := filepath.Join(tempDir, "contracts")
+	if _, err := os.Stat(expectedSubmodule); os.IsNotExist(err) {
+		t.Log("submodule not found — this may vary based on repo")
+	}
+}
+
+func TestGitFetcher_MaxDepth(t *testing.T) {
+	fetcher := &GitFetcher{MaxDepth: 0}
+	tempDir := t.TempDir()
+
+	repo := "https://github.com/Layr-Labs/hourglass-avs-template"
+
+	err := fetcher.Fetch(repo, tempDir, false, true)
+	if err != nil {
+		t.Fatalf("unexpected error fetching repo with depth: %v", err)
+	}
+	visited := filepath.Join(tempDir, "contracts")
+	if _, err := os.Stat(visited); err != nil {
+		t.Fatalf("expected top-level submodule not found")
+	}
+
+	contractsGitmodules := filepath.Join(tempDir, "contracts/.gitmodules")
+	if _, err := os.Stat(contractsGitmodules); err == nil {
+		t.Errorf("contracts/.gitmodules parsed despite MaxDepth=1")
+	}
+}
+
+func TestGitFetcher_NonexistentBranch(t *testing.T) {
+	fetcher := &GitFetcher{}
+	tempDir := t.TempDir()
+
+	repo := "https://github.com/Layr-Labs/hourglass-avs-template/tree/missing-branch"
+
+	err := fetcher.Fetch(repo, tempDir, false, true)
+	if err == nil {
+		t.Error("expected error for nonexistent branch")
 	}
 }

--- a/pkg/template/fetcher_test.go
+++ b/pkg/template/fetcher_test.go
@@ -27,7 +27,7 @@ func TestGitFetcher_ValidRepo(t *testing.T) {
 	fetcher := &GitFetcher{}
 	tempDir := t.TempDir()
 
-	repo := "https://github.com/Layr-Labs/hourglass-avs-template"
+	repo := "https://github.com/Layr-labs/eigenlayer-contracts"
 
 	err := fetcher.Fetch(repo, tempDir, false, true)
 	if err != nil {
@@ -47,7 +47,7 @@ func TestGitFetcher_Submodules(t *testing.T) {
 	tempDir := t.TempDir()
 
 	// Includes submodules: simple example with known submodule
-	repo := "https://github.com/Layr-Labs/hourglass-avs-template"
+	repo := "https://github.com/Layr-labs/eigenlayer-contracts"
 
 	err := fetcher.Fetch(repo, tempDir, false, true)
 	if err != nil {
@@ -55,7 +55,7 @@ func TestGitFetcher_Submodules(t *testing.T) {
 	}
 
 	// Example path — verify at least one known submodule folder exists
-	expectedSubmodule := filepath.Join(tempDir, "contracts")
+	expectedSubmodule := filepath.Join(tempDir, "lib", "forge-std")
 	if _, err := os.Stat(expectedSubmodule); os.IsNotExist(err) {
 		t.Log("submodule not found — this may vary based on repo")
 	}
@@ -65,20 +65,20 @@ func TestGitFetcher_MaxDepth(t *testing.T) {
 	fetcher := &GitFetcher{MaxDepth: 0}
 	tempDir := t.TempDir()
 
-	repo := "https://github.com/Layr-Labs/hourglass-avs-template"
+	repo := "https://github.com/Layr-labs/eigenlayer-contracts"
 
 	err := fetcher.Fetch(repo, tempDir, false, true)
 	if err != nil {
 		t.Fatalf("unexpected error fetching repo with depth: %v", err)
 	}
-	visited := filepath.Join(tempDir, "contracts")
+	visited := filepath.Join(tempDir, "lib", "forge-std")
 	if _, err := os.Stat(visited); err != nil {
 		t.Fatalf("expected top-level submodule not found")
 	}
 
-	contractsGitmodules := filepath.Join(tempDir, "contracts/.gitmodules")
+	contractsGitmodules := filepath.Join(tempDir, "lib", "forge-std", ".gitmodules")
 	if _, err := os.Stat(contractsGitmodules); err == nil {
-		t.Errorf("contracts/.gitmodules parsed despite MaxDepth=1")
+		t.Errorf("lib/forge-std/.gitmodules parsed despite MaxDepth=1")
 	}
 }
 
@@ -86,7 +86,7 @@ func TestGitFetcher_NonexistentBranch(t *testing.T) {
 	fetcher := &GitFetcher{}
 	tempDir := t.TempDir()
 
-	repo := "https://github.com/Layr-Labs/hourglass-avs-template/tree/missing-branch"
+	repo := "https://github.com/Layr-labs/eigenlayer-contracts/tree/missing-branch"
 
 	err := fetcher.Fetch(repo, tempDir, false, true)
 	if err == nil {


### PR DESCRIPTION
<!-- 
    🚨 ATTENTION! 🚨 
    
    This PR template is REQUIRED. PRs not following this format will be closed without review.
    
    Requirements:
    - PR title must follow commit conventions: https://www.conventionalcommits.org/en/v1.0.0/
    - Label your PR with the correct type (e.g., 🐛 Bug, ✨ Enhancement, 🧪 Test, etc.)
    - Provide clear and specific details in each section
-->

**Motivation:**
<!--
Explain here the context, and why you're making that change. What is the problem you're trying to solve.
-->

Cloning templates and their submodules needed to be more reliable, cacheable, and observable. The previous approach lacked caching, depth control, and surfaced errors poorly. This change ensures reproducibility, avoids redundant network calls, and provides clear feedback to the user.

**Modifications:**
<!--
Describe the modifications you've done from a high level. What are the key technical decisions and why were they made?
-->

Modified `GitFetcher` with:
- Caching via `--bare` clone and local mirrors
- `copyFromCache` with locking and progress tracking
- Submodule resolution via `.gitmodules` and `ls-tree` (to checkout active commit)
- Depth control via `--depth`
- Disable cache via `--no-cache`
- Progress grid with freezing on failure (to show progress & errors)
- Locking per repo path (to prevent race conditions)

Tests covering:
- Invalid URLs
- Real repo cloning
- Submodule recursion
- MaxDepth behaviour
- Missing branches

**Result:**
<!--
*After your change, what will change.
-->

- Templates and submodules clone with progress and caching
- Failures are clearly reported
- Submodules respect depth limits
- Tests validate key fetch behaviours

**Open questions:**
<!--
(optional) Any open questions or feedback on design desired?
-->

- Should `--no-color` disable ANSI output?
- Should we support configurable cache locations?

