### PR TITLE
fix: name e2e test correctly in GHA

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,4 +1,4 @@
-name: Devkit AVS Create Test
+name: Devkit E2E Test
 
 on:
   push:


### PR DESCRIPTION
<!-- 
    🚨 ATTENTION! 🚨 
    
    This PR template is REQUIRED. PRs not following this format will be closed without review.
    
    Requirements:
    - PR title must follow commit conventions: https://www.conventionalcommits.org/en/v1.0.0/
    - Label your PR with the correct type (e.g., 🐛 Bug, ✨ Enhancement, 🧪 Test, etc.)
    - Provide clear and specific details in each section
-->

**Motivation:**
<!--
Explain here the context, and why you're making that change. What is the problem you're trying to solve.
-->
`e2e` test is named incorrectly in Github Actions

**Modifications:**
<!--
Describe the modifications you've done from a high level. What are the key technical decisions and why were they made?
-->
- Changes duplicate `Devkit AVS Create Test` to `Devkit E2E Test` for differentiation in CI

**Result:**
<!--
*After your change, what will change.
-->
- Uniquely named actions