### PR TITLE
feat: Implement AVS Setup and Operator Registration

### DIFF
--- a/config/contexts/devnet.yaml
+++ b/config/contexts/devnet.yaml
@@ -52,7 +52,7 @@ context:
       stake: "1000ETH"
   # AVS configuration
   avs:
-    address: "0x0123456789abcdef0123456789ABCDEF01234567"
+    address: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
     avs_private_key: "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80" # Anvil Private Key 0
     metadata_url: "https://my-org.com/avs/metadata.json"
     registrar_address: "0x0123456789abcdef0123456789ABCDEF01234567"

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 )
 
 require (
+	github.com/Layr-Labs/eigenlayer-contracts v1.4.2 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/StackExchange/wmi v1.2.1 // indirect
 	github.com/bits-and-blooms/bitset v1.17.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,9 @@
 github.com/DataDog/zstd v1.4.5 h1:EndNeuB0l9syBZhut0wns3gV1hL8zX8LIu6ZiVHWLIQ=
 github.com/DataDog/zstd v1.4.5/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
+github.com/Layr-Labs/eigenlayer-contracts v1.4.1 h1:FZKdVMcOgF8enRIgyfaaPVJFdRJtV9zt3INfJZnaP3I=
+github.com/Layr-Labs/eigenlayer-contracts v1.4.1/go.mod h1:Ie8YE3EQkTHqG6/tnUS0He7/UPMkXPo/3OFXwSy0iRo=
+github.com/Layr-Labs/eigenlayer-contracts v1.4.2 h1:1mhXQDCR4MtPutx+1ca7MR5XfKYNEkYwUKq0gaaMfOM=
+github.com/Layr-Labs/eigenlayer-contracts v1.4.2/go.mod h1:Ie8YE3EQkTHqG6/tnUS0He7/UPMkXPo/3OFXwSy0iRo=
 github.com/Layr-Labs/hourglass-monorepo/ponos v0.0.0-20250430200448-e0f09ac951eb h1:gGINRheG3ZI6iE9+EVbFaSBnJKafOtywkASHayJSwfs=
 github.com/Layr-Labs/hourglass-monorepo/ponos v0.0.0-20250430200448-e0f09ac951eb/go.mod h1:9Ax3YcQJMW007kP8lYTAvatfLUAkVb74NjrnR07bnd4=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=

--- a/pkg/commands/devnet.go
+++ b/pkg/commands/devnet.go
@@ -73,5 +73,11 @@ var DevnetCommand = &cli.Command{
 			Usage:  "Lists all running devkit devnet containers with their ports",
 			Action: ListDevnetContainersAction,
 		},
+		// TODO: Surface the following actions as separate commands:
+		// - update-avs-metadata: Updates the AVS metadata URI on the devnet
+		// - set-avs-registrar: Sets the AVS registrar address on the devnet
+		// - create-avs-operator-sets: Creates AVS operator sets on the devnet
+		// - register-operator-el: Registers an operator with EigenLayer
+		// - register-operator-avs: Registers an operator for a specific AVS
 	},
 }

--- a/pkg/commands/devnet.go
+++ b/pkg/commands/devnet.go
@@ -82,7 +82,6 @@ var DevnetCommand = &cli.Command{
 		// - update-avs-metadata: Updates the AVS metadata URI on the devnet
 		// - set-avs-registrar: Sets the AVS registrar address on the devnet
 		// - create-avs-operator-sets: Creates AVS operator sets on the devnet
-		// - register-operator-el: Registers an operator with EigenLayer
-		// - register-operator-avs: Registers an operator for a specific AVS
+		// - register-operators-from-config: Registers operators defined in config to Eigenlayer and the AVS on the devnet
 	},
 }

--- a/pkg/commands/devnet.go
+++ b/pkg/commands/devnet.go
@@ -40,6 +40,11 @@ var DevnetCommand = &cli.Command{
 					Usage: "Skip deploying contracts and only start local devnet",
 					Value: false,
 				},
+				&cli.BoolFlag{
+					Name:  "skip-setup",
+					Usage: "Skip AVS setup steps (metadata update, registrar setup, etc.) after contract deployment",
+					Value: false,
+				},
 			},
 			Action: StartDevnetAction,
 		},

--- a/pkg/commands/devnet_actions.go
+++ b/pkg/commands/devnet_actions.go
@@ -122,7 +122,7 @@ func StartDevnetAction(cCtx *cli.Context) error {
 		}
 		log.Info("AVS registered with EigenLayer successfully.")
 
