### PR TITLE
fix: replace bool with iota-based enum for response expectation in CallTemplateScript

### DIFF
--- a/pkg/commands/call.go
+++ b/pkg/commands/call.go
@@ -57,8 +57,7 @@ var CallCommand = &cli.Command{
 		}
 
 		// Run init on the template init script
-		const expectJSONResponse = true
-		if _, err := common.CallTemplateScript(cCtx.Context, dir, scriptPath, expectJSONResponse, contextJSON, paramsJSON); err != nil {
+		if _, err := common.CallTemplateScript(cCtx.Context, dir, scriptPath, common.ExpectJSONResponse, contextJSON, paramsJSON); err != nil {
 			return fmt.Errorf("call failed: %w", err)
 		}
 

--- a/pkg/commands/create.go
+++ b/pkg/commands/create.go
@@ -170,8 +170,7 @@ var CreateCommand = &cli.Command{
 		log.Info("Installing template dependencies\n\n")
 
 		// Run init on the template init script
-		const expectJSONResponse = false
-		if _, err = common.CallTemplateScript(cCtx.Context, targetDir, scriptPath, expectJSONResponse, nil); err != nil {
+		if _, err = common.CallTemplateScript(cCtx.Context, targetDir, scriptPath, common.ExpectNonJSONResponse, nil); err != nil {
 			return fmt.Errorf("failed to initialize %s: %w", scriptPath, err)
 		}
 

--- a/pkg/commands/devnet_actions.go
+++ b/pkg/commands/devnet_actions.go
@@ -105,9 +105,6 @@ func DeployContractsAction(cCtx *cli.Context) error {
 	// Run scriptPath from cwd
 	const dir = ""
 
-	// Run script with expectJSONResponse - each script returns context fragment
-	const expectJSONResponse = true
-
 	// Set path for .devkit scripts
 	scriptsDir := filepath.Join(".devkit", "scripts")
 

--- a/pkg/commands/devnet_actions.go
+++ b/pkg/commands/devnet_actions.go
@@ -165,7 +165,7 @@ func DeployContractsAction(cCtx *cli.Context) error {
 		// Set path in scriptsDir
 		scriptPath := filepath.Join(scriptsDir, name)
 		// Expect a JSON response which we will curry to the next call and later save to context
-		outMap, err := common.CallTemplateScript(cCtx.Context, dir, scriptPath, expectJSONResponse, inputJSON)
+		outMap, err := common.CallTemplateScript(cCtx.Context, dir, scriptPath, common.ExpectJSONResponse, inputJSON)
 		if err != nil {
 			return fmt.Errorf("%s failed: %w", name, err)
 		}

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -39,8 +39,7 @@ var RunCommand = &cli.Command{
 		}
 
 		// Run init on the template init script
-		const expectJSONResponse = false
-		if _, err := common.CallTemplateScript(cCtx.Context, dir, scriptPath, expectJSONResponse, contextJSON); err != nil {
+		if _, err := common.CallTemplateScript(cCtx.Context, dir, scriptPath, common.ExpectNonJSONResponse, contextJSON); err != nil {
 			return fmt.Errorf("run failed: %w", err)
 		}
 

--- a/pkg/common/scripts_caller.go
+++ b/pkg/common/scripts_caller.go
@@ -10,7 +10,14 @@ import (
 	"os/exec"
 )
 
-func CallTemplateScript(cmdCtx context.Context, dir string, scriptPath string, expectJSONResponse bool, params ...[]byte) (map[string]interface{}, error) {
+type ResponseExpectation int
+
+const (
+	ExpectNonJSONResponse ResponseExpectation = iota
+	ExpectJSONResponse
+)
+
+func CallTemplateScript(cmdCtx context.Context, dir string, scriptPath string, expect ResponseExpectation, params ...[]byte) (map[string]interface{}, error) {
 	// Get logger
 	log, _ := GetLogger()
 
@@ -44,7 +51,7 @@ func CallTemplateScript(cmdCtx context.Context, dir string, scriptPath string, e
 	}
 
 	// Return the result as JSON if expected
-	if expectJSONResponse {
+	if expect == ExpectJSONResponse {
 		var result map[string]interface{}
 		if err := json.Unmarshal(raw, &result); err != nil {
 			log.Warn("Invalid or non-JSON script output: %s; returning empty result: %v", string(raw), err)


### PR DESCRIPTION
<!-- 
    🚨 ATTENTION! 🚨 
    
    This PR template is REQUIRED. PRs not following this format will be closed without review.
    
    Requirements:
    - PR title must follow commit conventions: https://www.conventionalcommits.org/en/v1.0.0/
    - Label your PR with the correct type (e.g., 🐛 Bug, ✨ Enhancement, 🧪 Test, etc.)
    - Provide clear and specific details in each section
-->

**Motivation:**
<!--
Explain here the context, and why you're making that change. What is the problem you're trying to solve.
-->
`CallTemplateScript` used a raw bool to indicate expected response type making the args use ambiguous. This PR improves type safety and code readability by replacing it with a properly named enum.

**Modifications:**
<!--
Describe the modifications you've done from a high level. What are the key technical decisions and why were they made?
-->
- Introduced `ResponseExpectation` as an `iota`-based enum (`ExpectJSONResponse`, `ExpectNonJSONResponse`)  
- Updated `CallTemplateScript` signature to use the new type  
- Replaced all usage of the old `bool` constants 

**Result:**
<!--
*After your change, what will change.
-->
Callers must now explicitly use the named enum value reducing ambiguity and preventing misuse.

**Testing:**
<!--
*List testing procedures taken and useful artifacts.
-->
- Integrations tests for `CallTemplateScript` with both json and non-json expected responses
