### PR TITLE
feat: pin hourglass-avs-template to before scripts upgrade

### DIFF
--- a/config/templates.yaml
+++ b/config/templates.yaml
@@ -2,7 +2,7 @@ architectures:
   task:
     languages:
       go:
-        template: "https://github.com/Layr-Labs/hourglass-avs-template"
+        template: "https://github.com/Layr-Labs/hourglass-avs-template/tree/pinned-may-13"
       ts:
         template: ""
       rust:

--- a/pkg/template/config_test.go
+++ b/pkg/template/config_test.go
@@ -15,7 +15,7 @@ func TestLoadConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to get template URL: %v", err)
 	}
-	expected := "https://github.com/Layr-Labs/hourglass-avs-template"
+	expected := "https://github.com/Layr-Labs/hourglass-avs-template/tree/pinned-may-13"
 	if url != expected {
 		t.Errorf("Unexpected template URL: got %s, want %s", url, expected)
 	}


### PR DESCRIPTION
<!-- 
    🚨 ATTENTION! 🚨 
    
    This PR template is REQUIRED. PRs not following this format will be closed without review.
    
    Requirements:
    - PR title must follow commit conventions: https://www.conventionalcommits.org/en/v1.0.0/
    - Label your PR with the correct type (e.g., 🐛 Bug, ✨ Enhancement, 🧪 Test, etc.)
    - Provide clear and specific details in each section
-->

**Motivation:**
<!--
Explain here the context, and why you're making that change. What is the problem you're trying to solve.
-->

This PR pins `hourglass-avs-template` to a branch before the `Makefile` approach was moved to a `scripts` approach.

**Modifications:**
<!--
Describe the modifications you've done from a high level. What are the key technical decisions and why were they made?
-->
- Sets default `template-path` to clone from known good branch

**Result:**
<!--
*After your change, what will change.
-->
- Unblocks ci 