-		if err := registerOperatorsFromConfig(cCtx, cfg); err != nil {
+		if err := registerOperatorsFromConfig(cCtx, config); err != nil {
 			return fmt.Errorf("registering operators failed: %w", err)
 		}
 	}

--- a/pkg/commands/devnet_test.go
+++ b/pkg/commands/devnet_test.go
@@ -151,12 +151,15 @@ func TestStartDevnet_WithDeployContracts(t *testing.T) {
 		Flags: []cli.Flag{
 			&cli.IntFlag{Name: "port"},
 			&cli.BoolFlag{Name: "verbose"},
+			&cli.BoolFlag{Name: "skip-deploy-contracts"},
+			&cli.BoolFlag{Name: "skip-setup"},
 		},
 		Action: StartDevnetAction,
 	}
 
 	stdout, stderr := testutils.CaptureOutput(func() {
-		err = app.Run([]string{"devkit", "--port", port})
+		// Use --skip-setup to avoid AVS setup steps while still deploying contracts
+		err = app.Run([]string{"devkit", "--port", port, "--skip-setup"})
 		assert.NoError(t, err)
 	})
 
@@ -253,13 +256,14 @@ func TestStartDevnet_SkipAVSRun(t *testing.T) {
 		Flags: []cli.Flag{
 			&cli.IntFlag{Name: "port"},
 			&cli.BoolFlag{Name: "verbose"},
+			&cli.BoolFlag{Name: "skip-setup"},
 			&cli.BoolFlag{Name: "skip-avs-run"},
 		},
 		Action: StartDevnetAction,
 	}
 
 	stdout, stderr := testutils.CaptureOutput(func() {
-		err = app.Run([]string{"devkit", "--port", port, "--skip-avs-run"})
+		err = app.Run([]string{"devkit", "--port", port, "--skip-setup", "--skip-avs-run"})
 		assert.NoError(t, err)
 	})
 

