### PR TITLE
fix: be less restrictive in projects .gitignore

### DIFF
--- a/config/.gitignore
+++ b/config/.gitignore
@@ -29,6 +29,6 @@ Thumbs.db
 # Release outputs
 temp_external/
 
-# DevKit configuration (remove only after ensuring no personal data is exposed here)
-config/
-.config.devkit.yml
+# DevKit context configurations (only devnet.yaml is indexed)
+config/contexts/**/*
+!config/contexts/devnet.yaml


### PR DESCRIPTION
<!-- 
    🚨 ATTENTION! 🚨 
    
    This PR template is REQUIRED. PRs not following this format will be closed without review.
    
    Requirements:
    - PR title must follow commit conventions: https://www.conventionalcommits.org/en/v1.0.0/
    - Label your PR with the correct type (e.g., 🐛 Bug, ✨ Enhancement, 🧪 Test, etc.)
    - Provide clear and specific details in each section
-->

**Motivation:**
<!--
Explain here the context, and why you're making that change. What is the problem you're trying to solve.
-->
We now have descriptive comments in the default `config/context/devnet.yaml` describing the keys and their origins, as such we can be less restrictive in what we add to the projects `.gitignore`.

**Modifications:**
<!--
Describe the modifications you've done from a high level. What are the key technical decisions and why were they made?
-->
- Adds all `config/context/*.yaml` files to the `.gitignore` EXCEPT `devnet.yaml`
**Result:**
<!--
*After your change, what will change.
-->
- All other contexts except for `devnet.yaml` will not be indexed in the project git repo
