### PR TITLE
fix: prevent leaking rpcs in github actions

### DIFF
--- a/.github/workflows/devnet.yml
+++ b/.github/workflows/devnet.yml
@@ -8,8 +8,8 @@ on:
 
 env:
   FOUNDRY_PROFILE: ci
-  L1_FORK_URL: ${{ vars.L1_FORK_URL }}
-  L2_FORK_URL: ${{ vars.L2_FORK_URL }}
+  L1_FORK_URL: ${{ secrets.L1_FORK_URL }}
+  L2_FORK_URL: ${{ secrets.L2_FORK_URL }}
 
 jobs:
   devnet-test:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,8 +9,8 @@ on:
 env:
   FOUNDRY_PROFILE: ci
   GOPRIVATE: github.com/Layr-Labs/*
-  L1_FORK_URL: ${{ vars.L1_FORK_URL }}
-  L2_FORK_URL: ${{ vars.L2_FORK_URL }}
+  L1_FORK_URL: ${{ secrets.L1_FORK_URL }}
+  L2_FORK_URL: ${{ secrets.L2_FORK_URL }}
 
 jobs:
   e2e:


### PR DESCRIPTION
<!-- 
    🚨 ATTENTION! 🚨 
    
    This PR template is REQUIRED. PRs not following this format will be closed without review.
    
    Requirements:
    - PR title must follow commit conventions: https://www.conventionalcommits.org/en/v1.0.0/
    - Label your PR with the correct type (e.g., 🐛 Bug, ✨ Enhancement, 🧪 Test, etc.)
    - Provide clear and specific details in each section
-->

**Motivation:**
<!--
Explain here the context, and why you're making that change. What is the problem you're trying to solve.
-->
Our github actions are using vars instead of secrets for L1_RPC_URL and L2_RPC_URL, we should switch to prevent leaking in private preview

**Modifications:**
<!--
Describe the modifications you've done from a high level. What are the key technical decisions and why were they made?
-->

- Switches vars for secrets in github actions

**Result:**
<!--
*After your change, what will change.
-->
- RPC_URLS will not be exposed in github action runs

