### PR TITLE
chore: unique keys for devnet config

### DIFF
--- a/config/contexts/devnet.yaml
+++ b/config/contexts/devnet.yaml
@@ -22,37 +22,37 @@ context:
   # BLS keystores are deterministically pre-generated and embedded. These are NOT derived from a secure seed
   # Available private keys for deploying
   deployer_private_key: "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80" # Anvil Private Key 0
-  app_private_key: "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80" # Anvil Private Key 0
+  app_private_key: "0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a" # Anvil Private Key 2
   # List of Operators and their private keys / stake details
   operators:
-    - address: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
-      ecdsa_key: "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80" # Anvil Private Key 0
-      bls_keystore_path: "keystores/operator1.keystore.json"
-      bls_keystore_password: "testpass"
-      stake: "1000ETH"
-    - address: "0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
-      ecdsa_key: "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d" # Anvil Private Key 1
-      bls_keystore_path: "keystores/operator2.keystore.json"
-      bls_keystore_password: "testpass"
-      stake: "1000ETH"
-    - address: "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC"
-      ecdsa_key: "0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a" # Anvil Private Key 2
-      bls_keystore_path: "keystores/operator3.keystore.json"
-      bls_keystore_password: "testpass"
-      stake: "1000ETH"
     - address: "0x90F79bf6EB2c4f870365E785982E1f101E93b906"
       ecdsa_key: "0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6" # Anvil Private Key 3
-      bls_keystore_path: "keystores/operator4.keystore.json"
+      bls_keystore_path: "keystores/operator1.keystore.json"
       bls_keystore_password: "testpass"
       stake: "1000ETH"
     - address: "0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65"
       ecdsa_key: "0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a" # Anvil Private Key 4
+      bls_keystore_path: "keystores/operator2.keystore.json"
+      bls_keystore_password: "testpass"
+      stake: "1000ETH"
+    - address: "0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc"
+      ecdsa_key: "0x8b3a350cf5c34c9194ca85829a2df0ec3153be0318b5e2d3348e872092edffba" # Anvil Private Key 5
+      bls_keystore_path: "keystores/operator3.keystore.json"
+      bls_keystore_password: "testpass"
+      stake: "1000ETH"
+    - address: "0x976EA74026E726554dB657fA54763abd0C3a0aa9"
+      ecdsa_key: "0x92db14e403b83dfe3df233f83dfa3a0d7096f21ca9b0d6d6b8d88b2b4ec1564e" # Anvil Private Key 6
+      bls_keystore_path: "keystores/operator4.keystore.json"
+      bls_keystore_password: "testpass"
+      stake: "1000ETH"
+    - address: "0x14dC79964da2C08b23698B3D3cc7Ca32193d9955"
+      ecdsa_key: "0x4bbbf85ce3377467afe5d46f804f221813b2bb87f24d81f60f1fcdbf7cbf4356" # Anvil Private Key 7
       bls_keystore_path: "keystores/operator5.keystore.json"
       bls_keystore_password: "testpass"
       stake: "1000ETH"
   # AVS configuration
   avs:
-    address: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
-    avs_private_key: "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80" # Anvil Private Key 0
+    address: "0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
+    avs_private_key: "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d" # Anvil Private Key 1
     metadata_url: "https://my-org.com/avs/metadata.json"
     registrar_address: "0x0123456789abcdef0123456789ABCDEF01234567"

--- a/pkg/common/config_test.go
+++ b/pkg/common/config_test.go
@@ -36,7 +36,7 @@ func TestLoadConfigWithContextConfig_FromCopiedTempFile(t *testing.T) {
 	assert.Equal(t, "devnet", cfg.Config.Project.Context)
 
 	assert.Equal(t, "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80", cfg.Context["devnet"].DeployerPrivateKey)
-	assert.Equal(t, "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80", cfg.Context["devnet"].AppDeployerPrivateKey)
+	assert.Equal(t, "0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a", cfg.Context["devnet"].AppDeployerPrivateKey)
 
 	assert.Equal(t, "keystores/operator1.keystore.json", cfg.Context["devnet"].Operators[0].BlsKeystorePath)
 	assert.Equal(t, "keystores/operator2.keystore.json", cfg.Context["devnet"].Operators[1].BlsKeystorePath)
@@ -51,7 +51,7 @@ func TestLoadConfigWithContextConfig_FromCopiedTempFile(t *testing.T) {
 	assert.Equal(t, 22475020, cfg.Context["devnet"].Chains["l1"].Fork.Block)
 	assert.Equal(t, 22475020, cfg.Context["devnet"].Chains["l1"].Fork.Block)
 
-	assert.Equal(t, "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266", cfg.Context["devnet"].Avs.Address)
+	assert.Equal(t, "0x70997970C51812dc3A010C7d01b50e0d17dc79C8", cfg.Context["devnet"].Avs.Address)
 	assert.Equal(t, "0x0123456789abcdef0123456789ABCDEF01234567", cfg.Context["devnet"].Avs.RegistrarAddress)
 	assert.Equal(t, "https://my-org.com/avs/metadata.json", cfg.Context["devnet"].Avs.MetadataUri)
 


### PR DESCRIPTION


**Motivation:**


- Unique keys for app, deployer private keys , operators keys and avs address. So its more realistic

**Modifications:**

`devnet.yaml`

**Result:**

More realistic behaviour

**Testing:**
<!--
*List testing procedures taken and useful artifacts.
-->
**Open questions:**
<!--
(optional) Any open questions or feedback on design desired?
-->