### PR TITLE
fix: avs run on devnet start unless skipped

### DIFF
--- a/pkg/commands/devnet.go
+++ b/pkg/commands/devnet.go
@@ -31,6 +31,11 @@ var DevnetCommand = &cli.Command{
 					Value: 8545,
 				},
 				&cli.BoolFlag{
+					Name:  "skip-avs-run",
+					Usage: "Skip starting offchain AVS components",
+					Value: false,
+				},
+				&cli.BoolFlag{
 					Name:  "skip-deploy-contracts",
 					Usage: "Skip deploying contracts and only start local devnet",
 					Value: false,

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -15,35 +15,41 @@ var RunCommand = &cli.Command{
 	Usage: "Start offchain AVS components",
 	Flags: append([]cli.Flag{}, common.GlobalFlags...),
 	Action: func(cCtx *cli.Context) error {
-		// Get logger
-		log, _ := common.GetLogger()
-
-		// Print task if verbose
-		if cCtx.Bool("verbose") {
-			log.Info("Starting offchain AVS components...")
-		}
-
-		// Run the script from root of project dir
-		// (@TODO (GD): this should always be the root of the project, but we need to do this everywhere (ie reading ctx/config etc))
-		const dir = ""
-
-		// Set path for .devkit scripts
-		scriptPath := filepath.Join(".devkit", "scripts", "run")
-
-		// Set path for context yaml
-		contextDir := filepath.Join("config", "contexts")
-		yamlPath := path.Join(contextDir, "devnet.yaml") // @TODO: use selected context name
-		contextJSON, err := common.LoadContext(yamlPath)
-		if err != nil {
-			return fmt.Errorf("failed to load context: %w", err)
-		}
-
-		// Run init on the template init script
-		if _, err := common.CallTemplateScript(cCtx.Context, dir, scriptPath, common.ExpectNonJSONResponse, contextJSON); err != nil {
-			return fmt.Errorf("run failed: %w", err)
-		}
-
-		log.Info("Offchain AVS components started successfully!")
-		return nil
+		// Invoke and return AVSRun
+		return AVSRun(cCtx)
 	},
+}
+
+func AVSRun(cCtx *cli.Context) error {
+	// Get logger
+	log, _ := common.GetLogger()
+
+	// Print task if verbose
+	if cCtx.Bool("verbose") {
+		log.Info("Starting offchain AVS components...")
+	}
+
+	// Run the script from root of project dir
+	// (@TODO (GD): this should always be the root of the project, but we need to do this everywhere (ie reading ctx/config etc))
+	const dir = ""
+
+	// Set path for .devkit scripts
+	scriptPath := filepath.Join(".devkit", "scripts", "run")
+
+	// Set path for context yaml
+	contextDir := filepath.Join("config", "contexts")
+	yamlPath := path.Join(contextDir, "devnet.yaml") // @TODO: use selected context name
+	contextJSON, err := common.LoadContext(yamlPath)
+	if err != nil {
+		return fmt.Errorf("failed to load context: %w", err)
+	}
+
+	// Run init on the template init script
+	if _, err := common.CallTemplateScript(cCtx.Context, dir, scriptPath, common.ExpectNonJSONResponse, contextJSON); err != nil {
+		return fmt.Errorf("run failed: %w", err)
+	}
+
+	log.Info("Offchain AVS components started successfully!")
+
+	return nil
 }


### PR DESCRIPTION
<!-- 
    🚨 ATTENTION! 🚨 
    
    This PR template is REQUIRED. PRs not following this format will be closed without review.
    
    Requirements:
    - PR title must follow commit conventions: https://www.conventionalcommits.org/en/v1.0.0/
    - Label your PR with the correct type (e.g., 🐛 Bug, ✨ Enhancement, 🧪 Test, etc.)
    - Provide clear and specific details in each section
-->

**Motivation:**
<!--
Explain here the context, and why you're making that change. What is the problem you're trying to solve.
-->
In order to simplify user interactions with DevKit, we want as much of the process to be up and running after `avs devnet start`.

**Modifications:**
<!--
Describe the modifications you've done from a high level. What are the key technical decisions and why were they made?
-->
- `avs run` is called as part of `avs devnet start` unless `--skip-deploy-contracts` or `--skip-avs-run` is flagged

**Result:**
<!--
*After your change, what will change.
-->
- reduced cognitive load on dev
