### PR TITLE
fix: clear template .git before initialising new empty repo

### DIFF
--- a/config/.gitignore
+++ b/config/.gitignore
@@ -28,3 +28,7 @@ Thumbs.db
 
 # Release outputs
 temp_external/
+
+# DevKit configuration (remove only after ensuring no personal data is exposed here)
+config/
+.config.devkit.yml

--- a/config/config_embeds.go
+++ b/config/config_embeds.go
@@ -8,6 +8,9 @@ var DefaultConfigYaml string
 //go:embed templates.yaml
 var TemplatesYaml string
 
+//go:embed .gitignore
+var GitIgnore string
+
 //go:embed contexts/devnet.yaml
 var devnetContextYaml string
 

--- a/pkg/commands/create.go
+++ b/pkg/commands/create.go
@@ -174,6 +174,11 @@ var CreateCommand = &cli.Command{
 			return fmt.Errorf("failed to initialize %s: %w", scriptPath, err)
 		}
 
+		// Tidy the logs
+		if cCtx.Bool("verbose") {
+			log.Info("\nFinalising new project\n\n")
+		}
+
 		// Copy config.yaml to the project directory
 		if err := copyDefaultConfigToProject(targetDir, projectName, cCtx.Bool("verbose")); err != nil {
 			return fmt.Errorf("failed to initialize %s: %w", common.BaseConfig, err)
@@ -342,8 +347,17 @@ func initGitRepo(ctx *cli.Context, targetDir string, verbose bool) error {
 	log, _ := common.GetLogger()
 
 	if verbose {
+		log.Info("Removing existing .git directory in %s (if any)...", targetDir)
+	}
+	gitDir := filepath.Join(targetDir, ".git")
+	if err := os.RemoveAll(gitDir); err != nil {
+		return fmt.Errorf("failed to remove existing .git directory: %w", err)
+	}
+
+	if verbose {
 		log.Info("Initializing Git repository in %s...", targetDir)
 	}
+
 	cmd := exec.CommandContext(ctx.Context, "git", "init")
 	cmd.Dir = targetDir
 	output, err := cmd.CombinedOutput()

--- a/pkg/commands/create.go
+++ b/pkg/commands/create.go
@@ -364,6 +364,12 @@ func initGitRepo(ctx *cli.Context, targetDir string, verbose bool) error {
 	if err != nil {
 		return fmt.Errorf("git init failed: %w\nOutput: %s", err, string(output))
 	}
+
+	err = os.WriteFile(filepath.Join(targetDir, ".gitignore"), []byte(config.GitIgnore), 0644)
+	if err != nil {
+		return fmt.Errorf("failed to write .gitignore: %w", err)
+	}
+
 	if verbose {
 		log.Info("Git repository initialized successfully.")
 		if len(output) > 0 {


### PR DESCRIPTION
**Motivation:**
Previously, `initGitRepo` would initialize a Git repository even if one already existed in the target directory. This could result in corrupted or unintended Git states. We need to ensure a clean slate every time this function is called. 

Also, if a user was to push these changes to a remote target, there is a chance they might leak secrets in their config files. We need to make sure that any config files are excluded from the repo.

**Modifications:**
- Added logic to detect and completely remove any existing `.git` directory in the target directory before initializing a new Git repo.
- Added a .gitignore file to exclude config files

**Result:**
Calling `initGitRepo` now guarantees a fresh Git repository with no remnants of any prior repo state. In addition, the potential for leaking config now takes additional steps.