--- a/pkg/common/config.go
+++ b/pkg/common/config.go
@@ -27,6 +27,7 @@ type ForkConfig struct {
 }
 
 type OperatorSpec struct {
+	Address             string `json:"address" yaml:"address"`
 	ECDSAKey            string `json:"ecdsa_key" yaml:"ecdsa_key"`
 	BlsKeystorePath     string `json:"bls_keystore_path" yaml:"bls_keystore_path"`
 	BlsKeystorePassword string `json:"bls_keystore_password" yaml:"bls_keystore_password"`
@@ -41,6 +42,8 @@ type ChainContextConfig struct {
 	Operators             []OperatorSpec         `json:"operators" yaml:"operators"`
 	Avs                   AvsConfig              `json:"avs" yaml:"avs"`
 	DeployedContracts     []DeployedContract     `json:"deployed_contracts,omitempty" yaml:"deployed_contracts,omitempty"`
+	OperatorSets          []OperatorSet          `json:"operator_sets" yaml:"operator_sets"`
+	OperatorRegistrations []OperatorRegistration `json:"operator_registrations" yaml:"operator_registrations"`
 }
 
 type AvsConfig struct {
@@ -59,7 +62,9 @@ type ChainConfig struct {
 type DeployedContract struct {
 	Name    string `json:"name" yaml:"name"`
 	Address string `json:"address" yaml:"address"`
+	Abi     string `json:"abi" yaml:"abi"`
 }
+
 type ConfigWithContextConfig struct {
 	Config  ConfigBlock                   `json:"config" yaml:"config"`
 	Context map[string]ChainContextConfig `json:"context" yaml:"context"`
@@ -68,6 +73,21 @@ type ConfigWithContextConfig struct {
 type ContextConfig struct {
 	Version string             `json:"version" yaml:"version"`
 	Context ChainContextConfig `json:"context" yaml:"context"`
+}
+
+type OperatorSet struct {
+	OperatorSetID uint64     `json:"operator_set_id" yaml:"operator_set_id"`
+	Strategies    []Strategy `json:"strategies" yaml:"strategies"`
+}
+
+type Strategy struct {
+	StrategyAddress string `json:"strategy" yaml:"strategy"`
+}
+
+type OperatorRegistration struct {
+	Address       string `json:"address" yaml:"address"`
+	OperatorSetID uint64 `json:"operator_set_id" yaml:"operator_set_id"`
+	Payload       string `json:"payload" yaml:"payload"`
 }
 
 func LoadConfigWithContextConfig(contextName string) (*ConfigWithContextConfig, error) {

--- a/pkg/common/config_test.go
+++ b/pkg/common/config_test.go
@@ -51,7 +51,7 @@ func TestLoadConfigWithContextConfig_FromCopiedTempFile(t *testing.T) {
 	assert.Equal(t, 22475020, cfg.Context["devnet"].Chains["l1"].Fork.Block)
 	assert.Equal(t, 22475020, cfg.Context["devnet"].Chains["l1"].Fork.Block)
 
-	assert.Equal(t, "0x0123456789abcdef0123456789ABCDEF01234567", cfg.Context["devnet"].Avs.Address)
+	assert.Equal(t, "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266", cfg.Context["devnet"].Avs.Address)
 	assert.Equal(t, "0x0123456789abcdef0123456789ABCDEF01234567", cfg.Context["devnet"].Avs.RegistrarAddress)
 	assert.Equal(t, "https://my-org.com/avs/metadata.json", cfg.Context["devnet"].Avs.MetadataUri)
 

--- a/pkg/common/contract_caller.go
+++ b/pkg/common/contract_caller.go
@@ -1,0 +1,147 @@
+package common
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"fmt"
+	"math/big"
+	"strings"
+
+	allocationmanager "github.com/Layr-Labs/eigenlayer-contracts/pkg/bindings/AllocationManager"
+	delegationmanager "github.com/Layr-Labs/eigenlayer-contracts/pkg/bindings/DelegationManager"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
+)
+
+// TODO: Should we break this out into it's own package?
+type ContractCaller struct {
+	allocationManager *allocationmanager.AllocationManager
+	delegationManager *delegationmanager.DelegationManager
+	ethclient         *ethclient.Client
+	privateKey        *ecdsa.PrivateKey
+	chainID           *big.Int
+}
+
+func NewContractCaller(privateKeyHex string, chainID *big.Int, client *ethclient.Client, allocationManagerAddr, delegationManagerAddr common.Address) (*ContractCaller, error) {
+	privateKey, err := crypto.HexToECDSA(strings.TrimPrefix(privateKeyHex, "0x"))
+	if err != nil {
+		return nil, fmt.Errorf("invalid private key: %w", err)
+	}
+
+	allocationManager, err := allocationmanager.NewAllocationManager(allocationManagerAddr, client)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create AllocationManager: %w", err)
+	}
+
+	delegationManager, err := delegationmanager.NewDelegationManager(delegationManagerAddr, client)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create DelegationManager: %w", err)
+	}
+
+	return &ContractCaller{
+		allocationManager: allocationManager,
+		delegationManager: delegationManager,
+		ethclient:         client,
+		privateKey:        privateKey,
+		chainID:           chainID,
+	}, nil
+}
+
+func (cc *ContractCaller) buildTxOpts(ctx context.Context) (*bind.TransactOpts, error) {
+	opts, err := bind.NewKeyedTransactorWithChainID(cc.privateKey, cc.chainID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create transactor: %w", err)
+	}
+	return opts, nil
+}
+
+func (cc *ContractCaller) SendAndWaitForTransaction(
+	ctx context.Context,
+	txDescription string,
+	fn func() (*types.Transaction, error),
+) error {
+	log, _ := GetLogger()
+
+	tx, err := fn()
+	if err != nil {
+		log.Error("%s failed during execution: %v", txDescription, err)
+		return fmt.Errorf("%s execution: %w", txDescription, err)
+	}
+
+	receipt, err := bind.WaitMined(ctx, cc.ethclient, tx)
+	if err != nil {
+		log.Error("Waiting for %s transaction (hash: %s) failed: %v", txDescription, tx.Hash().Hex(), err)
+		return fmt.Errorf("waiting for %s transaction (hash: %s): %w", txDescription, tx.Hash().Hex(), err)
+	}
+	if receipt.Status == 0 {
+		log.Error("%s transaction (hash: %s) reverted", txDescription, tx.Hash().Hex())
+		return fmt.Errorf("%s transaction (hash: %s) reverted", txDescription, tx.Hash().Hex())
+	}
+	return nil
+}
+
+func (cc *ContractCaller) UpdateAVSMetadata(ctx context.Context, avsAddress common.Address, metadataURI string) error {
+	opts, err := cc.buildTxOpts(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to build transaction options: %w", err)
+	}
+
+	return cc.SendAndWaitForTransaction(ctx, "UpdateAVSMetadataURI", func() (*types.Transaction, error) {
+		return cc.allocationManager.UpdateAVSMetadataURI(opts, avsAddress, metadataURI)
+	})
+}
+
+// SetAVSRegistrar sets the registrar address for an AVS
+func (cc *ContractCaller) SetAVSRegistrar(ctx context.Context, avsAddress, registrarAddress common.Address) error {
+	opts, err := cc.buildTxOpts(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to build transaction options: %w", err)
+	}
+
+	return cc.SendAndWaitForTransaction(ctx, "SetAVSRegistrar", func() (*types.Transaction, error) {
+		return cc.allocationManager.SetAVSRegistrar(opts, avsAddress, registrarAddress)
+	})
+}
+
+// CreateOperatorSets creates operator sets for an AVS
+func (cc *ContractCaller) CreateOperatorSets(ctx context.Context, avsAddress common.Address, sets []allocationmanager.IAllocationManagerTypesCreateSetParams) error {
+	opts, err := cc.buildTxOpts(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to build transaction options: %w", err)
+	}
+
+	return cc.SendAndWaitForTransaction(ctx, "CreateOperatorSets", func() (*types.Transaction, error) {
+		return cc.allocationManager.CreateOperatorSets(opts, avsAddress, sets)
+	})
+}
+
+func (cc *ContractCaller) RegisterAsOperator(ctx context.Context, operatorAddress common.Address, allocationDelay uint32, metadataURI string) error {
+	opts, err := cc.buildTxOpts(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to build transaction options: %w", err)
+	}
+
+	return cc.SendAndWaitForTransaction(ctx, fmt.Sprintf("RegisterAsOperator for %s", operatorAddress.Hex()), func() (*types.Transaction, error) {
+		return cc.delegationManager.RegisterAsOperator(opts, operatorAddress, allocationDelay, metadataURI)
+	})
+}
+
+func (cc *ContractCaller) RegisterForOperatorSets(ctx context.Context, operatorAddress, avsAddress common.Address, operatorSetIDs []uint32, payload []byte) error {
+	opts, err := cc.buildTxOpts(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to build transaction options: %w", err)
+	}
+
+	params := allocationmanager.IAllocationManagerTypesRegisterParams{
+		Avs:            avsAddress,
+		OperatorSetIds: operatorSetIDs,
+		Data:           payload,
+	}
+
+	return cc.SendAndWaitForTransaction(ctx, fmt.Sprintf("RegisterForOperatorSets for %s", operatorAddress.Hex()), func() (*types.Transaction, error) {
+		return cc.allocationManager.RegisterForOperatorSets(opts, operatorAddress, params)
+	})
+}

--- a/pkg/common/devnet/constants.go
+++ b/pkg/common/devnet/constants.go
@@ -7,3 +7,7 @@ const FUND_VALUE = "10000000000000000000"
 const RPC_URL = "http://localhost:8545"
 const CONTEXT = "devnet"
 const L1 = "l1"
+
+// @TODO: Add core eigenlayer deployment addresses to context
+const ALLOCATION_MANAGER_ADDRESS = "0x948a420b8CC1d6BFd0B6087C2E7c344a2CD0bc39"
+const DELEGATION_MANAGER_ADDRESS = "0x39053D51B77DC0d36036Fc1fCc8Cb819df8Ef37A"


### PR DESCRIPTION
**Motivation:**
The devnet needs functionality to set up AVSs and register operators with EigenLayer.

**Modifications:**
- Added `ContractCaller` struct to handle interactions with EigenLayer core contracts:
- Added new devnet actions for AVS setup, surfacing as devnet subcommands is not needed at the moment, but has been left as a TODO 
- Integrated new actions into `StartDevnetAction`

Key technical decisions:
1. Created a dedicated `ContractCaller` struct to encapsulate core contract interactions
2. Made actions self-contained with their own validation and error handling
3. Used the existing config structure for operator and AVS information

**Result:**
After these changes:
- Users can set up an AVS on the devnet with proper metadata and registrar
- Operators can be registered with EigenLayer and for specific AVSs
- The process is automated during devnet startup

**Testing:**
- Manual testing:
  - Verified AVS setup flow in devnet
  - Tested operator registration with various AVS configurations
![Screenshot 2025-05-19 at 1 59 56 AM](https://github.com/user-attachments/assets/5e7d34c5-bfa1-44f7-8fd3-3f5a56922e9f)


**Open questions:**
1. Should we add more comprehensive tests for contract interactions? aka do we need an integration test suite
2. Do we need to add more validation for operator registration parameters?
4. Should we add an additional Debug log level? Might be useful when debugging any transaction issues.