### PR TITLE
fix: add retries for fault tolerance and remove flaky absorbGitDirs

### DIFF
--- a/pkg/commands/create.go
+++ b/pkg/commands/create.go
@@ -60,8 +60,18 @@ var CreateCommand = &cli.Command{
 		},
 		&cli.IntFlag{
 			Name:  "depth",
-			Usage: "Max submodule recursion depth",
+			Usage: "Maximum submodule recursion depth",
 			Value: -1,
+		},
+		&cli.IntFlag{
+			Name:  "retries",
+			Usage: "Maximum number of retries on submodule clone failure",
+			Value: 3,
+		},
+		&cli.IntFlag{
+			Name:  "concurrency",
+			Usage: "Maximum number of concurrent submodule clones",
+			Value: 8,
 		},
 	}, common.GlobalFlags...),
 	Action: func(cCtx *cli.Context) error {
@@ -114,7 +124,9 @@ var CreateCommand = &cli.Command{
 
 		// Fetch main template
 		fetcher := &template.GitFetcher{
-			MaxDepth: cCtx.Int("depth"),
+			MaxDepth:       cCtx.Int("depth"),
+			MaxRetries:     cCtx.Int("retries"),
+			MaxConcurrency: cCtx.Int("concurrency"),
 		}
 		if err := fetcher.Fetch(mainURL, targetDir, cCtx.Bool("verbose"), cCtx.Bool("no-cache")); err != nil {
 			return fmt.Errorf("failed to fetch template from %s: %w", mainURL, err)

--- a/pkg/template/fetcher.go
+++ b/pkg/template/fetcher.go
@@ -518,7 +518,9 @@ func cloneSubmodules(repoURL string, repoName string, repoDir string, noCache bo
 			grid.order = append(grid.order, f.mod.Path)
 			retrySubs = append(retrySubs, f.mod)
 		}
-		failures = attemptSubmoduleSetups(retrySubs, grid, repoDir, cacheDir, noCache)
+
+		// on subsequent attempts, skip cache and attempt full clone
+		failures = attemptSubmoduleSetups(retrySubs, grid, repoDir, cacheDir, true)
 	}
 
 	// maxRetries exceeded, report final failure

--- a/pkg/template/fetcher.go
+++ b/pkg/template/fetcher.go
@@ -493,7 +493,7 @@ func cloneSubmodules(repoURL string, repoName string, repoDir string, noCache bo
 	}
 	printLog("")
 
-	// print initial progresss
+	// print initial progress
 	renderProgressGrid(grid)
 
 	// initial run

--- a/pkg/template/fetcher.go
+++ b/pkg/template/fetcher.go
@@ -26,6 +26,10 @@ type Submodule struct {
 	Branch string
 }
 
+type SubmoduleFailure struct {
+	mod Submodule
+	err error
+}
 type ProgressGrid struct {
 	order    []string
 	progress map[string]int
@@ -71,6 +75,7 @@ func printLog(format string, args ...any) {
 	if !strings.HasSuffix(output, "\n") {
 		output += "\n"
 	}
+
 	fmt.Print(output)
 }
 
@@ -78,24 +83,13 @@ func printError(format string, args ...any) {
 	outputMu.Lock()
 	defer outputMu.Unlock()
 
-	msg := fmt.Sprintf(format, args...)
-	if !strings.HasSuffix(msg, "\n") {
-		msg += "\n"
+	output := fmt.Sprintf(format, args...)
+	if !strings.HasSuffix(output, "\n") {
+		output += "\n"
 	}
 
 	// ANSI red: \033[31m ... \033[0m
-	fmt.Fprintf(os.Stderr, "\033[31m%s\033[0m", msg)
-}
-
-func printGitError(grid *ProgressGrid, mu *sync.Mutex, modPath, reason string, err error) {
-	// freeze the progressGrid before printing error
-	mu.Lock()
-	renderProgressGrid(grid)
-	grid.frozen = true
-	mu.Unlock()
-
-	// print log with ANSI red formatting wrapper
-	printError("\n❌ %s for %s: %v\n", reason, modPath, err)
+	fmt.Fprintf(os.Stderr, "\033[31m%s\033[0m", output)
 }
 
 func percentToInt(s string) int {
@@ -148,16 +142,6 @@ func renderProgressGrid(grid *ProgressGrid) {
 		bar := buildBar(pct)
 		fmt.Printf("\r\033[K%s %3d%%   %s\n", bar, pct, name)
 	}
-}
-
-func completeGrid(grid *ProgressGrid) {
-	if grid == nil {
-		return
-	}
-	for _, name := range grid.order {
-		grid.progress[name] = 100
-	}
-	renderProgressGrid(grid)
 }
 
 func parseGitHubURL(url string) (repoURL, branch string) {
@@ -274,26 +258,15 @@ func activateSubmodule(repoDir, name string) error {
 	return cmd.Run()
 }
 
-func absorbGitDirs(repoDir string) error {
-	cmd := exec.Command("git", "submodule", "absorbgitdirs")
-	cmd.Dir = repoDir
-	return cmd.Run()
-}
-
 func notExists(path string) bool {
 	_, err := os.Stat(path)
 	return os.IsNotExist(err)
 }
 
 func cloneWithCache(repoURL, branch, cachePath, destPath string, noCache bool, updateProgress func(int)) error {
-	// Lock on the cache path to prevent races
-	lock := lockForRepo(repoURL)
-	lock.Lock()
-	defer lock.Unlock()
-
 	// only pull the repo if cache is missing or noCache is provided
 	if noCache || notExists(cachePath) {
-		if !notExists(cachePath) {
+		if noCache {
 			_ = os.RemoveAll(cachePath)
 		}
 
@@ -308,11 +281,6 @@ func cloneWithCache(repoURL, branch, cachePath, destPath string, noCache bool, u
 }
 
 func copyFromCache(mirrorPath, destPath string, updateProgress func(int)) error {
-	// lock the destination path
-	lock := lockForRepo(destPath)
-	lock.Lock()
-	defer lock.Unlock()
-
 	// proactively clean up before cloning
 	if err := os.RemoveAll(destPath); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("failed to remove destPath %s: %w", destPath, err)
@@ -320,7 +288,11 @@ func copyFromCache(mirrorPath, destPath string, updateProgress func(int)) error 
 
 	// perform a clone from the cache to the workingDir
 	cmd := exec.Command("git", "clone", "--dissociate", "--no-hardlinks", "--progress", mirrorPath, destPath)
-
+	// force git to flush stderr early
+	cmd.Env = append(os.Environ(),
+		"GIT_PROGRESS_DELAY=0",
+		"GIT_FLUSH=1",
+	)
 	stderr, err := cmd.StderrPipe()
 	if err != nil {
 		return err
@@ -394,6 +366,98 @@ func runClone(repoURL, branch string, args []string, dest string, updateProgress
 	return nil
 }
 
+func runSubmoduleTasks(submodules []Submodule, grid *ProgressGrid, repoDir string, cacheDir string, noCache bool) []SubmoduleFailure {
+	// set up a waitGroup to perform a concurrent fanout and join
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+
+	// record any failures
+	var failures []SubmoduleFailure
+
+	// for each submodule, perform cloneWithCache and copy to workingCopyPath
+	for _, mod := range submodules {
+		// shadow to avoid race
+		mod := mod
+		// mark that we're waiting on this routine
+		wg.Add(1)
+		// define the routine
+		go func() {
+			// wait for this goroutine to finish
+			defer wg.Done()
+
+			// unpack submodule commit hash from the parent ls-tree
+			commitHash, err := getSubmoduleCommit(repoDir, mod.Path)
+			if err != nil {
+				printLog("failed to get commit for %s: %v\n", mod.Path, err)
+				return
+			}
+			baseName := filepath.Base(mod.Name)
+			cacheName := fmt.Sprintf("%s-%s.git", baseName, commitHash)
+			cachePath := filepath.Join(cacheDir, cacheName)
+			workingCopyPath := filepath.Join(repoDir, mod.Path)
+
+			// lock against workingCopyPath to guard against modules with same path in same parent
+			cloneLock := lockForRepo(workingCopyPath)
+			cloneLock.Lock()
+			defer cloneLock.Unlock()
+
+			// check for errors in the cloning procedure
+			err = func() error {
+				// we do not clone from Branch because we immediately checkout the commit ref'd in parents submodule
+				// passing in the Branch could move us to a tree without the commit we want, we can safely ignore it
+				if err := cloneWithCache(mod.URL, "", cachePath, workingCopyPath, noCache, func(pct int) {
+					if pct < 90 {
+						updateProgress(grid, mod.Path, pct)
+						renderProgressGrid(grid)
+					}
+				}); err != nil {
+					return fmt.Errorf("clone: %w", err)
+				}
+
+				// checkout the submodule on the referenced commitHash
+				if err := checkoutCommit(workingCopyPath, commitHash); err != nil {
+					return fmt.Errorf("checkout: %w", err)
+				}
+				// stage the submodule in the parent index at the correct SHA
+				if err := stageSubmodule(workingCopyPath, mod.Path, commitHash); err != nil {
+					return fmt.Errorf("stage: %w", err)
+				}
+
+				// lock against repoDir to guard global state
+				cloneLock := lockForRepo(repoDir)
+				cloneLock.Lock()
+				defer cloneLock.Unlock()
+
+				// set the submodules url in local git config
+				if err := setSubmoduleURL(repoDir, mod.Name, mod.URL); err != nil {
+					return fmt.Errorf("setSubmoduleURL: %w", err)
+				}
+				// mark submodule as active in local config
+				if err := activateSubmodule(repoDir, mod.Name); err != nil {
+					return fmt.Errorf("activateSubmodule: %w", err)
+				}
+
+				// move progress to 100%
+				updateProgress(grid, mod.Path, 100)
+				renderProgressGrid(grid)
+				return nil
+			}()
+
+			// if we encountered an error then record into failures
+			if err != nil {
+				mu.Lock()
+				defer mu.Unlock()
+				failures = append(failures, SubmoduleFailure{mod: mod, err: err})
+			}
+		}()
+	}
+	// block until all goroutines call Done()
+	wg.Wait()
+
+	// return SubmoduleFailures
+	return failures
+}
+
 func cloneSubmodules(repoURL string, repoName string, repoDir string, noCache bool, depth int, maxDepth int) error {
 	// exit early if the maxDepth is exceeded
 	if maxDepth != -1 && depth >= maxDepth {
@@ -429,88 +493,40 @@ func cloneSubmodules(repoURL string, repoName string, repoDir string, noCache bo
 	}
 	printLog("")
 
-	// set up a waitGroup to perform a concurrent fanout and join
-	var wg sync.WaitGroup
-	var mu sync.Mutex
+	// print initial progresss
+	renderProgressGrid(grid)
 
-	// for each submodule, perform cloneWithCache and copy to workingCopyPath
-	for _, mod := range submodules {
-		// shadow to avoid race
-		mod := mod
-		// mark that we're waiting on this routine
-		wg.Add(1)
-		// define the routine
-		go func() {
-			// wait for this goroutine to finish
-			defer wg.Done()
+	// initial run
+	failures := runSubmoduleTasks(submodules, grid, repoDir, cacheDir, noCache)
 
-			// unpack submodule commit hash from the parent ls-tree
-			commitHash, err := getSubmoduleCommit(repoDir, mod.Path)
-			if err != nil {
-				printLog("failed to get commit for %s: %v\n", mod.Path, err)
-				return
-			}
-			baseName := filepath.Base(mod.Name)
-			cacheName := fmt.Sprintf("%s-%s.git", baseName, commitHash)
-			cachePath := filepath.Join(cacheDir, cacheName)
-			workingCopyPath := filepath.Join(repoDir, mod.Path)
-
-			// we do not clone from Branch because we immediately checkout the commit ref'd in parents submodule
-			// passing in the Branch could move us to a tree without the commit we want, we can safely ignore it
-			err = cloneWithCache(mod.URL, "", cachePath, workingCopyPath, noCache, func(pct int) {
-				mu.Lock()
-				updateProgress(grid, mod.Path, pct)
-				renderProgressGrid(grid)
-				mu.Unlock()
-			})
-			if err != nil {
-				printGitError(grid, &mu, mod.Path, "clone failed", err)
-				return
-			}
-
-			// lock before modifying shared repo state
-			lock := lockForRepo(repoDir)
-			lock.Lock()
-			defer lock.Unlock()
-
-			// checkout the submodule on the referenced commitHash
-			if err := checkoutCommit(workingCopyPath, commitHash); err != nil {
-				printGitError(grid, &mu, mod.Path, "checkout failed", err)
-				return
-			}
-
-			// stage the submodule in the parent index at the correct SHA
-			if err := stageSubmodule(workingCopyPath, mod.Path, commitHash); err != nil {
-				printGitError(grid, &mu, mod.Path, "stage submodule failed", err)
-				return
-			}
-
-			// set the submodules url in local git config
-			if err := setSubmoduleURL(repoDir, mod.Name, mod.URL); err != nil {
-				printGitError(grid, &mu, mod.Path, "set submodule URL failed", err)
-				return
-			}
-
-			// mark submodule as active in local config
-			if err := activateSubmodule(repoDir, mod.Name); err != nil {
-				printGitError(grid, &mu, mod.Path, "activate submodule failed", err)
-				return
-			}
-
-			// absorb .git directories into the parent repo
-			if err := absorbGitDirs(repoDir); err != nil {
-				printGitError(grid, &mu, mod.Path, "absorb git dirs failed", err)
-				return
-			}
-		}()
+	// retry loop
+	const maxRetries = 3
+	for attempt := 1; attempt <= maxRetries && len(failures) > 0; attempt++ {
+		// set up a new grid to hold progress
+		grid = &ProgressGrid{
+			order:    []string{},
+			progress: map[string]int{},
+		}
+		var retrySubs []Submodule
+		// detail the failures
+		printLog("\nRetrying %d failed submodule clones (%d/%d)...\n\n", len(failures), attempt, maxRetries)
+		// set up grid and submodules for next attempt
+		for _, f := range failures {
+			grid.order = append(grid.order, f.mod.Path)
+			retrySubs = append(retrySubs, f.mod)
+		}
+		failures = runSubmoduleTasks(retrySubs, grid, repoDir, cacheDir, noCache)
 	}
-	// block until all goroutines call Done()
-	wg.Wait()
 
-	// complete this grid
-	completeGrid(grid)
+	// maxRetries exceeded, report final failure
+	if len(failures) > 0 {
+		printLog("\n")
+		for _, f := range failures {
+			printError("❌ submodule setup failed for %s: %v\n", f.mod.Path, f.err)
+		}
+	}
 
-	// guard against duplicate submodules with same name but different paths
+	// recurse into nested submodules
 	for _, mod := range submodules {
 		nestedPath := filepath.Join(repoDir, mod.Path)
 		if shouldVisit(nestedPath) {
@@ -518,6 +534,7 @@ func cloneSubmodules(repoURL string, repoName string, repoDir string, noCache bo
 		}
 	}
 
+	// none-halting so that we continue to cache remainder
 	return nil
 }
 
@@ -526,10 +543,13 @@ func (g *GitFetcher) Fetch(templateURL, targetDir string, verbose bool, noCache 
 	repoURL, branch := parseGitHubURL(templateURL)
 	printLog("Cloning template repo: %s → %s\n\n", repoURL, targetDir)
 
+	// get name from the repoUrl
+	templateName := filepath.Base(strings.TrimSuffix(repoURL, ".git"))
+
 	// set up a new grid to hold progress
 	grid := &ProgressGrid{
-		order:    []string{targetDir},
-		progress: map[string]int{targetDir: 0},
+		order:    []string{templateName},
+		progress: map[string]int{templateName: 0},
 	}
 	renderProgressGrid(grid)
 
@@ -540,8 +560,6 @@ func (g *GitFetcher) Fetch(templateURL, targetDir string, verbose bool, noCache 
 		useCache = false
 		printError("⚠️  Warning: couldn't resolve HEAD commit, falling back to direct clone: %v\n", err)
 	}
-	// get name from the repoUrl
-	templateName := filepath.Base(strings.TrimSuffix(repoURL, ".git"))
 
 	// if we can useCache then cloneWithCache
 	if useCache {
@@ -556,7 +574,7 @@ func (g *GitFetcher) Fetch(templateURL, targetDir string, verbose bool, noCache 
 
 		// clone into cache if requested and copy to targetDir
 		if err := cloneWithCache(repoURL, branch, cachePath, targetDir, noCache, func(pct int) {
-			updateProgress(grid, targetDir, pct)
+			updateProgress(grid, templateName, pct)
 			renderProgressGrid(grid)
 		}); err != nil {
 			return fmt.Errorf("clone with cache failed: %w", err)
@@ -564,16 +582,13 @@ func (g *GitFetcher) Fetch(templateURL, targetDir string, verbose bool, noCache 
 	} else {
 		// clone fresh directly to the targetDir
 		err = runClone(repoURL, branch, []string{"--depth=1", "--recurse-submodules=0"}, targetDir, func(pct int) {
-			updateProgress(grid, targetDir, pct)
+			updateProgress(grid, templateName, pct)
 			renderProgressGrid(grid)
 		})
 		if err != nil {
 			return fmt.Errorf("fallback clone failed: %w", err)
 		}
 	}
-
-	// complete progress in the grid
-	completeGrid(grid)
 
 	// recurse into submodules
 	if err := cloneSubmodules(repoURL, templateName, targetDir, noCache, 0, g.MaxDepth); err != nil {

--- a/pkg/template/fetcher_test.go
+++ b/pkg/template/fetcher_test.go
@@ -24,7 +24,11 @@ func TestGitFetcher_InvalidURL(t *testing.T) {
 }
 
 func TestGitFetcher_ValidRepo(t *testing.T) {
-	fetcher := &GitFetcher{}
+	fetcher := &GitFetcher{
+		MaxDepth:       1,
+		MaxRetries:     3,
+		MaxConcurrency: 8,
+	}
 	tempDir := t.TempDir()
 
 	repo := "https://github.com/Layr-labs/eigenlayer-contracts"
@@ -43,7 +47,11 @@ func TestGitFetcher_ValidRepo(t *testing.T) {
 }
 
 func TestGitFetcher_Submodules(t *testing.T) {
-	fetcher := &GitFetcher{MaxDepth: 1}
+	fetcher := &GitFetcher{
+		MaxDepth:       1,
+		MaxRetries:     3,
+		MaxConcurrency: 8,
+	}
 	tempDir := t.TempDir()
 
 	// Includes submodules: simple example with known submodule
@@ -62,7 +70,11 @@ func TestGitFetcher_Submodules(t *testing.T) {
 }
 
 func TestGitFetcher_MaxDepth(t *testing.T) {
-	fetcher := &GitFetcher{MaxDepth: 0}
+	fetcher := &GitFetcher{
+		MaxDepth:       0,
+		MaxRetries:     3,
+		MaxConcurrency: 8,
+	}
 	tempDir := t.TempDir()
 
 	repo := "https://github.com/Layr-labs/eigenlayer-contracts"
@@ -83,7 +95,11 @@ func TestGitFetcher_MaxDepth(t *testing.T) {
 }
 
 func TestGitFetcher_NonexistentBranch(t *testing.T) {
-	fetcher := &GitFetcher{}
+	fetcher := &GitFetcher{
+		MaxDepth:       0,
+		MaxRetries:     3,
+		MaxConcurrency: 8,
+	}
 	tempDir := t.TempDir()
 
 	repo := "https://github.com/Layr-labs/eigenlayer-contracts/tree/missing-branch"


### PR DESCRIPTION
<!-- 
    🚨 ATTENTION! 🚨 
    
    This PR template is REQUIRED. PRs not following this format will be closed without review.
    
    Requirements:
    - PR title must follow commit conventions: https://www.conventionalcommits.org/en/v1.0.0/
    - Label your PR with the correct type (e.g., 🐛 Bug, ✨ Enhancement, 🧪 Test, etc.)
    - Provide clear and specific details in each section
-->

**Motivation:**
<!--
Explain here the context, and why you're making that change. What is the problem you're trying to solve.
-->
This PR adds graceful handling for failed submodule clones and removes flaky calls to `absorbGitDirs` to prevent `exit status 128` errors halting parent level clones.

**Modifications:**
<!--
Describe the modifications you've done from a high level. What are the key technical decisions and why were they made?
-->

- Removes `absorbGitDirs` calls
- Adds retry attempts to submodule cloning

**Result:**
<!--
*After your change, what will change.
-->
- Gracefully handles and reports failures (retrying up to 3 times before reporting as errors)
