### PR TITLE
feat: inject version and telemetry api key during release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.24.2'
 
       - name: Clone hourglass-monorepo privately
         env:
@@ -42,7 +42,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.24.2'
 
       - name: Clone hourglass-monorepo privately
         env:
@@ -83,6 +83,5 @@ jobs:
           version: latest
           args: release --clean
         env:
-          #https://docs.github.com/en/actions/security-guides/automatic-token-authentication#about-the-github_token-secret
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TELEMETRY_TOKEN: ${{ secrets.TELEMETRY_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.24.2'
 
       - name: Clone hourglass-monorepo privately
         env:
@@ -83,5 +83,6 @@ jobs:
           version: latest
           args: release --clean
         env:
+          #https://docs.github.com/en/actions/security-guides/automatic-token-authentication#about-the-github_token-secret
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TELEMETRY_TOKEN: ${{ secrets.TELEMETRY_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,6 @@ jobs:
           distribution: goreleaser
           version: latest
           args: release --clean
-          workdir: ./devkit-cli/
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TELEMETRY_TOKEN: ${{ secrets.TELEMETRY_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,22 +55,19 @@ jobs:
 
       - name: Run Tests
         run: make tests
-  release:
+  Release:
     needs: [Lint, Test]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
-      - name: Git checkout
+      - name: Checkout repo
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          path: devkit-cli
 
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.23.6"
+          go-version: '1.23'
 
-      - name: Configure Git for private repos
+      - name: Clone hourglass-monorepo privately
         env:
           HOURGLASS_TOKEN: ${{ secrets.HOURGLASS_TOKEN }}
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,36 +6,57 @@ on:
       - "*"
 
 jobs:
-  lint:
+  Lint:
     name: Lint
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v5
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
-      - uses: actions/checkout@v4
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+          go-version: '1.23'
+
+      - name: Clone hourglass-monorepo privately
+        env:
+          HOURGLASS_TOKEN: ${{ secrets.HOURGLASS_TOKEN }}
+        run: |
+          git config --global url."https://${HOURGLASS_TOKEN}@github.com/".insteadOf "https://github.com/"
+          git clone --depth=1 https://github.com/Layr-Labs/hourglass-monorepo.git temp_external/hourglass-monorepo
+          go mod edit -replace=github.com/Layr-Labs/hourglass-monorepo=./temp_external/hourglass-monorepo
+          go mod tidy
+
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v6
         with:
-          working-directory: .
+          version: latest
           args: --timeout 3m
-  test:
-    name: Golang Unit Tests v${{ matrix.go }} (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        go: ["1.21"]
-        os: [ubuntu-22.04]
+  Test:
+    name: Unit Test
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
         with:
-          go-version: ${{ matrix.go }}
-      - run: go mod download
-      - run: make build
-      - run: make tests
+          go-version: '1.23'
+
+      - name: Clone hourglass-monorepo privately
+        env:
+          HOURGLASS_TOKEN: ${{ secrets.HOURGLASS_TOKEN }}
+        run: |
+          git config --global url."https://${HOURGLASS_TOKEN}@github.com/".insteadOf "https://github.com/"
+          git clone --depth=1 https://github.com/Layr-Labs/hourglass-monorepo.git temp_external/hourglass-monorepo
+          go mod edit -replace=github.com/Layr-Labs/hourglass-monorepo=./temp_external/hourglass-monorepo
+          go mod tidy
+
+      - name: Run Tests
+        run: make tests
   release:
-    needs: [lint, test]
+    needs: [Lint, Test]
     runs-on: ubuntu-22.04
     steps:
       - name: Git checkout
@@ -43,10 +64,21 @@ jobs:
         with:
           fetch-depth: 0
           path: devkit-cli
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version: "1.23.6"
+
+      - name: Configure Git for private repos
+        env:
+          HOURGLASS_TOKEN: ${{ secrets.HOURGLASS_TOKEN }}
+        run: |
+          git config --global url."https://${HOURGLASS_TOKEN}@github.com/".insteadOf "https://github.com/"
+          git clone --depth=1 https://github.com/Layr-Labs/hourglass-monorepo.git temp_external/hourglass-monorepo
+          go mod edit -replace=github.com/Layr-Labs/hourglass-monorepo=./temp_external/hourglass-monorepo
+          go mod tidy
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
@@ -55,6 +87,5 @@ jobs:
           args: release --clean
           workdir: ./devkit-cli/
         env:
-          #https://docs.github.com/en/actions/security-guides/automatic-token-authentication#about-the-github_token-secret
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TELEMETRY_TOKEN: ${{ secrets.TELEMETRY_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,60 @@
+name: Release (with lint and test)
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.21"
+      - uses: actions/checkout@v4
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          working-directory: .
+          args: --timeout 3m
+  test:
+    name: Golang Unit Tests v${{ matrix.go }} (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        go: ["1.21"]
+        os: [ubuntu-22.04]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go }}
+      - run: go mod download
+      - run: make build
+      - run: make tests
+  release:
+    needs: [lint, test]
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          path: devkit-cli
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.23.6"
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+          workdir: ./devkit-cli/
+        env:
+          #https://docs.github.com/en/actions/security-guides/automatic-token-authentication#about-the-github_token-secret
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TELEMETRY_TOKEN: ${{ secrets.TELEMETRY_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ Thumbs.db
 
 .git-submodule-cache
 .git-template-cache
+
+# Release outputs
+temp_external

--- a/.gitignore
+++ b/.gitignore
@@ -30,4 +30,4 @@ Thumbs.db
 .git-template-cache
 
 # Release outputs
-temp_external
+temp_external/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,7 +8,6 @@ builds:
     flags:
       - -v
     ldflags:
-      - -X 'main.version={{.Version}}'
       - -X 'github.com/Layr-Labs/devkit-cli/pkg/telemetry.embeddedTelemetryApiKey={{ .Env.TELEMETRY_TOKEN }}'
       - -X 'github.com/Layr-Labs/devkit-cli/pkg/context.embeddedDevkitReleaseVersion={{.Version}}'
     # windows is ignored by default, as the `goos` field by default only

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,7 +16,6 @@ builds:
     env:
       - CGO_ENABLED=0
     goos:
-      - linux
       - darwin
     goarch:
       - amd64

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,32 @@
+# ref. https://goreleaser.com/customization/build/
+version: 2
+
+builds:
+  - id: devkit-cli
+    main: ./cmd/devkit/main.go
+    binary: devkit
+    flags:
+      - -v
+    ldflags:
+      - -X 'main.version={{.Version}}'
+      - -X 'github.com/Layr-Labs/devkit-cli/pkg/telemetry.embeddedTelemetryApiKey={{ .Env.TELEMETRY_TOKEN }}'
+      - -X 'github.com/Layr-Labs/devkit-cli/pkg/context.embeddedDevkitReleaseVersion={{.Version}}'
+    # windows is ignored by default, as the `goos` field by default only
+    # contains linux and darwin
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+
+release:
+  # Repo in which the release will be created.
+  # Default is extracted from the origin remote URL or empty if its private hosted.
+  github:
+    owner: layr-labs
+    name: devkit-cli
+
+  draft: true

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,8 +8,8 @@ builds:
     flags:
       - -v
     ldflags:
-      - -X 'github.com/Layr-Labs/devkit-cli/pkg/telemetry.embeddedTelemetryApiKey={{ .Env.TELEMETRY_TOKEN }}'
-      - -X 'github.com/Layr-Labs/devkit-cli/pkg/context.embeddedDevkitReleaseVersion={{.Version}}'
+      - -X 'devkit-cli/pkg/telemetry.embeddedTelemetryApiKey={{ .Env.TELEMETRY_TOKEN }}'
+      - -X 'devkit-cli/pkg/context.embeddedDevkitReleaseVersion={{.Version}}'
     # windows is ignored by default, as the `goos` field by default only
     # contains linux and darwin
     env:

--- a/README.md
+++ b/README.md
@@ -206,3 +206,24 @@ devkit avs call
 ## 🤝 Contributing
 
 Contributions are welcome! Please open an issue to discuss significant changes before submitting a pull request.
+
+## Release Process
+To release a new version of the CLI, follow the steps below:
+> Note: You need to have write permission to this repo to release new version
+
+1. Checkout the master branch and pull the latest changes:
+    ```bash
+    git checkout master
+    git pull origin master
+    ```
+2. In your local clone, create a new release tag using the following command:
+    ```bash
+     git tag v<version> -m "Release v<version>"
+    ```
+3. Push the tag to the repository using the following command:
+    ```bash
+    git push origin v<version>
+    ```
+
+4. This will automatically start the release process in the [GitHub Actions](https://github.com/Layr-Labs/eigenlayer-cli/actions/workflows/release.yml) and will create a draft release to the [GitHub Releases](https://github.com/Layr-Labs/eigenlayer-cli/releases) with all the required binaries and assets
+5. Check the release notes and add any notable changes and publish the release

--- a/go.mod
+++ b/go.mod
@@ -37,8 +37,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/shirou/gopsutil v3.21.4-0.20210419000835-c7a38de76ee5+incompatible // indirect
 	github.com/supranational/blst v0.3.14 // indirect
-	github.com/tidwall/match v1.1.1 // indirect
-	github.com/tidwall/pretty v1.2.0 // indirect
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	go.uber.org/multierr v1.10.0 // indirect
@@ -53,7 +51,6 @@ require (
 	github.com/ethereum/go-ethereum v1.15.9
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/stretchr/testify v1.10.0
-	github.com/tidwall/gjson v1.18.0
 	github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 // indirect
 	go.uber.org/zap v1.27.0
 	golang.org/x/term v0.32.0

--- a/go.sum
+++ b/go.sum
@@ -157,12 +157,6 @@ github.com/supranational/blst v0.3.14 h1:xNMoHRJOTwMn63ip6qoWJ2Ymgvj7E2b9jY2FAwY
 github.com/supranational/blst v0.3.14/go.mod h1:jZJtfjgudtNl4en1tzwPIV3KjUnQUvG3/j+w+fVonLw=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 h1:epCh84lMvA70Z7CTTCmYQn2CKbY8j86K7/FAIr141uY=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7/go.mod h1:q4W45IWZaF22tdD+VEXcAWRA037jwmWEB5VWYORlTpc=
-github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=
-github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
-github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
-github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
-github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
-github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/tklauser/go-sysconf v0.3.12 h1:0QaGUFOdQaIVdPgfITYzaTegZvdCjmYO52cSFAEVmqU=
 github.com/tklauser/go-sysconf v0.3.12/go.mod h1:Ho14jnntGE1fpdOqQEEaiKRpvIavV0hSfmBq8nJbHYI=
 github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+Fk=

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -38,7 +38,7 @@ type AppEnvironment struct {
 }
 
 func NewAppEnvironment(os string, arch string, projectUuid string) *AppEnvironment {
-	logger.NewLogger().Info("embedded application release version: %s", embeddedDevkitReleaseVersion)
+	logger.NewLogger().Info("embedded application release embeddedDevkitReleaseVersion: %s", embeddedDevkitReleaseVersion)
 	return &AppEnvironment{
 		CLIVersion:  embeddedDevkitReleaseVersion,
 		OS:          os,

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Embedded devkit version from release
-var embeddedDevkitReleaseVersion string
+var embeddedDevkitReleaseVersion = "Development"
 
 // WithShutdown creates a new context that will be cancelled on SIGTERM/SIGINT
 func WithShutdown(ctx context.Context) context.Context {

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Embedded devkit version from release
-var embeddedDevkitReleaseVersion = "dev"
+var embeddedDevkitReleaseVersion string
 
 // WithShutdown creates a new context that will be cancelled on SIGTERM/SIGINT
 func WithShutdown(ctx context.Context) context.Context {

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -8,6 +8,9 @@ import (
 	"syscall"
 )
 
+// Embedded devkit version from release
+var embeddedDevkitReleaseVersion = "dev"
+
 // WithShutdown creates a new context that will be cancelled on SIGTERM/SIGINT
 func WithShutdown(ctx context.Context) context.Context {
 	ctx, cancel := context.WithCancel(ctx)
@@ -33,9 +36,9 @@ type AppEnvironment struct {
 	ProjectUUID string
 }
 
-func NewAppEnvironment(cliVersion string, os string, arch string, projectUuid string) *AppEnvironment {
+func NewAppEnvironment(os string, arch string, projectUuid string) *AppEnvironment {
 	return &AppEnvironment{
-		CLIVersion:  cliVersion,
+		CLIVersion:  embeddedDevkitReleaseVersion,
 		OS:          os,
 		Arch:        arch,
 		ProjectUUID: projectUuid,

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -2,6 +2,7 @@ package context
 
 import (
 	"context"
+	"devkit-cli/pkg/common/logger"
 	"fmt"
 	"os"
 	"os/signal"
@@ -37,6 +38,7 @@ type AppEnvironment struct {
 }
 
 func NewAppEnvironment(os string, arch string, projectUuid string) *AppEnvironment {
+	logger.NewLogger().Info("embedded application release version: %s", embeddedDevkitReleaseVersion)
 	return &AppEnvironment{
 		CLIVersion:  embeddedDevkitReleaseVersion,
 		OS:          os,

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -2,7 +2,6 @@ package context
 
 import (
 	"context"
-	"devkit-cli/pkg/common/logger"
 	"fmt"
 	"os"
 	"os/signal"
@@ -38,7 +37,6 @@ type AppEnvironment struct {
 }
 
 func NewAppEnvironment(os string, arch string, projectUuid string) *AppEnvironment {
-	logger.NewLogger().Info("embedded application release embeddedDevkitReleaseVersion: %s", embeddedDevkitReleaseVersion)
 	return &AppEnvironment{
 		CLIVersion:  embeddedDevkitReleaseVersion,
 		OS:          os,

--- a/pkg/hooks/hooks.go
+++ b/pkg/hooks/hooks.go
@@ -110,7 +110,6 @@ func setupTelemetry(ctx *cli.Context) telemetry.Client {
 
 func WithAppEnvironment(ctx *cli.Context) {
 	ctx.Context = kitcontext.WithAppEnvironment(ctx.Context, kitcontext.NewAppEnvironment(
-		ctx.App.Version,
 		runtime.GOOS,
 		runtime.GOARCH,
 		common.GetProjectUUID(),

--- a/pkg/telemetry/posthog.go
+++ b/pkg/telemetry/posthog.go
@@ -2,7 +2,6 @@ package telemetry
 
 import (
 	"context"
-	"devkit-cli/pkg/common/logger"
 	kitcontext "devkit-cli/pkg/context"
 	"github.com/posthog/posthog-go"
 	"gopkg.in/yaml.v3"
@@ -20,11 +19,9 @@ type PostHogClient struct {
 func NewPostHogClient(environment *kitcontext.AppEnvironment, namespace string) (*PostHogClient, error) {
 	apiKey := getPostHogAPIKey()
 	if apiKey == "" {
-		logger.NewLogger().Error("PostHog API key is empty.")
 		// No API key available, return noop client without error
 		return nil, nil
 	}
-	logger.NewLogger().Error("PostHog API key: %s.", apiKey)
 	client, err := posthog.NewWithConfig(apiKey, posthog.Config{Endpoint: getPostHogEndpoint()})
 	if err != nil {
 		return nil, err

--- a/pkg/telemetry/posthog.go
+++ b/pkg/telemetry/posthog.go
@@ -69,9 +69,6 @@ func (c *PostHogClient) Close() error {
 	return nil
 }
 
-// Embedded API key, can be set during build time
-var embeddedPostHogAPIKey string
-
 func getPostHogAPIKey() string {
 	// Priority order:
 	// 1. Environment variable
@@ -97,8 +94,8 @@ func getPostHogAPIKey() string {
 		}
 	}
 
-	// Finally, check embedded key
-	return embeddedPostHogAPIKey
+	// return embedded key if no overrides provided
+	return embeddedTelemetryApiKey
 }
 
 func getPostHogEndpoint() string {

--- a/pkg/telemetry/posthog.go
+++ b/pkg/telemetry/posthog.go
@@ -2,6 +2,7 @@ package telemetry
 
 import (
 	"context"
+	"devkit-cli/pkg/common/logger"
 	kitcontext "devkit-cli/pkg/context"
 	"github.com/posthog/posthog-go"
 	"gopkg.in/yaml.v3"
@@ -19,9 +20,11 @@ type PostHogClient struct {
 func NewPostHogClient(environment *kitcontext.AppEnvironment, namespace string) (*PostHogClient, error) {
 	apiKey := getPostHogAPIKey()
 	if apiKey == "" {
+		logger.NewLogger().Error("PostHog API key is empty.")
 		// No API key available, return noop client without error
 		return nil, nil
 	}
+	logger.NewLogger().Error("PostHog API key: %s.", apiKey)
 	client, err := posthog.NewWithConfig(apiKey, posthog.Config{Endpoint: getPostHogEndpoint()})
 	if err != nil {
 		return nil, err

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -4,6 +4,9 @@ import (
 	"context"
 )
 
+// Embedded devkit telemetry api key from release
+var embeddedTelemetryApiKey string
+
 // Client defines the interface for telemetry operations
 type Client interface {
 	// AddMetric emits a single metric

--- a/pkg/telemetry/telemetry_test.go
+++ b/pkg/telemetry/telemetry_test.go
@@ -48,7 +48,7 @@ func TestContext(t *testing.T) {
 }
 
 func TestProperties(t *testing.T) {
-	props := kitcontext.NewAppEnvironment("1.0.0", "darwin", "amd64", "test-uuid")
+	props := kitcontext.NewAppEnvironment("darwin", "amd64", "test-uuid")
 	if props.CLIVersion != "1.0.0" {
 		t.Error("CLIVersion mismatch")
 	}

--- a/pkg/telemetry/telemetry_test.go
+++ b/pkg/telemetry/telemetry_test.go
@@ -49,6 +49,9 @@ func TestContext(t *testing.T) {
 
 func TestProperties(t *testing.T) {
 	props := kitcontext.NewAppEnvironment("darwin", "amd64", "test-uuid")
+	if props.CLIVersion == "" {
+		t.Error("Version not using default")
+	}
 	if props.OS != "darwin" {
 		t.Error("OS mismatch")
 	}

--- a/pkg/telemetry/telemetry_test.go
+++ b/pkg/telemetry/telemetry_test.go
@@ -49,6 +49,9 @@ func TestContext(t *testing.T) {
 
 func TestProperties(t *testing.T) {
 	props := kitcontext.NewAppEnvironment("darwin", "amd64", "test-uuid")
+	if props.CLIVersion != "" {
+		t.Error("CLIVersion empty")
+	}
 	if props.OS != "darwin" {
 		t.Error("OS mismatch")
 	}

--- a/pkg/telemetry/telemetry_test.go
+++ b/pkg/telemetry/telemetry_test.go
@@ -49,7 +49,7 @@ func TestContext(t *testing.T) {
 
 func TestProperties(t *testing.T) {
 	props := kitcontext.NewAppEnvironment("darwin", "amd64", "test-uuid")
-	if props.CLIVersion != "" {
+	if props.CLIVersion == "" {
 		t.Error("CLIVersion empty")
 	}
 	if props.OS != "darwin" {

--- a/pkg/telemetry/telemetry_test.go
+++ b/pkg/telemetry/telemetry_test.go
@@ -49,9 +49,6 @@ func TestContext(t *testing.T) {
 
 func TestProperties(t *testing.T) {
 	props := kitcontext.NewAppEnvironment("darwin", "amd64", "test-uuid")
-	if props.CLIVersion == "" {
-		t.Error("CLIVersion empty")
-	}
 	if props.OS != "darwin" {
 		t.Error("OS mismatch")
 	}

--- a/pkg/telemetry/telemetry_test.go
+++ b/pkg/telemetry/telemetry_test.go
@@ -49,9 +49,6 @@ func TestContext(t *testing.T) {
 
 func TestProperties(t *testing.T) {
 	props := kitcontext.NewAppEnvironment("darwin", "amd64", "test-uuid")
-	if props.CLIVersion != "1.0.0" {
-		t.Error("CLIVersion mismatch")
-	}
 	if props.OS != "darwin" {
 		t.Error("OS mismatch")
 	}


### PR DESCRIPTION
<!-- 
    🚨 ATTENTION! 🚨 
    
    This PR template is REQUIRED. PRs not following this format will be closed without review.
    
    Requirements:
    - PR title must follow commit conventions: https://www.conventionalcommits.org/en/v1.0.0/
    - Label your PR with the correct type (e.g., 🐛 Bug, ✨ Enhancement, 🧪 Test, etc.)
    - Provide clear and specific details in each section
-->

**Motivation:**
In order to emit telemetry for official releases without exposing our API key, we need to inject it via secure secrets via the linker. 

**Modifications:**
- Updated README with release instructions.
- Added a `release` GitHub workflow that calls Go release via goreleaser.yml.

**Result:**
- PostHog is able to emit metrics securely from distributed binaries.

**Testing:**
Added log statements to test releases created with the release process. Confirmed the version and key were correctly set.

>  embedded application release embeddedDevkitReleaseVersion: 0.1.0-test.17
> PostHog API key: redacted

See the [pre-release candidate](https://github.com/Layr-Labs/devkit-cli/releases/tag/v0.1.0-preview.1.rc) with embedded metrics.

**Open questions:**
- CI does not pin the hourglass-template to a specific version in the GitHub action flows.. seems like a problem long-term.