### PR TITLE
feat: refactoring hooks and standardizing uuid generation process

### DIFF
--- a/cmd/devkit/main.go
+++ b/cmd/devkit/main.go
@@ -8,14 +8,13 @@ import (
 	"devkit-cli/pkg/commands"
 	"devkit-cli/pkg/commands/keystore"
 	"devkit-cli/pkg/common"
-	kitcontext "devkit-cli/pkg/context"
 	"devkit-cli/pkg/hooks"
 
 	"github.com/urfave/cli/v2"
 )
 
 func main() {
-	ctx := kitcontext.WithShutdown(context.Background())
+	ctx := common.WithShutdown(context.Background())
 
 	app := &cli.App{
 		Name:  "devkit",
@@ -26,7 +25,7 @@ func main() {
 			if err != nil {
 				return err
 			}
-			hooks.WithAppEnvironment(ctx)
+			common.WithAppEnvironment(ctx)
 			return hooks.WithCommandMetricsContext(ctx)
 		},
 		Commands:               []*cli.Command{commands.AVSCommand, keystore.KeystoreCommand},

--- a/pkg/commands/build_test.go
+++ b/pkg/commands/build_test.go
@@ -3,7 +3,6 @@ package commands
 import (
 	"context"
 	"devkit-cli/pkg/common"
-	kitcontext "devkit-cli/pkg/context"
 	"devkit-cli/pkg/testutils"
 	"errors"
 	"os"
@@ -128,7 +127,7 @@ echo "Mock build executed"`
 	defer func() { _ = os.Chdir(oldWd) }()
 
 	parentCtx, cancel := context.WithCancel(context.Background())
-	ctx := kitcontext.WithShutdown(parentCtx)
+	ctx := common.WithShutdown(parentCtx)
 
 	app := &cli.App{
 		Name:     "test",

--- a/pkg/commands/config_list_test.go
+++ b/pkg/commands/config_list_test.go
@@ -34,7 +34,7 @@ telemetry_enabled: true
 `
 
 	require.NoError(t, os.WriteFile(
-		filepath.Join(tmpDir, ".config.devkit.yml"),
+		filepath.Join(tmpDir, common.DevkitConfigFile),
 		[]byte(mockTelemteryContent),
 		0644,
 	))

--- a/pkg/commands/create.go
+++ b/pkg/commands/create.go
@@ -173,7 +173,11 @@ var CreateCommand = &cli.Command{
 		}
 
 		// Save project settings with telemetry preference
-		if err := common.SaveTelemetrySetting(targetDir, true); err != nil {
+		appEnv, ok := common.AppEnvironmentFromContext(cCtx.Context)
+		if !ok {
+			return fmt.Errorf("could not determine application environment")
+		}
+		if err := common.SaveProjectIdAndTelemetryToggle(targetDir, appEnv.ProjectUUID, true); err != nil {
 			return fmt.Errorf("failed to save project settings: %w", err)
 		}
 

--- a/pkg/common/context.go
+++ b/pkg/common/context.go
@@ -1,10 +1,13 @@
-package context
+package common
 
 import (
 	"context"
 	"fmt"
+	"github.com/google/uuid"
+	"github.com/urfave/cli/v2"
 	"os"
 	"os/signal"
+	"runtime"
 	"syscall"
 )
 
@@ -45,7 +48,23 @@ func NewAppEnvironment(os string, arch string, projectUuid string) *AppEnvironme
 	}
 }
 
-func WithAppEnvironment(ctx context.Context, appEnvironment *AppEnvironment) context.Context {
+func WithAppEnvironment(ctx *cli.Context) {
+	withAppEnvironmentFromLocation(ctx, DevkitConfigFile)
+}
+
+func withAppEnvironmentFromLocation(ctx *cli.Context, location string) {
+	id := getProjectUUIDFromLocation(location)
+	if id == "" {
+		id = uuid.New().String()
+	}
+	ctx.Context = withAppEnvironment(ctx.Context, NewAppEnvironment(
+		runtime.GOOS,
+		runtime.GOARCH,
+		id,
+	))
+}
+
+func withAppEnvironment(ctx context.Context, appEnvironment *AppEnvironment) context.Context {
 	return context.WithValue(ctx, appEnvironmentContextKey{}, appEnvironment)
 }
 

--- a/pkg/common/project_config_test.go
+++ b/pkg/common/project_config_test.go
@@ -1,9 +1,15 @@
 package common
 
 import (
+	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/urfave/cli/v2"
 )
 
 func TestSaveAndLoadProjectSettings(t *testing.T) {
@@ -11,13 +17,13 @@ func TestSaveAndLoadProjectSettings(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	// Test saving project settings
-	err := SaveTelemetrySetting(tmpDir, true)
+	err := SaveProjectIdAndTelemetryToggle(tmpDir, uuid.New().String(), true)
 	if err != nil {
 		t.Fatalf("Failed to save project settings: %v", err)
 	}
 
 	// Verify file exists
-	configPath := filepath.Join(tmpDir, configFileName)
+	configPath := filepath.Join(tmpDir, DevkitConfigFile)
 	if _, err := os.Stat(configPath); os.IsNotExist(err) {
 		t.Fatalf("Config file was not created")
 	}
@@ -52,4 +58,130 @@ func TestSaveAndLoadProjectSettings(t *testing.T) {
 	if !settings.TelemetryEnabled {
 		t.Error("TelemetryEnabled should be true")
 	}
+}
+
+func TestGetProjectUUIDFromLocation_ValidFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	expectedUUID := uuid.New().String()
+
+	content := []byte("project_uuid: " + expectedUUID + "\ntelemetry_enabled: true\n")
+	configPath := filepath.Join(tmpDir, "devkit.yaml")
+	err := os.WriteFile(configPath, content, 0644)
+	if err != nil {
+		t.Fatalf("Failed to write config file: %v", err)
+	}
+
+	actual := getProjectUUIDFromLocation(configPath)
+	if actual != expectedUUID {
+		t.Errorf("Expected UUID %s, got %s", expectedUUID, actual)
+	}
+}
+
+func TestGetProjectUUIDFromLocation_FileMissing(t *testing.T) {
+	missingPath := filepath.Join(t.TempDir(), "nonexistent.yaml")
+	uuid := getProjectUUIDFromLocation(missingPath)
+	if uuid != "" {
+		t.Errorf("Expected empty UUID for missing file, got %s", uuid)
+	}
+}
+
+func TestLoadProjectSettings_InvalidYAML(t *testing.T) {
+	tmpDir := t.TempDir()
+	invalidContent := []byte("{invalid_yaml:::")
+	configPath := filepath.Join(tmpDir, "devkit.yaml")
+	err := os.WriteFile(configPath, invalidContent, 0644)
+	if err != nil {
+		t.Fatalf("Failed to write invalid config file: %v", err)
+	}
+
+	_, err = loadProjectSettingsFromLocation(configPath)
+	if err == nil {
+		t.Error("Expected YAML parsing error, got nil")
+	}
+}
+
+func TestIsTelemetryEnabled_TrueAndFalse(t *testing.T) {
+	tmpDir := t.TempDir()
+	truePath := filepath.Join(tmpDir, "telemetry_true.yaml")
+	falsePath := filepath.Join(tmpDir, "telemetry_false.yaml")
+
+	// Write "true" config
+	os.WriteFile(truePath, []byte("project_uuid: "+uuid.New().String()+"\ntelemetry_enabled: true\n"), 0644)
+	// Write "false" config
+	os.WriteFile(falsePath, []byte("project_uuid: "+uuid.New().String()+"\ntelemetry_enabled: false\n"), 0644)
+
+	// Override global path
+	if !isTelemetryEnabled(truePath) {
+		t.Error("Expected telemetry to be enabled")
+	}
+
+	if isTelemetryEnabled(falsePath) {
+		t.Error("Expected telemetry to be disabled")
+	}
+}
+
+func TestIsTelemetryEnabled_FileMissing(t *testing.T) {
+	truePath := filepath.Join(t.TempDir(), "missing.yaml")
+	if isTelemetryEnabled(truePath) {
+		t.Error("Expected telemetry to be disabled when config is missing")
+	}
+}
+
+func writeTempConfig(t *testing.T, content string) string {
+	t.Helper()
+	tmpFile, err := os.CreateTemp("", "devkit-config-test.yaml")
+	assert.NoError(t, err)
+	_, err = tmpFile.WriteString(content)
+	assert.NoError(t, err)
+	tmpFile.Close()
+	return tmpFile.Name()
+}
+
+func TestGetProjectUUID_WhenUUIDIsPresent(t *testing.T) {
+	expectedUUID := uuid.New().String()
+	content := "project_uuid: " + expectedUUID + "\n"
+	writeTempConfig(t, content)
+
+	actualUUID := getProjectUUIDFromLocation(writeTempConfig(t, content))
+	assert.Equal(t, expectedUUID, actualUUID)
+}
+
+func TestGetProjectUUID_WhenConfigMissing(t *testing.T) {
+	actualUUID := GetProjectUUID()
+	assert.Equal(t, "", actualUUID)
+}
+
+func TestWithAppEnvironment_GeneratesUUIDWhenMissing(t *testing.T) {
+	ctx := &cli.Context{
+		Context: context.Background(),
+	}
+	WithAppEnvironment(ctx)
+
+	env, ok := AppEnvironmentFromContext(ctx.Context)
+	if !ok {
+		t.Errorf("No app environment found in context")
+	}
+	assert.Equal(t, runtime.GOOS, env.OS)
+	assert.Equal(t, runtime.GOARCH, env.Arch)
+	_, err := uuid.Parse(env.ProjectUUID)
+	assert.NoError(t, err)
+}
+
+func TestWithAppEnvironment_UsesUUIDFromConfig(t *testing.T) {
+	expectedUUID := uuid.New().String()
+	content := "project_uuid: " + expectedUUID + "\n"
+	tempFile := writeTempConfig(t, content)
+	ctx := &cli.Context{
+		Context: context.Background(),
+	}
+
+	withAppEnvironmentFromLocation(ctx, tempFile)
+
+	env, ok := AppEnvironmentFromContext(ctx.Context)
+	if !ok {
+		t.Errorf("No app environment found in context")
+	}
+	assert.Equal(t, runtime.GOOS, env.OS)
+	assert.Equal(t, runtime.GOARCH, env.Arch)
+	assert.Equal(t, expectedUUID, env.ProjectUUID)
 }

--- a/pkg/common/project_config_test.go
+++ b/pkg/common/project_config_test.go
@@ -106,9 +106,15 @@ func TestIsTelemetryEnabled_TrueAndFalse(t *testing.T) {
 	falsePath := filepath.Join(tmpDir, "telemetry_false.yaml")
 
 	// Write "true" config
-	os.WriteFile(truePath, []byte("project_uuid: "+uuid.New().String()+"\ntelemetry_enabled: true\n"), 0644)
+	err := os.WriteFile(truePath, []byte("project_uuid: "+uuid.New().String()+"\ntelemetry_enabled: true\n"), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write telemetry config: %v", err)
+	}
 	// Write "false" config
-	os.WriteFile(falsePath, []byte("project_uuid: "+uuid.New().String()+"\ntelemetry_enabled: false\n"), 0644)
+	err = os.WriteFile(falsePath, []byte("project_uuid: "+uuid.New().String()+"\ntelemetry_enabled: false\n"), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write telemetry config: %v", err)
+	}
 
 	// Override global path
 	if !isTelemetryEnabled(truePath) {

--- a/pkg/telemetry/metric.go
+++ b/pkg/telemetry/metric.go
@@ -20,7 +20,7 @@ type Metric struct {
 	Dimensions map[string]string `json:"dimensions"`
 }
 
-// contextKey is used to store the metrics context
+// clientContextKey is used to store the metrics context
 type metricsContextKey struct{}
 
 // WithMetricsContext returns a new context with the metrics context

--- a/pkg/telemetry/metric.go
+++ b/pkg/telemetry/metric.go
@@ -20,7 +20,7 @@ type Metric struct {
 	Dimensions map[string]string `json:"dimensions"`
 }
 
-// clientContextKey is used to store the metrics context
+// metricsContextKey is used to store the metrics context
 type metricsContextKey struct{}
 
 // WithMetricsContext returns a new context with the metrics context

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -15,15 +15,15 @@ type Client interface {
 	Close() error
 }
 
+type clientContextKey struct{}
+
 // ContextWithClient returns a new context with the telemetry client
 func ContextWithClient(ctx context.Context, client Client) context.Context {
-	return context.WithValue(ctx, contextKey{}, client)
+	return context.WithValue(ctx, clientContextKey{}, client)
 }
 
 // ClientFromContext retrieves the telemetry client from context
 func ClientFromContext(ctx context.Context) (Client, bool) {
-	client, ok := ctx.Value(contextKey{}).(Client)
+	client, ok := ctx.Value(clientContextKey{}).(Client)
 	return client, ok
 }
-
-type contextKey struct{}

--- a/pkg/telemetry/telemetry_test.go
+++ b/pkg/telemetry/telemetry_test.go
@@ -2,7 +2,7 @@ package telemetry
 
 import (
 	"context"
-	kitcontext "devkit-cli/pkg/context"
+	"devkit-cli/pkg/common"
 	"testing"
 )
 
@@ -48,7 +48,7 @@ func TestContext(t *testing.T) {
 }
 
 func TestProperties(t *testing.T) {
-	props := kitcontext.NewAppEnvironment("darwin", "amd64", "test-uuid")
+	props := common.NewAppEnvironment("darwin", "amd64", "test-uuid")
 	if props.CLIVersion == "" {
 		t.Error("Version not using default")
 	}


### PR DESCRIPTION
<!-- 
    🚨 ATTENTION! 🚨 
    
    This PR template is REQUIRED. PRs not following this format will be closed without review.
    
    Requirements:
    - PR title must follow commit conventions: https://www.conventionalcommits.org/en/v1.0.0/
    - Label your PR with the correct type (e.g., 🐛 Bug, ✨ Enhancement, 🧪 Test, etc.)
    - Provide clear and specific details in each section
-->

**Motivation:**
DevKit telemetry relies on a ProjectUuid being present to uniquely identify projects customers create. This change standardizes the creation of a project uuid at the start of the command flow, rather than after creation of the project. Further, the `hooks` package was not aptly named, bloated and due for refactoring. 


**Modifications:**
- Standardizes uuid generation in command middleware.
- Add error logging for metric failures.
- Refactor hooks package
- Move context package contents to common package.
- Refactor various methods for improved testing.

**Result:**
- Telemetry for `create` command now emitted.

**Testing:**
- Unit tests
- Manual testing at [PostHog](https://us.posthog.com/project/150668/sql)