### PR TITLE
feat: standardize devkit telemetry with simplified middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,8 @@ devkit avs build
 devkit avs run
 ```
 
+---
+
 ## 🤝 Contributing
 
 Contributions are welcome! Please open an issue to discuss significant changes before submitting a pull request.

--- a/README.md
+++ b/README.md
@@ -201,8 +201,6 @@ devkit avs build
 devkit avs run
 ```
 
----
-
 ## 🤝 Contributing
 
 Contributions are welcome! Please open an issue to discuss significant changes before submitting a pull request.

--- a/cmd/devkit/main.go
+++ b/cmd/devkit/main.go
@@ -25,8 +25,14 @@ func main() {
 		UseShortOptionHandling: true,
 	}
 
-	// Apply both middleware functions to all commands
-	hooks.ApplyMiddleware(app.Commands, hooks.WithEnvLoader, hooks.WithTelemetry)
+	middleware := hooks.NewCommandMiddleware()
+
+	middleware.AddPreProcessor(hooks.WithEnvLoader())
+	middleware.AddPreProcessor(hooks.WithTelemetryPreProcessor())
+
+	middleware.AddPostProcessor(hooks.WithTelemetryPostProcessor())
+
+	hooks.ApplyMiddleware(app.Commands, middleware)
 
 	if err := app.RunContext(ctx, os.Args); err != nil {
 		log.Fatal(err)

--- a/cmd/devkit/main.go
+++ b/cmd/devkit/main.go
@@ -8,14 +8,14 @@ import (
 	"devkit-cli/pkg/commands"
 	"devkit-cli/pkg/commands/keystore"
 	"devkit-cli/pkg/common"
-	devcontext "devkit-cli/pkg/context"
+	kitcontext "devkit-cli/pkg/context"
 	"devkit-cli/pkg/hooks"
 
 	"github.com/urfave/cli/v2"
 )
 
 func main() {
-	ctx := devcontext.WithShutdown(context.Background())
+	ctx := kitcontext.WithShutdown(context.Background())
 
 	app := &cli.App{
 		Name:                   "devkit",

--- a/cmd/devkit/main.go
+++ b/cmd/devkit/main.go
@@ -25,14 +25,11 @@ func main() {
 		UseShortOptionHandling: true,
 	}
 
-	middleware := hooks.NewCommandMiddleware()
+	actionChain := hooks.NewActionChain()
+	actionChain.Use(hooks.WithEnvLoader)
+	actionChain.Use(hooks.WithTelemetry)
 
-	middleware.AddPreProcessor(hooks.WithEnvLoader())
-	middleware.AddPreProcessor(hooks.WithTelemetryPreProcessor())
-
-	middleware.AddPostProcessor(hooks.WithTelemetryPostProcessor())
-
-	hooks.ApplyMiddleware(app.Commands, middleware)
+	hooks.ApplyMiddleware(app.Commands, actionChain)
 
 	if err := app.RunContext(ctx, os.Args); err != nil {
 		log.Fatal(err)

--- a/cmd/devkit/main.go
+++ b/cmd/devkit/main.go
@@ -18,18 +18,20 @@ func main() {
 	ctx := kitcontext.WithShutdown(context.Background())
 
 	app := &cli.App{
-		Name:                   "devkit",
-		Usage:                  "EigenLayer Development Kit",
-		Flags:                  common.GlobalFlags,
+		Name:  "devkit",
+		Usage: "EigenLayer Development Kit",
+		Flags: common.GlobalFlags,
+		Before: func(ctx *cli.Context) error {
+			err := hooks.LoadEnvFile(ctx)
+			if err != nil {
+				return err
+			}
+			hooks.WithAppEnvironment(ctx)
+			return hooks.WithCommandMetricsContext(ctx)
+		},
 		Commands:               []*cli.Command{commands.AVSCommand, keystore.KeystoreCommand},
 		UseShortOptionHandling: true,
 	}
-
-	actionChain := hooks.NewActionChain()
-	actionChain.Use(hooks.WithEnvLoader)
-	actionChain.Use(hooks.WithTelemetry)
-
-	hooks.ApplyMiddleware(app.Commands, actionChain)
 
 	if err := app.RunContext(ctx, os.Args); err != nil {
 		log.Fatal(err)

--- a/cmd/devkit/main.go
+++ b/cmd/devkit/main.go
@@ -33,6 +33,11 @@ func main() {
 		UseShortOptionHandling: true,
 	}
 
+	actionChain := hooks.NewActionChain()
+	actionChain.Use(hooks.WithMetricEmission)
+
+	hooks.ApplyMiddleware(app.Commands, actionChain)
+
 	if err := app.RunContext(ctx, os.Args); err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/commands/build_test.go
+++ b/pkg/commands/build_test.go
@@ -3,7 +3,7 @@ package commands
 import (
 	"context"
 	"devkit-cli/pkg/common"
-	devcontext "devkit-cli/pkg/context"
+	kitcontext "devkit-cli/pkg/context"
 	"devkit-cli/pkg/testutils"
 	"errors"
 	"github.com/urfave/cli/v2"
@@ -169,7 +169,7 @@ build:
 	defer func() { _ = os.Chdir(oldWd) }()
 
 	parentCtx, cancel := context.WithCancel(context.Background())
-	ctx := devcontext.WithShutdown(parentCtx)
+	ctx := kitcontext.WithShutdown(parentCtx)
 
 	app := &cli.App{
 		Name:     "test",

--- a/pkg/commands/config_edit.go
+++ b/pkg/commands/config_edit.go
@@ -323,7 +323,7 @@ func sendConfigChangeTelemetry(ctx context.Context, changes []ConfigChange) {
 	// Add change count as a metric
 	metrics.AddMetric(hooks.FormatMetricName("config", "edit_changes"), float64(len(changes)))
 
-	// Add section change counts as dimensions
+	// Add section change counts
 	sectionCounts := make(map[string]int)
 	for _, change := range changes {
 		section := strings.Split(change.Path, ".")[0]

--- a/pkg/commands/config_edit.go
+++ b/pkg/commands/config_edit.go
@@ -3,7 +3,6 @@ package commands
 import (
 	"context"
 	"devkit-cli/pkg/common"
-	"devkit-cli/pkg/hooks"
 	"devkit-cli/pkg/telemetry"
 	"fmt"
 	"go.uber.org/zap"
@@ -321,7 +320,7 @@ func sendConfigChangeTelemetry(ctx context.Context, changes []ConfigChange) {
 		logger.Warn("Error while getting telemetry client from context.", zap.Error(err))
 	}
 	// Add change count as a metric
-	metrics.AddMetric(hooks.FormatMetricName("config", "edit_changes"), float64(len(changes)))
+	metrics.AddMetric("ConfigChangeCount", float64(len(changes)))
 
 	// Add section change counts
 	sectionCounts := make(map[string]int)

--- a/pkg/commands/config_edit.go
+++ b/pkg/commands/config_edit.go
@@ -58,11 +58,7 @@ func editConfig(cCtx *cli.Context, configPath string) error {
 	logConfigChanges(changes)
 
 	// Send telemetry
-	err = sendConfigChangeTelemetry(cCtx.Context, changes)
-	if err != nil {
-		logger, _ := getLogger()
-		logger.Warn("Error while sending config change telemetry", zap.Error(err))
-	}
+	sendConfigChangeTelemetry(cCtx.Context, changes)
 
 	log.Printf("Config file updated successfully.")
 	return nil
@@ -313,9 +309,9 @@ func formatAndLogChange(change ConfigChange) {
 }
 
 // sendConfigChangeTelemetry sends telemetry data for config changes
-func sendConfigChangeTelemetry(ctx context.Context, changes []ConfigChange) error {
+func sendConfigChangeTelemetry(ctx context.Context, changes []ConfigChange) {
 	if len(changes) == 0 {
-		return nil
+		return
 	}
 
 	// Get metrics context
@@ -367,5 +363,4 @@ func sendConfigChangeTelemetry(ctx context.Context, changes []ConfigChange) erro
 	for section, count := range sectionCounts {
 		metrics.Properties[section+"_changes"] = fmt.Sprintf("%d", count)
 	}
-	return nil
 }

--- a/pkg/commands/config_edit.go
+++ b/pkg/commands/config_edit.go
@@ -316,7 +316,7 @@ func sendConfigChangeTelemetry(ctx context.Context, changes []ConfigChange) {
 	// Get metrics context
 	metrics, err := telemetry.MetricsFromContext(ctx)
 	if err != nil {
-		logger, _ := getLogger()
+		logger, _ := common.GetLogger()
 		logger.Warn("Error while getting telemetry client from context.", zap.Error(err))
 	}
 	// Add change count as a metric
@@ -333,7 +333,7 @@ func sendConfigChangeTelemetry(ctx context.Context, changes []ConfigChange) {
 	maxChangesToInclude := 20 // Avoid sending too much data
 	for i, change := range changes {
 		if i >= maxChangesToInclude {
-			logger, _ := getLogger()
+			logger, _ := common.GetLogger()
 			logger.Warn("Reached max change limit of ", maxChangesToInclude, " for ", change.Path)
 			break
 		}

--- a/pkg/commands/create.go
+++ b/pkg/commands/create.go
@@ -116,7 +116,7 @@ var CreateCommand = &cli.Command{
 			if cCtx.Bool("no-telemetry") {
 				log.Info("Telemetry: disabled (via flag)")
 			} else {
-				client, ok := telemetry.FromContext(cCtx.Context)
+				client, ok := telemetry.ClientFromContext(cCtx.Context)
 				if !ok || telemetry.IsNoopClient(client) {
 					log.Info("Telemetry: disabled")
 				} else {

--- a/pkg/commands/create.go
+++ b/pkg/commands/create.go
@@ -43,7 +43,7 @@ var CreateCommand = &cli.Command{
 			Usage: "Direct GitHub URL to use as template (overrides templates.yml)",
 		},
 		&cli.BoolFlag{
-			Name:  "no-telemetry",
+			Name:  "disable-telemetry",
 			Usage: "Opt out of anonymous telemetry collection",
 		},
 		&cli.StringFlag{
@@ -113,7 +113,7 @@ var CreateCommand = &cli.Command{
 			}
 
 			// Log telemetry status (accounting for client type)
-			if cCtx.Bool("no-telemetry") {
+			if cCtx.Bool("disable-telemetry") {
 				log.Info("Telemetry: disabled (via flag)")
 			} else {
 				client, ok := telemetry.ClientFromContext(cCtx.Context)
@@ -191,7 +191,7 @@ var CreateCommand = &cli.Command{
 		}
 
 		// Save project settings with telemetry preference
-		telemetryEnabled := !cCtx.Bool("no-telemetry")
+		telemetryEnabled := !cCtx.Bool("disable-telemetry")
 		if err := common.SaveProjectSettings(targetDir, telemetryEnabled); err != nil {
 			return fmt.Errorf("failed to save project settings: %w", err)
 		}

--- a/pkg/commands/create.go
+++ b/pkg/commands/create.go
@@ -174,7 +174,7 @@ var CreateCommand = &cli.Command{
 		}
 
 		// Save project settings with telemetry preference
-		if err := common.SaveProjectSettings(targetDir, true); err != nil {
+		if err := common.SaveTelemetrySetting(targetDir, true); err != nil {
 			return fmt.Errorf("failed to save project settings: %w", err)
 		}
 

--- a/pkg/commands/create.go
+++ b/pkg/commands/create.go
@@ -11,7 +11,6 @@ import (
 	"devkit-cli/pkg/commands/keystore"
 	"devkit-cli/pkg/common"
 	"devkit-cli/pkg/common/logger"
-	"devkit-cli/pkg/telemetry"
 	"devkit-cli/pkg/template"
 
 	"github.com/urfave/cli/v2"
@@ -41,10 +40,6 @@ var CreateCommand = &cli.Command{
 		&cli.StringFlag{
 			Name:  "template-path",
 			Usage: "Direct GitHub URL to use as template (overrides templates.yml)",
-		},
-		&cli.BoolFlag{
-			Name:  "disable-telemetry",
-			Usage: "Opt out of anonymous telemetry collection",
 		},
 		&cli.StringFlag{
 			Name:  "env",
@@ -110,18 +105,6 @@ var CreateCommand = &cli.Command{
 			log.Info("Environment: %s", cCtx.String("env"))
 			if cCtx.String("template-path") != "" {
 				log.Info("Template Path: %s", cCtx.String("template-path"))
-			}
-
-			// Log telemetry status (accounting for client type)
-			if cCtx.Bool("disable-telemetry") {
-				log.Info("Telemetry: disabled (via flag)")
-			} else {
-				client, ok := telemetry.ClientFromContext(cCtx.Context)
-				if !ok || telemetry.IsNoopClient(client) {
-					log.Info("Telemetry: disabled")
-				} else {
-					log.Info("Telemetry: enabled")
-				}
 			}
 		}
 
@@ -191,8 +174,7 @@ var CreateCommand = &cli.Command{
 		}
 
 		// Save project settings with telemetry preference
-		telemetryEnabled := !cCtx.Bool("disable-telemetry")
-		if err := common.SaveProjectSettings(targetDir, telemetryEnabled); err != nil {
+		if err := common.SaveProjectSettings(targetDir, true); err != nil {
 			return fmt.Errorf("failed to save project settings: %w", err)
 		}
 

--- a/pkg/common/project_config.go
+++ b/pkg/common/project_config.go
@@ -19,8 +19,8 @@ const (
 	configFileName = ".config.devkit.yml"
 )
 
-// SaveProjectSettings saves project settings to the project directory
-func SaveProjectSettings(projectDir string, telemetryEnabled bool) error {
+// SaveTelemetrySetting saves project settings to the project directory
+func SaveTelemetrySetting(projectDir string, telemetryEnabled bool) error {
 	// Try to load existing settings first to preserve UUID if it exists
 	var settings ProjectSettings
 	existingSettings, err := LoadProjectSettings()

--- a/pkg/common/project_config.go
+++ b/pkg/common/project_config.go
@@ -68,7 +68,7 @@ func LoadProjectSettings() (*ProjectSettings, error) {
 
 // IsTelemetryEnabled returns whether telemetry is enabled for the project
 // Returns false if config file doesn't exist or telemetry is explicitly disabled
-// TODO: use config flag after private preview
+// TODO: (brandon c) currently unused -- update to use after private preview
 func IsTelemetryEnabled() bool {
 	settings, err := LoadProjectSettings()
 	if err != nil {

--- a/pkg/common/project_config.go
+++ b/pkg/common/project_config.go
@@ -29,7 +29,6 @@ func SaveProjectSettings(projectDir string, telemetryEnabled bool) error {
 		settings = *existingSettings
 		// Only update telemetry setting
 		settings.TelemetryEnabled = telemetryEnabled
-		settings.PostHogAPIKey = existingSettings.PostHogAPIKey
 	} else {
 		// Create new settings with a new UUID
 		settings = ProjectSettings{

--- a/pkg/common/project_config.go
+++ b/pkg/common/project_config.go
@@ -13,7 +13,6 @@ import (
 type ProjectSettings struct {
 	ProjectUUID      string `yaml:"project_uuid"`
 	TelemetryEnabled bool   `yaml:"telemetry_enabled"`
-	PostHogAPIKey    string `yaml:"posthog_api_key,omitempty"`
 }
 
 const (

--- a/pkg/common/project_config.go
+++ b/pkg/common/project_config.go
@@ -29,6 +29,7 @@ func SaveProjectSettings(projectDir string, telemetryEnabled bool) error {
 		settings = *existingSettings
 		// Only update telemetry setting
 		settings.TelemetryEnabled = telemetryEnabled
+		settings.PostHogAPIKey = existingSettings.PostHogAPIKey
 	} else {
 		// Create new settings with a new UUID
 		settings = ProjectSettings{

--- a/pkg/common/project_config.go
+++ b/pkg/common/project_config.go
@@ -68,6 +68,7 @@ func LoadProjectSettings() (*ProjectSettings, error) {
 
 // IsTelemetryEnabled returns whether telemetry is enabled for the project
 // Returns false if config file doesn't exist or telemetry is explicitly disabled
+// TODO: use config flag after private preview
 func IsTelemetryEnabled() bool {
 	settings, err := LoadProjectSettings()
 	if err != nil {

--- a/pkg/common/project_config_test.go
+++ b/pkg/common/project_config_test.go
@@ -11,7 +11,7 @@ func TestSaveAndLoadProjectSettings(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	// Test saving project settings
-	err := SaveProjectSettings(tmpDir, true)
+	err := SaveTelemetrySetting(tmpDir, true)
 	if err != nil {
 		t.Fatalf("Failed to save project settings: %v", err)
 	}

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -23,3 +23,30 @@ func WithShutdown(ctx context.Context) context.Context {
 
 	return ctx
 }
+
+type appEnvironmentContextKey struct{}
+
+type AppEnvironment struct {
+	CLIVersion  string
+	OS          string
+	Arch        string
+	ProjectUUID string
+}
+
+func NewAppEnvironment(cliVersion string, os string, arch string, projectUuid string) *AppEnvironment {
+	return &AppEnvironment{
+		CLIVersion:  cliVersion,
+		OS:          os,
+		Arch:        arch,
+		ProjectUUID: projectUuid,
+	}
+}
+
+func WithAppEnvironment(ctx context.Context, appEnvironment *AppEnvironment) context.Context {
+	return context.WithValue(ctx, appEnvironmentContextKey{}, appEnvironment)
+}
+
+func AppEnvironmentFromContext(ctx context.Context) (*AppEnvironment, bool) {
+	env, ok := ctx.Value(appEnvironmentContextKey{}).(*AppEnvironment)
+	return env, ok
+}

--- a/pkg/hooks/hooks.go
+++ b/pkg/hooks/hooks.go
@@ -62,6 +62,7 @@ func collectFlagValues(ctx *cli.Context) map[string]interface{} {
 }
 
 func setupTelemetry(ctx *cli.Context, command string) telemetry.Client {
+	// TODO: future-proof for other "create" commands.
 	if command == "create" && ctx.Bool("disable-telemetry") {
 		return telemetry.NewNoopClient()
 	}

--- a/pkg/hooks/hooks.go
+++ b/pkg/hooks/hooks.go
@@ -132,9 +132,8 @@ func (m *CommandMiddleware) Wrap(action cli.ActionFunc) cli.ActionFunc {
 		// Run the main action
 		err := action(ctx)
 
-		// Run all post-processors in reverse order
-		for i := len(m.PostProcessors) - 1; i >= 0; i-- {
-			post := m.PostProcessors[i]
+		// Run all post-processors in order
+		for _, post := range m.PostProcessors {
 			// We don't want to stop post-processing if one fails
 			_ = post(ctx)
 		}

--- a/pkg/hooks/hooks.go
+++ b/pkg/hooks/hooks.go
@@ -76,13 +76,12 @@ func setupTelemetry(ctx *cli.Context, command string) telemetry.Client {
 	}
 
 	logger.NewLogger().Info("Creating posthog client.")
-	phClient, _ := telemetry.NewPostHogClient(appEnv)
-	if phClient != nil {
-		return phClient
+	phClient, err := telemetry.NewPostHogClient(appEnv)
+	if err != nil {
+		return telemetry.NewNoopClient()
 	}
 
-	// no client available, return noop client which means telemetry is disabled
-	return telemetry.NewNoopClient()
+	return phClient
 }
 
 func FormatMetricName(command, action string) string {
@@ -198,6 +197,7 @@ func emitTelemetryMetrics(ctx *cli.Context, command string, actionError error) {
 	if !ok {
 		return
 	}
+	defer client.Close()
 
 	for _, metric := range metrics.Metrics {
 		props := make(map[string]interface{})

--- a/pkg/hooks/hooks.go
+++ b/pkg/hooks/hooks.go
@@ -93,16 +93,8 @@ func collectFlagValues(ctx *cli.Context) map[string]interface{} {
 	return flags
 }
 
-func setupTelemetry(ctx *cli.Context, command string) telemetry.Client {
-	// TODO: future-proof for other "create" commands.
-	if command == "devkit avs create" && ctx.Bool("disable-telemetry") {
-		return telemetry.NewNoopClient()
-	}
-
-	if !common.IsTelemetryEnabled() {
-		return telemetry.NewNoopClient()
-	}
-
+func setupTelemetry(ctx *cli.Context) telemetry.Client {
+	// TODO: (brandon c) handle disabled telemetry after private preview.
 	appEnv, ok := kitcontext.AppEnvironmentFromContext(ctx.Context)
 	if !ok {
 		return telemetry.NewNoopClient()
@@ -130,7 +122,7 @@ func WithMetricEmission(action cli.ActionFunc) cli.ActionFunc {
 		// Run command action
 		err := action(ctx)
 
-		client := setupTelemetry(ctx, ctx.Command.HelpName)
+		client := setupTelemetry(ctx)
 		ctx.Context = telemetry.ContextWithClient(ctx.Context, client)
 		// emit result metrics
 		emitTelemetryMetrics(ctx, err)

--- a/pkg/hooks/hooks_test.go
+++ b/pkg/hooks/hooks_test.go
@@ -3,6 +3,8 @@ package hooks
 import (
 	"context"
 	"errors"
+	"fmt"
+	"runtime"
 	"testing"
 	"time"
 
@@ -13,19 +15,11 @@ import (
 
 // mockTelemetryClient is a test implementation of the telemetry.Client interface
 type mockTelemetryClient struct {
-	events []mockEvent
+	metrics []telemetry.Metric
 }
 
-type mockEvent struct {
-	name  string
-	props map[string]interface{}
-}
-
-func (m *mockTelemetryClient) Track(_ context.Context, event string, props map[string]interface{}) error {
-	m.events = append(m.events, mockEvent{
-		name:  event,
-		props: props,
-	})
+func (m *mockTelemetryClient) AddMetric(_ context.Context, metric telemetry.Metric) error {
+	m.metrics = append(m.metrics, metric)
 	return nil
 }
 
@@ -41,32 +35,78 @@ func MockWithTelemetry(action cli.ActionFunc, mockClient telemetry.Client) cli.A
 		// Use the mock client directly instead of setupTelemetry
 		ctx.Context = telemetry.WithContext(ctx.Context, mockClient)
 
-		// Collect flags and store metrics
-		flags := collectFlagValues(ctx)
-		startTime := time.Now()
+		// Create metrics context
+		metrics := telemetry.NewMetricsContext(ctx.App.Name, command)
+		ctx.Context = telemetry.WithMetricsContext(ctx.Context, metrics)
 
-		// Store command metrics in context
-		metrics := CommandMetrics{
-			StartTime: startTime,
-			Command:   command,
-			Flags:     flags,
+		// Add base properties
+		metrics.Properties["cli_version"] = ctx.App.Version
+		metrics.Properties["os"] = runtime.GOOS
+		metrics.Properties["arch"] = runtime.GOARCH
+		metrics.Properties["project_uuid"] = "test-uuid"
+
+		// Add command flags as properties
+		flags := collectFlagValues(ctx)
+		for k, v := range flags {
+			metrics.Properties[k] = fmt.Sprintf("%v", v)
 		}
-		ctx.Context = WithCommandMetrics(ctx.Context, metrics)
 
 		// Track command invocation
-		_ = Track(ctx.Context, FormatEventName(command, "invoked"), flags)
+		metrics.AddMetric(FormatMetricName(command, "invoked"), 1)
 
 		// Execute the wrapped action and capture result
 		err := action(ctx)
-
-		// Track result based on error
+		// Add command result as a metric
+		result := "success"
 		if err != nil {
-			trackCommandResult(ctx, "fail", err)
-		} else {
-			trackCommandResult(ctx, "success", nil)
+			result = "failure"
+			metrics.Properties["error"] = err.Error()
 		}
+		metrics.AddMetric(FormatMetricName(command, result), 1)
+
+		// Add duration metric
+		duration := time.Since(metrics.StartTime).Milliseconds()
+		metrics.AddMetric(FormatMetricName(command, "DurationMilliseconds"), float64(duration))
 
 		return err
+	}
+}
+
+func TestAddMetric(t *testing.T) {
+	// Create a mock telemetry client
+	mockClient := &mockTelemetryClient{}
+
+	// Create context with telemetry client
+	ctx := context.Background()
+	ctx = telemetry.WithContext(ctx, mockClient)
+
+	// Add a custom metric
+	props := map[string]string{
+		"direct_prop": "direct_value",
+	}
+
+	err := mockClient.AddMetric(ctx, telemetry.Metric{Name: "metricName", Value: 42, Dimensions: props})
+	if err != nil {
+		t.Fatalf("AddMetric returned error: %v", err)
+	}
+
+	// Verify metrics were tracked
+	if len(mockClient.metrics) != 1 {
+		t.Fatalf("Expected 1 metric, got %d", len(mockClient.metrics))
+	}
+
+	metric := mockClient.metrics[0]
+	if metric.Name != "metricName" {
+		t.Errorf("Expected metric 'custom.event', got '%s'", metric.Name)
+	}
+
+	if metric.Value != 42 {
+		t.Errorf("Expected value 42, got %f", metric.Value)
+	}
+
+	// Check dimensions
+	if val, ok := metric.Dimensions["direct_prop"]; !ok || val != "direct_value" {
+		t.Errorf("Direct property not correctly captured: %v", metric.Dimensions)
 	}
 }
 
@@ -101,18 +141,18 @@ func TestWithTelemetry(t *testing.T) {
 	}
 
 	// Verify events were tracked (invoked and success)
-	if len(mockClient.events) != 2 {
-		t.Fatalf("Expected 2 events, got %d", len(mockClient.events))
+	if len(mockClient.metrics) != 2 {
+		t.Fatalf("Expected 2 metrics, got %d", len(mockClient.metrics))
 	}
 
 	// Check invoked event
-	if mockClient.events[0].name != FormatEventName("test-command", "invoked") {
-		t.Errorf("Expected invoked event, got '%s'", mockClient.events[0].name)
+	if mockClient.metrics[0].Name != FormatMetricName("test-command", "invoked") {
+		t.Errorf("Expected invoked metric, got '%s'", mockClient.metrics[0].Name)
 	}
 
 	// Check success event
-	if mockClient.events[1].name != FormatEventName("test-command", "success") {
-		t.Errorf("Expected success event, got '%s'", mockClient.events[1].name)
+	if mockClient.metrics[1].Name != FormatMetricName("test-command", "success") {
+		t.Errorf("Expected success metric, got '%s'", mockClient.metrics[1].Name)
 	}
 }
 
@@ -148,61 +188,27 @@ func TestWithTelemetryError(t *testing.T) {
 	}
 
 	// Verify events were tracked (invoked and fail)
-	if len(mockClient.events) != 2 {
-		t.Fatalf("Expected 2 events, got %d", len(mockClient.events))
+	if len(mockClient.metrics) != 2 {
+		t.Fatalf("Expected 2 metrics, got %d", len(mockClient.metrics))
 	}
 
 	// Check invoked event
-	if mockClient.events[0].name != FormatEventName("test-command", "invoked") {
-		t.Errorf("Expected invoked event, got '%s'", mockClient.events[0].name)
+	if mockClient.metrics[0].Name != FormatMetricName("test-command", "invoked") {
+		t.Errorf("Expected invoked metric, got '%s'", mockClient.metrics[0].Name)
 	}
 
 	// Check fail event
-	if mockClient.events[1].name != FormatEventName("test-command", "fail") {
-		t.Errorf("Expected fail event, got '%s'", mockClient.events[1].name)
+	if mockClient.metrics[1].Name != FormatMetricName("test-command", "fail") {
+		t.Errorf("Expected fail metric, got '%s'", mockClient.metrics[1].Name)
 	}
 
 	// Check error message in event properties
-	if val, ok := mockClient.events[1].props["error"]; !ok || val != "test error message" {
-		t.Errorf("Error message not correctly captured: %v", mockClient.events[1].props)
+	if val, ok := mockClient.metrics[1].Dimensions["error"]; !ok || val != "test error message" {
+		t.Errorf("Error message not correctly captured: %v", mockClient.metrics[1].Dimensions)
 	}
 }
 
-func TestTrack(t *testing.T) {
-	// Create a mock telemetry client
-	mockClient := &mockTelemetryClient{}
-
-	// Create context with telemetry client
-	ctx := context.Background()
-	ctx = telemetry.WithContext(ctx, mockClient)
-
-	// Track a custom metric
-	props := map[string]interface{}{
-		"direct_prop": "direct_value",
-	}
-
-	err := Track(ctx, "custom.event", props)
-	if err != nil {
-		t.Fatalf("Track returned error: %v", err)
-	}
-
-	// Verify events were tracked
-	if len(mockClient.events) != 1 {
-		t.Fatalf("Expected 1 event, got %d", len(mockClient.events))
-	}
-
-	event := mockClient.events[0]
-	if event.name != "custom.event" {
-		t.Errorf("Expected event 'custom.event', got '%s'", event.name)
-	}
-
-	// Check properties
-	if val, ok := event.props["direct_prop"]; !ok || val != "direct_value" {
-		t.Errorf("Direct property not correctly captured: %v", event.props)
-	}
-}
-
-func TestFormatEventName(t *testing.T) {
+func TestFormatMetricName(t *testing.T) {
 	tests := []struct {
 		command  string
 		action   string
@@ -214,9 +220,9 @@ func TestFormatEventName(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		result := FormatEventName(test.command, test.action)
+		result := FormatMetricName(test.command, test.action)
 		if result != test.expected {
-			t.Errorf("FormatEventName(%s, %s) = %s, want %s",
+			t.Errorf("FormatMetricName(%s, %s) = %s, want %s",
 				test.command, test.action, result, test.expected)
 		}
 	}

--- a/pkg/hooks/hooks_test.go
+++ b/pkg/hooks/hooks_test.go
@@ -25,7 +25,7 @@ func (m *mockTelemetryClient) Close() error {
 	return nil
 }
 
-// MockWithTelemetry is a test version of WithTelemetry that uses a provided client
+// MockWithTelemetry is a test version of WithMetricEmission that uses a provided client
 func MockWithTelemetry(action cli.ActionFunc, mockClient telemetry.Client) cli.ActionFunc {
 	return func(ctx *cli.Context) error {
 		// Use the mock client directly instead of setupTelemetry
@@ -36,7 +36,6 @@ func MockWithTelemetry(action cli.ActionFunc, mockClient telemetry.Client) cli.A
 		ctx.Context = telemetry.WithMetricsContext(ctx.Context, metrics)
 
 		// Add base properties
-		metrics.Properties["namespace"] = "DevKit"
 		metrics.Properties["cli_version"] = ctx.App.Version
 		metrics.Properties["os"] = runtime.GOOS
 		metrics.Properties["arch"] = runtime.GOARCH
@@ -49,7 +48,7 @@ func MockWithTelemetry(action cli.ActionFunc, mockClient telemetry.Client) cli.A
 		}
 
 		// Track command invocation
-		metrics.AddMetric("Invoked", 1)
+		metrics.AddMetric("Count", 1)
 
 		// Execute the wrapped action and capture result
 		err := action(ctx)
@@ -119,7 +118,7 @@ func TestWithTelemetry(t *testing.T) {
 		return nil
 	}
 
-	// Use our mock version instead of the real WithTelemetry
+	// Use our mock version instead of the real WithMetricEmission
 	wrappedAction := MockWithTelemetry(originalAction, mockClient)
 
 	// Run the wrapped action
@@ -134,8 +133,8 @@ func TestWithTelemetry(t *testing.T) {
 	}
 
 	// Check invoked event
-	if mockClient.metrics[0].Name != "Invoked" {
-		t.Errorf("Expected invoked metric, got '%s'", mockClient.metrics[0].Name)
+	if mockClient.metrics[0].Name != "Count" {
+		t.Errorf("Expected Count metric, got '%s'", mockClient.metrics[0].Name)
 	}
 
 	// Check success event
@@ -186,8 +185,8 @@ func TestWithTelemetryError(t *testing.T) {
 	}
 
 	// Check invoked event
-	if mockClient.metrics[0].Name != "Invoked" {
-		t.Errorf("Expected invoked metric, got '%s'", mockClient.metrics[0].Name)
+	if mockClient.metrics[0].Name != "Count" {
+		t.Errorf("Expected Count metric, got '%s'", mockClient.metrics[0].Name)
 	}
 
 	// Check fail event

--- a/pkg/hooks/hooks_test.go
+++ b/pkg/hooks/hooks_test.go
@@ -28,13 +28,11 @@ func (m *mockTelemetryClient) Close() error {
 // MockWithTelemetry is a test version of WithTelemetry that uses a provided client
 func MockWithTelemetry(action cli.ActionFunc, mockClient telemetry.Client) cli.ActionFunc {
 	return func(ctx *cli.Context) error {
-		command := ctx.Command.Name
-
 		// Use the mock client directly instead of setupTelemetry
-		ctx.Context = telemetry.WithContext(ctx.Context, mockClient)
+		ctx.Context = telemetry.ContextWithClient(ctx.Context, mockClient)
 
 		// Create metrics context
-		metrics := telemetry.NewMetricsContext(ctx.App.Name, command)
+		metrics := telemetry.NewMetricsContext()
 		ctx.Context = telemetry.WithMetricsContext(ctx.Context, metrics)
 
 		// Add base properties
@@ -68,7 +66,7 @@ func TestAddMetric(t *testing.T) {
 
 	// Create context with telemetry client
 	ctx := context.Background()
-	ctx = telemetry.WithContext(ctx, mockClient)
+	ctx = telemetry.ContextWithClient(ctx, mockClient)
 
 	// Add a custom metric
 	props := map[string]string{

--- a/pkg/telemetry/metric.go
+++ b/pkg/telemetry/metric.go
@@ -1,0 +1,64 @@
+package telemetry
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// MetricsContext holds all metrics collected during command execution
+type MetricsContext struct {
+	StartTime   time.Time         `json:"start_time"`
+	RootCommand string            `json:"root_command"`
+	Subcommand  string            `json:"subcommand"`
+	Metrics     []Metric          `json:"metrics"`
+	Properties  map[string]string `json:"properties"`
+}
+
+// Metric represents a single metric with its value and dimensions
+type Metric struct {
+	Value      float64           `json:"value"`
+	Name       string            `json:"name"`
+	Dimensions map[string]string `json:"dimensions"`
+}
+
+// contextKey is used to store the metrics context
+type metricsContextKey struct{}
+
+// WithMetricsContext returns a new context with the metrics context
+func WithMetricsContext(ctx context.Context, metrics *MetricsContext) context.Context {
+	return context.WithValue(ctx, metricsContextKey{}, metrics)
+}
+
+// MetricsFromContext retrieves the metrics context
+func MetricsFromContext(ctx context.Context) (*MetricsContext, error) {
+	metrics, ok := ctx.Value(metricsContextKey{}).(*MetricsContext)
+	if !ok {
+		return &MetricsContext{}, errors.New("no metrics context")
+	}
+	return metrics, nil
+}
+
+// NewMetricsContext creates a new metrics context
+func NewMetricsContext(rootCommand, subcommand string) *MetricsContext {
+	return &MetricsContext{
+		StartTime:   time.Now(),
+		RootCommand: rootCommand,
+		Subcommand:  subcommand,
+		Metrics:     make([]Metric, 0),
+	}
+}
+
+// AddMetric adds a new metric to the context without dimensions
+func (m *MetricsContext) AddMetric(name string, value float64) {
+	m.AddMetricWithDimensions(name, value, make(map[string]string))
+}
+
+// AddMetricWithDimensions adds a new metric to the context with dimensions
+func (m *MetricsContext) AddMetricWithDimensions(name string, value float64, dimensions map[string]string) {
+	m.Metrics = append(m.Metrics, Metric{
+		Name:       name,
+		Value:      value,
+		Dimensions: dimensions,
+	})
+}

--- a/pkg/telemetry/metric.go
+++ b/pkg/telemetry/metric.go
@@ -8,11 +8,9 @@ import (
 
 // MetricsContext holds all metrics collected during command execution
 type MetricsContext struct {
-	StartTime   time.Time         `json:"start_time"`
-	RootCommand string            `json:"root_command"`
-	Subcommand  string            `json:"subcommand"`
-	Metrics     []Metric          `json:"metrics"`
-	Properties  map[string]string `json:"properties"`
+	StartTime  time.Time         `json:"start_time"`
+	Metrics    []Metric          `json:"metrics"`
+	Properties map[string]string `json:"properties"`
 }
 
 // Metric represents a single metric with its value and dimensions
@@ -40,13 +38,11 @@ func MetricsFromContext(ctx context.Context) (*MetricsContext, error) {
 }
 
 // NewMetricsContext creates a new metrics context
-func NewMetricsContext(rootCommand, subcommand string) *MetricsContext {
+func NewMetricsContext() *MetricsContext {
 	return &MetricsContext{
-		StartTime:   time.Now(),
-		RootCommand: rootCommand,
-		Subcommand:  subcommand,
-		Metrics:     make([]Metric, 0),
-		Properties:  make(map[string]string),
+		StartTime:  time.Now(),
+		Metrics:    make([]Metric, 0),
+		Properties: make(map[string]string),
 	}
 }
 

--- a/pkg/telemetry/metric.go
+++ b/pkg/telemetry/metric.go
@@ -46,6 +46,7 @@ func NewMetricsContext(rootCommand, subcommand string) *MetricsContext {
 		RootCommand: rootCommand,
 		Subcommand:  subcommand,
 		Metrics:     make([]Metric, 0),
+		Properties:  make(map[string]string),
 	}
 }
 

--- a/pkg/telemetry/noop.go
+++ b/pkg/telemetry/noop.go
@@ -10,8 +10,8 @@ func NewNoopClient() *NoopClient {
 	return &NoopClient{}
 }
 
-// Track implements the Client interface
-func (c *NoopClient) Track(_ context.Context, _ string, _ map[string]interface{}) error {
+// AddMetric implements the Client interface
+func (c *NoopClient) AddMetric(_ context.Context, _ Metric) error {
 	return nil
 }
 

--- a/pkg/telemetry/posthog.go
+++ b/pkg/telemetry/posthog.go
@@ -2,7 +2,7 @@ package telemetry
 
 import (
 	"context"
-	devcontext "devkit-cli/pkg/context"
+	kitcontext "devkit-cli/pkg/context"
 	"github.com/posthog/posthog-go"
 	"gopkg.in/yaml.v3"
 	"os"
@@ -11,11 +11,11 @@ import (
 // PostHogClient implements the Client interface using PostHog
 type PostHogClient struct {
 	client         posthog.Client
-	appEnvironment *devcontext.AppEnvironment
+	appEnvironment *kitcontext.AppEnvironment
 }
 
 // NewPostHogClient creates a new PostHog client
-func NewPostHogClient(environment *devcontext.AppEnvironment) (*PostHogClient, error) {
+func NewPostHogClient(environment *kitcontext.AppEnvironment) (*PostHogClient, error) {
 	apiKey := getPostHogAPIKey()
 	if apiKey == "" {
 		// No API key available, return noop client without error

--- a/pkg/telemetry/posthog.go
+++ b/pkg/telemetry/posthog.go
@@ -40,13 +40,8 @@ func (c *PostHogClient) AddMetric(ctx context.Context, metric Metric) error {
 
 	// Create properties map starting with base properties
 	props := make(map[string]interface{})
-	props["cli_version"] = c.appEnvironment.CLIVersion
-	props["os"] = c.appEnvironment.OS
-	props["arch"] = c.appEnvironment.Arch
-	props["project_uuid"] = c.appEnvironment.ProjectUUID
-
 	// Add metric value
-	props["metric_value"] = metric.Value
+	props["value"] = metric.Value
 
 	// Add metric dimensions
 	for k, v := range metric.Dimensions {

--- a/pkg/telemetry/posthog.go
+++ b/pkg/telemetry/posthog.go
@@ -21,7 +21,10 @@ func NewPostHogClient(environment *devcontext.AppEnvironment) (*PostHogClient, e
 		// No API key available, return noop client without error
 		return nil, nil
 	}
-	client := posthog.New(apiKey)
+	client, err := posthog.NewWithConfig(apiKey, posthog.Config{Endpoint: getPostHogEndpoint()})
+	if err != nil {
+		return nil, err
+	}
 
 	return &PostHogClient{
 		client:         client,
@@ -105,5 +108,5 @@ func getPostHogEndpoint() string {
 	if endpoint := os.Getenv("DEVKIT_POSTHOG_ENDPOINT"); endpoint != "" {
 		return endpoint
 	}
-	return "https://app.posthog.com"
+	return "https://us.i.posthog.com"
 }

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -12,24 +12,6 @@ type Client interface {
 	Close() error
 }
 
-// Properties represents the base properties for all events
-type Properties struct {
-	CLIVersion  string
-	OS          string
-	Arch        string
-	ProjectUUID string
-}
-
-// NewProperties creates a new Properties instance
-func NewProperties(cliVersion, os, arch, projectUUID string) Properties {
-	return Properties{
-		CLIVersion:  cliVersion,
-		OS:          os,
-		Arch:        arch,
-		ProjectUUID: projectUUID,
-	}
-}
-
 // WithContext returns a new context with the telemetry client
 func WithContext(ctx context.Context, client Client) context.Context {
 	return context.WithValue(ctx, contextKey{}, client)

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -6,8 +6,8 @@ import (
 
 // Client defines the interface for telemetry operations
 type Client interface {
-	// Track sends a single event with properties
-	Track(ctx context.Context, event string, props map[string]interface{}) error
+	// AddMetric emits a single metric
+	AddMetric(ctx context.Context, metric Metric) error
 	// Close cleans up any resources
 	Close() error
 }
@@ -35,8 +35,8 @@ func WithContext(ctx context.Context, client Client) context.Context {
 	return context.WithValue(ctx, contextKey{}, client)
 }
 
-// FromContext retrieves the telemetry client from context
-func FromContext(ctx context.Context) (Client, bool) {
+// ClientFromContext retrieves the telemetry client from context
+func ClientFromContext(ctx context.Context) (Client, bool) {
 	client, ok := ctx.Value(contextKey{}).(Client)
 	return client, ok
 }

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -12,8 +12,8 @@ type Client interface {
 	Close() error
 }
 
-// WithContext returns a new context with the telemetry client
-func WithContext(ctx context.Context, client Client) context.Context {
+// ContextWithClient returns a new context with the telemetry client
+func ContextWithClient(ctx context.Context, client Client) context.Context {
 	return context.WithValue(ctx, contextKey{}, client)
 }
 

--- a/pkg/telemetry/telemetry_test.go
+++ b/pkg/telemetry/telemetry_test.go
@@ -2,6 +2,8 @@ package telemetry
 
 import (
 	"context"
+	devcontext "devkit-cli/pkg/context"
+	"github.com/google/uuid"
 	"testing"
 )
 
@@ -34,13 +36,21 @@ func TestPostHogClient(t *testing.T) {
 		t.Skip("Skipping PostHog test in short mode")
 	}
 
-	client := NewPostHogClient("test-key", "test-host")
+	client, err := NewPostHogClient(devcontext.NewAppEnvironment(
+		"version",
+		"linux",
+		"Testx86",
+		uuid.New().String(),
+	))
+	if err != nil {
+		t.Errorf("NewPostHogClient returned error: %v", err)
+	}
 	if client == nil {
 		t.Fatal("Expected non-nil client")
 	}
 
 	// Test AddMetric
-	err := client.AddMetric(context.Background(), Metric{
+	err = client.AddMetric(context.Background(), Metric{
 		Name:       "test.metric",
 		Value:      42,
 		Dimensions: map[string]string{"test": "value"},
@@ -75,7 +85,7 @@ func TestContext(t *testing.T) {
 }
 
 func TestProperties(t *testing.T) {
-	props := NewProperties("1.0.0", "darwin", "amd64", "test-uuid")
+	props := devcontext.NewAppEnvironment("1.0.0", "darwin", "amd64", "test-uuid")
 	if props.CLIVersion != "1.0.0" {
 		t.Error("CLIVersion mismatch")
 	}

--- a/pkg/telemetry/telemetry_test.go
+++ b/pkg/telemetry/telemetry_test.go
@@ -31,7 +31,7 @@ func TestNoopClient(t *testing.T) {
 
 func TestContext(t *testing.T) {
 	client := NewNoopClient()
-	ctx := WithContext(context.Background(), client)
+	ctx := ContextWithClient(context.Background(), client)
 
 	retrieved, ok := ClientFromContext(ctx)
 	if !ok {

--- a/pkg/telemetry/telemetry_test.go
+++ b/pkg/telemetry/telemetry_test.go
@@ -3,7 +3,6 @@ package telemetry
 import (
 	"context"
 	devcontext "devkit-cli/pkg/context"
-	"github.com/google/uuid"
 	"testing"
 )
 
@@ -24,42 +23,6 @@ func TestNoopClient(t *testing.T) {
 	}
 
 	// Test Close doesn't panic
-	err = client.Close()
-	if err != nil {
-		t.Errorf("Close returned error: %v", err)
-	}
-}
-
-func TestPostHogClient(t *testing.T) {
-	// Skip if no API key
-	if testing.Short() {
-		t.Skip("Skipping PostHog test in short mode")
-	}
-
-	client, err := NewPostHogClient(devcontext.NewAppEnvironment(
-		"version",
-		"linux",
-		"Testx86",
-		uuid.New().String(),
-	))
-	if err != nil {
-		t.Errorf("NewPostHogClient returned error: %v", err)
-	}
-	if client == nil {
-		t.Fatal("Expected non-nil client")
-	}
-
-	// Test AddMetric
-	err = client.AddMetric(context.Background(), Metric{
-		Name:       "test.metric",
-		Value:      42,
-		Dimensions: map[string]string{"test": "value"},
-	})
-	if err != nil {
-		t.Errorf("AddMetric returned error: %v", err)
-	}
-
-	// Test Close
 	err = client.Close()
 	if err != nil {
 		t.Errorf("Close returned error: %v", err)

--- a/pkg/telemetry/telemetry_test.go
+++ b/pkg/telemetry/telemetry_test.go
@@ -2,7 +2,7 @@ package telemetry
 
 import (
 	"context"
-	devcontext "devkit-cli/pkg/context"
+	kitcontext "devkit-cli/pkg/context"
 	"testing"
 )
 
@@ -48,7 +48,7 @@ func TestContext(t *testing.T) {
 }
 
 func TestProperties(t *testing.T) {
-	props := devcontext.NewAppEnvironment("1.0.0", "darwin", "amd64", "test-uuid")
+	props := kitcontext.NewAppEnvironment("1.0.0", "darwin", "amd64", "test-uuid")
 	if props.CLIVersion != "1.0.0" {
 		t.Error("CLIVersion mismatch")
 	}


### PR DESCRIPTION
<!-- 
    🚨 ATTENTION! 🚨 
    
    This PR template is REQUIRED. PRs not following this format will be closed without review.
    
    Requirements:
    - PR title must follow commit conventions: https://www.conventionalcommits.org/en/v1.0.0/
    - Label your PR with the correct type (e.g., 🐛 Bug, ✨ Enhancement, 🧪 Test, etc.)
    - Provide clear and specific details in each section
-->

**Motivation:**
CLI telemetry is needed for product insights as early as next week, when private preview begins. All users of the private preview must report telemetry, so disabling the toggle is needed.

**Modifications:**
- Simplified telemetry middleware
- Added a standard metrics context
- Removed telemetry toggle from config file & flags

**Result:**
- Telemetry is emitted to [PostHog](https://us.posthog.com/project/150668/sql).

**Testing:**
- Manually tested (see PostHog link).
- Unit test updates

#### Metric Payload Example
Event: DevKit
> {
  "value":15405
  "cli_version":""
  "project_uuid":"ba78a165-25aa-43bf-9971-ba9bd6e11cf9"
  "os":"darwin"
  "arch":"arm64"
  "$lib":"posthog-go"
  "name":"DurationMilliseconds"
  "$lib_version":"1.4.10"
  "command":"devkit avs build" ...
}
