### PR TITLE
chore: rename avs run to test

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ EigenLayer DevKit streamlines AVS development, enabling you to quickly scaffold 
 | `avs config` | Configure your AVS (`config/config.yaml`,`config/devnet.yaml`...)        |
 | `avs build`  | Compile AVS smart contracts and binaries |
 | `avs devnet` | Manage local development network         |
-| `avs run`    | Simulate AVS task execution locally      |
+| `avs test`    | Simulate AVS task execution locally      |
 
 ---
 
@@ -140,7 +140,7 @@ DevNet management commands:
 | `stop --port`  | Stops the specific port .ex: `stop --port 8545`                                  |
 
 
-### 5️⃣ Simulate Task Execution (`avs run`)
+### 5️⃣ Simulate Task Execution (`avs test`)
 
 Test your AVS logic locally by simulating task execution:
 
@@ -151,7 +151,7 @@ Test your AVS logic locally by simulating task execution:
 Run this from your project directory:
 
 ```bash
-devkit avs run
+devkit avs test
 ```
 
 Optionally, submit tasks directly to the on-chain TaskMailBox contract via a frontend or another method for more realistic testing scenarios.
@@ -198,7 +198,7 @@ nano .env
 
 # Run commands - the .env file will be automatically loaded
 devkit avs build
-devkit avs run
+devkit avs test
 ```
 
 ---

--- a/pkg/commands/avs.go
+++ b/pkg/commands/avs.go
@@ -12,7 +12,7 @@ var AVSCommand = &cli.Command{
 		ConfigCommand,
 		BuildCommand,
 		DevnetCommand,
-		RunCommand,
+		TestCommand,
 		ReleaseCommand,
 	},
 }

--- a/pkg/commands/avs_test_command.go
+++ b/pkg/commands/avs_test_command.go
@@ -8,17 +8,17 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-// RunCommand defines the "run" command
-var RunCommand = &cli.Command{
-	Name:  "run",
+// TestCommand defines the "test" command
+var TestCommand = &cli.Command{
+	Name:  "test",
 	Usage: "Submits tasks to the local devnet, triggers off-chain execution, and aggregates results",
 	Flags: append([]cli.Flag{}, common.GlobalFlags...),
 	Action: func(cCtx *cli.Context) error {
 		if cCtx.Bool("verbose") {
-			log.Printf("Running AVS tasks...")
+			log.Printf("Testing AVS tasks...")
 		}
 
-		err := common.CallDevkitMakeTarget(cCtx.Context, "run")
+		err := common.CallDevkitMakeTarget(cCtx.Context, "test")
 		if err != nil {
 			return fmt.Errorf("failed to call make run in Makefile.Devkit %w", err)
 		}

--- a/pkg/commands/avs_test_test.go
+++ b/pkg/commands/avs_test_test.go
@@ -17,9 +17,9 @@ func TestTestCommand(t *testing.T) {
 
 	// Create a mock Makefile.Devkit
 	mockMakefile := `
-.PHONY: run
-run:
-	@echo "Mock run executed"
+.PHONY: test
+test:
+	@echo "Mock test executed"
 	`
 	if err := os.WriteFile(filepath.Join(tmpDir, common.DevkitMakefile), []byte(mockMakefile), 0644); err != nil {
 		t.Fatal(err)
@@ -54,9 +54,9 @@ func TestCancelledTestCommand(t *testing.T) {
 
 	// Create a mock Makefile.Devkit
 	mockMakefile := `
-.PHONY: run
+.PHONY: test
 run:
-	@echo "Mock run executed"
+	@echo "Mock test executed"
 	`
 	if err := os.WriteFile(filepath.Join(tmpDir, common.DevkitMakefile), []byte(mockMakefile), 0644); err != nil {
 		t.Fatal(err)

--- a/pkg/commands/avs_test_test.go
+++ b/pkg/commands/avs_test_test.go
@@ -4,14 +4,15 @@ import (
 	"context"
 	"devkit-cli/pkg/common"
 	"errors"
-	"github.com/urfave/cli/v2"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/urfave/cli/v2"
 )
 
-func TestRunCommand(t *testing.T) {
+func TestTestCommand(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	// Create a mock Makefile.Devkit
@@ -40,15 +41,15 @@ run:
 
 	app := &cli.App{
 		Name:     "test",
-		Commands: []*cli.Command{RunCommand},
+		Commands: []*cli.Command{TestCommand},
 	}
 
-	if err := app.Run([]string{"app", "run"}); err != nil {
+	if err := app.Run([]string{"app", "test"}); err != nil {
 		t.Errorf("Failed to execute run command: %v", err)
 	}
 }
 
-func TestCancelledRunCommand(t *testing.T) {
+func TestCancelledTestCommand(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	// Create a mock Makefile.Devkit
@@ -78,23 +79,23 @@ run:
 	ctx, cancel := context.WithCancel(context.Background())
 	app := &cli.App{
 		Name:     "test",
-		Commands: []*cli.Command{RunCommand},
+		Commands: []*cli.Command{TestCommand},
 	}
 
 	result := make(chan error)
 	go func() {
-		result <- app.RunContext(ctx, []string{"app", "run"})
+		result <- app.RunContext(ctx, []string{"app", "test"})
 	}()
 	cancel()
 
 	select {
 	case err = <-result:
 		if err != nil && errors.Is(err, context.Canceled) {
-			t.Log("Run exited cleanly after context cancellation")
+			t.Log("Test exited cleanly after context cancellation")
 		} else {
-			t.Errorf("Run returned with error after context cancellation: %v", err)
+			t.Errorf("Test returned with error after context cancellation: %v", err)
 		}
 	case <-time.After(1 * time.Second):
-		t.Error("Run did not exit after context cancellation")
+		t.Error("Test did not exit after context cancellation")
 	}
 }


### PR DESCRIPTION

**Motivation:**

Rename `avs run` to `avs test` as per discussion .

**Modifications:**

Change commands to test from run

**Result:**

- New command 
`devkit avs test`

**Testing:**
<!--
*List testing procedures taken and useful artifacts.
-->
**Open questions:**
<!--
(optional) Any open questions or feedback on design desired?
-->