### PR TITLE
fix: use stable foundry for GHA tests and pin template repo

### DIFF
--- a/.github/workflows/create.yml
+++ b/.github/workflows/create.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly-1ae64e38a1c69bda45343947875f7c86bad00038
+          version: stable
       
       - name: Authenticate Go to GitHub private repos
         run: |

--- a/.github/workflows/devnet.yml
+++ b/.github/workflows/devnet.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly-1ae64e38a1c69bda45343947875f7c86bad00038
+          version: stable
       
       - name: Authenticate Go to GitHub private repos
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,6 +9,8 @@ on:
 env:
   FOUNDRY_PROFILE: ci
   GOPRIVATE: github.com/Layr-Labs/*
+  L1_FORK_URL: ${{ vars.L1_FORK_URL }}
+  L2_FORK_URL: ${{ vars.L2_FORK_URL }}
 
 jobs:
   e2e:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly-1ae64e38a1c69bda45343947875f7c86bad00038
+          version: stable
 
       - name: Install devkit CLI
         run: make install

--- a/config/templates.yaml
+++ b/config/templates.yaml
@@ -2,7 +2,7 @@ architectures:
   task:
     languages:
       go:
-        template: "https://github.com/Layr-Labs/hourglass-avs-template"
+        template: "https://github.com/Layr-Labs/hourglass-avs-template/tree/pinned-may-16"
       ts:
         template: ""
       rust:

--- a/pkg/commands/build.go
+++ b/pkg/commands/build.go
@@ -3,7 +3,6 @@ package commands
 import (
 	"devkit-cli/pkg/common"
 	"devkit-cli/pkg/testutils"
-	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -63,38 +62,7 @@ var BuildCommand = &cli.Command{
 			return err
 		}
 
-		// Build contracts if available
-		if err := buildContractsIfAvailable(cCtx); err != nil {
-			return err
-		}
-
 		log.Info("Build completed successfully")
 		return nil
 	},
-}
-
-// buildContractsIfAvailable builds the contracts if the contracts directory exists
-func buildContractsIfAvailable(cCtx *cli.Context) error {
-	log, _ := common.GetLogger()
-	contractsDir := common.ContractsDir
-	if _, err := os.Stat(contractsDir); os.IsNotExist(err) {
-		return nil
-	}
-
-	configPath := filepath.Join(contractsDir, common.ContractsMakefile)
-	log.Info(configPath)
-	if _, err := os.Stat(configPath); os.IsNotExist(err) {
-		return fmt.Errorf("contracts directory exists but no %s found", common.ContractsMakefile)
-	}
-
-	cmd := exec.CommandContext(cCtx.Context, "make", "-f", common.ContractsMakefile, "build")
-	cmd.Dir = contractsDir
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-
-	if cmdErr := cmd.Run(); cmdErr != nil {
-		return fmt.Errorf("build failed %w", cmdErr)
-	}
-
-	return nil
 }

--- a/pkg/commands/build_test.go
+++ b/pkg/commands/build_test.go
@@ -104,51 +104,6 @@ echo "Mock build executed"`
 	}
 }
 
-// Test the case where contracts directory exists but has no Makefile
-func TestBuildCommand_ContractsNoMakefile(t *testing.T) {
-	tmpDir := t.TempDir()
-
-	// Create build script
-	scriptsDir := filepath.Join(tmpDir, ".devkit", "scripts")
-	if err := os.MkdirAll(scriptsDir, 0755); err != nil {
-		t.Fatal(err)
-	}
-	buildScript := `#!/bin/bash
-echo "Mock build executed"`
-	if err := os.WriteFile(filepath.Join(scriptsDir, "build"), []byte(buildScript), 0755); err != nil {
-		t.Fatal(err)
-	}
-
-	// Create contracts directory but no Makefile
-	contractsDir := filepath.Join(tmpDir, common.ContractsDir)
-	if err := os.MkdirAll(contractsDir, 0755); err != nil {
-		t.Fatal(err)
-	}
-
-	oldWd, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := os.Chdir(tmpDir); err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		if err := os.Chdir(oldWd); err != nil {
-			t.Logf("Failed to restore original directory: %v", err)
-		}
-	}()
-
-	app := &cli.App{
-		Name:     "test",
-		Commands: []*cli.Command{testutils.WithTestConfig(BuildCommand)},
-	}
-
-	// This should fail because contracts dir exists but has no Makefile
-	if err := app.Run([]string{"app", "build"}); err == nil {
-		t.Errorf("Expected build to fail due to missing contracts Makefile, but it succeeded")
-	}
-}
-
 func TestBuildCommand_ContextCancellation(t *testing.T) {
 	tmpDir := t.TempDir()
 

--- a/pkg/common/devnet/constants.go
+++ b/pkg/common/devnet/constants.go
@@ -2,7 +2,7 @@ package devnet
 
 // Foundry Image Date : 21 April 2025
 const FOUNDRY_IMAGE = "ghcr.io/foundry-rs/foundry:stable"
-const CHAIN_ARGS = "--block-time 12 --base-fee 0 --gas-price 0"
+const CHAIN_ARGS = "--block-time 12 --chain-id 31337"
 const FUND_VALUE = "10000000000000000000"
 const RPC_URL = "http://localhost:8545"
 const CONTEXT = "devnet"

--- a/pkg/common/devnet/getters.go
+++ b/pkg/common/devnet/getters.go
@@ -35,6 +35,19 @@ func FileExistsInRoot(filename string) bool {
 }
 
 func GetDevnetForkUrlDefault(cfg *common.ConfigWithContextConfig, chainName string) (string, error) {
+	// Check in env first for L1 fork url
+	l1ForkUrl := os.Getenv("L1_FORK_URL")
+	if chainName == "l1" && l1ForkUrl != "" {
+		return l1ForkUrl, nil
+	}
+
+	// Check in env first for l2 fork url
+	l2ForkUrl := os.Getenv("L2_FORK_URL")
+	if chainName == "l2" && l2ForkUrl != "" {
+		return l2ForkUrl, nil
+	}
+
+	// Fallback to context defined value
 	chainConfig, found := cfg.Context[CONTEXT].Chains[chainName]
 	if !found {
 		return "", fmt.Errorf("failed to get chainConfig for chainName : %s", chainName)
@@ -43,5 +56,4 @@ func GetDevnetForkUrlDefault(cfg *common.ConfigWithContextConfig, chainName stri
 		return "", fmt.Errorf("no fork URL configured for chain: %s", chainName)
 	}
 	return chainConfig.Fork.Url, nil
-
 }

--- a/pkg/template/config_test.go
+++ b/pkg/template/config_test.go
@@ -15,7 +15,7 @@ func TestLoadConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to get template URL: %v", err)
 	}
-	expected := "https://github.com/Layr-Labs/hourglass-avs-template"
+	expected := "https://github.com/Layr-Labs/hourglass-avs-template/tree/pinned-may-16"
 	if url != expected {
 		t.Errorf("Unexpected template URL: got %s, want %s", url, expected)
 	}


### PR DESCRIPTION
<!-- 
    🚨 ATTENTION! 🚨 
    
    This PR template is REQUIRED. PRs not following this format will be closed without review.
    
    Requirements:
    - PR title must follow commit conventions: https://www.conventionalcommits.org/en/v1.0.0/
    - Label your PR with the correct type (e.g., 🐛 Bug, ✨ Enhancement, 🧪 Test, etc.)
    - Provide clear and specific details in each section
-->

**Motivation:**
<!--
Explain here the context, and why you're making that change. What is the problem you're trying to solve.
-->

Our GHAs are currently using a `nightly` build of `foundry` and this is causing flaky tests, we also need to pin the `hourglass-avs-template` to before the contracts were upgraded.

**Modifications:**
<!--
Describe the modifications you've done from a high level. What are the key technical decisions and why were they made?
-->

- Pins foundry to `stable` version
- Pins `hourglass-avs-template`

**Result:**
<!--
*After your change, what will change.
-->
- reliable CI runs
