### PR TITLE
fix: use private rpc for fork_url in smoke-test

### DIFF
--- a/.github/workflows/devnet.yml
+++ b/.github/workflows/devnet.yml
@@ -8,6 +8,9 @@ on:
 
 env:
   FOUNDRY_PROFILE: ci
+  L1_FORK_URL: ${{ vars.L1_FORK_URL }}
+  L2_FORK_URL: ${{ vars.L2_FORK_URL }}
+
 jobs:
   devnet-test:
     strategy:


### PR DESCRIPTION
<!-- 
    🚨 ATTENTION! 🚨 
    
    This PR template is REQUIRED. PRs not following this format will be closed without review.
    
    Requirements:
    - PR title must follow commit conventions: https://www.conventionalcommits.org/en/v1.0.0/
    - Label your PR with the correct type (e.g., 🐛 Bug, ✨ Enhancement, 🧪 Test, etc.)
    - Provide clear and specific details in each section
-->

**Motivation:**
<!--
Explain here the context, and why you're making that change. What is the problem you're trying to solve.
-->
Smoke test is failing as anvil is unavailable. This PR will allow the smoke test to use a devkit ci dedicated RPC URL for forking.

**Modifications:**
<!--
Describe the modifications you've done from a high level. What are the key technical decisions and why were they made?
-->
- Adds envs to allow use of private RPC.

**Result:**
<!--
*After your change, what will change.
-->
- Smoke test uses a dedicated CI RPC URL for forking
