### PR TITLE
feat: implement migration strategy for config and contexts

### DIFF
--- a/config/config_embeds.go
+++ b/config/config_embeds.go
@@ -2,22 +2,11 @@ package config
 
 import _ "embed"
 
-//go:embed config.yaml
-var DefaultConfigYaml string
-
 //go:embed templates.yaml
 var TemplatesYaml string
 
 //go:embed .gitignore
 var GitIgnore string
 
-//go:embed contexts/devnet.yaml
-var devnetContextYaml string
-
 //go:embed .env.example
 var EnvExample string
-
-// Map of context name → content
-var ContextYamls = map[string]string{
-	"devnet": devnetContextYaml,
-}

--- a/config/configs/registry.go
+++ b/config/configs/registry.go
@@ -1,0 +1,25 @@
+package configs
+
+import (
+	_ "embed"
+
+	"github.com/Layr-Labs/devkit-cli/pkg/migration"
+)
+
+// Set the latest version
+const LatestVersion = "0.0.1"
+
+// --
+// Versioned configs
+// --
+
+//go:embed v0.0.1.yaml
+var v0_0_1_default []byte
+
+// Map of context name -> content
+var ConfigYamls = map[string][]byte{
+	"0.0.1": v0_0_1_default,
+}
+
+// Map of sequential migrations
+var MigrationChain = []migration.MigrationStep{}

--- a/config/configs/v0.0.1.yaml
+++ b/config/configs/v0.0.1.yaml
@@ -1,0 +1,6 @@
+version: 0.0.1
+config:
+  project:
+    name: "my-avs"
+    version: "0.1.0"
+    context: "devnet"

--- a/config/contexts/migrations/v0.0.1-v0.0.2.go
+++ b/config/contexts/migrations/v0.0.1-v0.0.2.go
@@ -1,0 +1,40 @@
+package contextMigrations
+
+import (
+	"github.com/Layr-Labs/devkit-cli/pkg/migration"
+
+	"gopkg.in/yaml.v3"
+)
+
+func Migration_0_0_1_to_0_0_2(user, old, new *yaml.Node) (*yaml.Node, error) {
+	engine := migration.PatchEngine{
+		Old:  old,
+		New:  new,
+		User: user,
+		Rules: []migration.PatchRule{
+			{Path: []string{"context", "app_private_key"}, Condition: migration.IfUnchanged{}},
+			{Path: []string{"context", "operators", "0", "address"}, Condition: migration.IfUnchanged{}},
+			{Path: []string{"context", "operators", "0", "ecdsa_key"}, Condition: migration.IfUnchanged{}},
+			{Path: []string{"context", "operators", "1", "address"}, Condition: migration.IfUnchanged{}},
+			{Path: []string{"context", "operators", "1", "ecdsa_key"}, Condition: migration.IfUnchanged{}},
+			{Path: []string{"context", "operators", "2", "address"}, Condition: migration.IfUnchanged{}},
+			{Path: []string{"context", "operators", "2", "ecdsa_key"}, Condition: migration.IfUnchanged{}},
+			{Path: []string{"context", "operators", "3", "address"}, Condition: migration.IfUnchanged{}},
+			{Path: []string{"context", "operators", "3", "ecdsa_key"}, Condition: migration.IfUnchanged{}},
+			{Path: []string{"context", "operators", "4", "address"}, Condition: migration.IfUnchanged{}},
+			{Path: []string{"context", "operators", "4", "ecdsa_key"}, Condition: migration.IfUnchanged{}},
+			{Path: []string{"context", "avs", "address"}, Condition: migration.IfUnchanged{}},
+			{Path: []string{"context", "avs", "avs_private_key"}, Condition: migration.IfUnchanged{}},
+		},
+	}
+	err := engine.Apply()
+	if err != nil {
+		return nil, err
+	}
+
+	// bump version node
+	if v := migration.ResolveNode(user, []string{"version"}); v != nil {
+		v.Value = "0.0.2"
+	}
+	return user, nil
+}

--- a/config/contexts/registry.go
+++ b/config/contexts/registry.go
@@ -1,0 +1,44 @@
+package contexts
+
+import (
+	_ "embed"
+
+	"github.com/Layr-Labs/devkit-cli/pkg/migration"
+
+	contextMigrations "github.com/Layr-Labs/devkit-cli/config/contexts/migrations"
+)
+
+// Set the latest version
+const LatestVersion = "0.0.2"
+
+// Array of default contexts to create in project
+var DefaultContexts = [...]string{
+	"devnet",
+}
+
+// --
+// Versioned contexts
+// --
+
+//go:embed v0.0.1.yaml
+var v0_0_1_default []byte
+
+//go:embed v0.0.2.yaml
+var v0_0_2_default []byte
+
+// Map of context name -> content
+var ContextYamls = map[string][]byte{
+	"0.0.1": v0_0_1_default,
+	"0.0.2": v0_0_2_default,
+}
+
+// Map of sequential migrations
+var MigrationChain = []migration.MigrationStep{
+	{
+		From:    "0.0.1",
+		To:      "0.0.2",
+		Apply:   contextMigrations.Migration_0_0_1_to_0_0_2,
+		OldYAML: v0_0_1_default,
+		NewYAML: v0_0_2_default,
+	},
+}

--- a/config/contexts/v0.0.1.yaml
+++ b/config/contexts/v0.0.1.yaml
@@ -22,37 +22,37 @@ context:
   # BLS keystores are deterministically pre-generated and embedded. These are NOT derived from a secure seed
   # Available private keys for deploying
   deployer_private_key: "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80" # Anvil Private Key 0
-  app_private_key: "0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a" # Anvil Private Key 2
+  app_private_key: "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80" # Anvil Private Key 0
   # List of Operators and their private keys / stake details
   operators:
+    - address: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+      ecdsa_key: "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80" # Anvil Private Key 0
+      bls_keystore_path: "keystores/operator1.keystore.json"
+      bls_keystore_password: "testpass"
+      stake: "1000ETH"
+    - address: "0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
+      ecdsa_key: "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d" # Anvil Private Key 1
+      bls_keystore_path: "keystores/operator2.keystore.json"
+      bls_keystore_password: "testpass"
+      stake: "1000ETH"
+    - address: "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC"
+      ecdsa_key: "0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a" # Anvil Private Key 2
+      bls_keystore_path: "keystores/operator3.keystore.json"
+      bls_keystore_password: "testpass"
+      stake: "1000ETH"
     - address: "0x90F79bf6EB2c4f870365E785982E1f101E93b906"
       ecdsa_key: "0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6" # Anvil Private Key 3
-      bls_keystore_path: "keystores/operator1.keystore.json"
+      bls_keystore_path: "keystores/operator4.keystore.json"
       bls_keystore_password: "testpass"
       stake: "1000ETH"
     - address: "0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65"
       ecdsa_key: "0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a" # Anvil Private Key 4
-      bls_keystore_path: "keystores/operator2.keystore.json"
-      bls_keystore_password: "testpass"
-      stake: "1000ETH"
-    - address: "0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc"
-      ecdsa_key: "0x8b3a350cf5c34c9194ca85829a2df0ec3153be0318b5e2d3348e872092edffba" # Anvil Private Key 5
-      bls_keystore_path: "keystores/operator3.keystore.json"
-      bls_keystore_password: "testpass"
-      stake: "1000ETH"
-    - address: "0x976EA74026E726554dB657fA54763abd0C3a0aa9"
-      ecdsa_key: "0x92db14e403b83dfe3df233f83dfa3a0d7096f21ca9b0d6d6b8d88b2b4ec1564e" # Anvil Private Key 6
-      bls_keystore_path: "keystores/operator4.keystore.json"
-      bls_keystore_password: "testpass"
-      stake: "1000ETH"
-    - address: "0x14dC79964da2C08b23698B3D3cc7Ca32193d9955"
-      ecdsa_key: "0x4bbbf85ce3377467afe5d46f804f221813b2bb87f24d81f60f1fcdbf7cbf4356" # Anvil Private Key 7
       bls_keystore_path: "keystores/operator5.keystore.json"
       bls_keystore_password: "testpass"
       stake: "1000ETH"
   # AVS configuration
   avs:
-    address: "0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
-    avs_private_key: "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d" # Anvil Private Key 1
+    address: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+    avs_private_key: "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80" # Anvil Private Key 0
     metadata_url: "https://my-org.com/avs/metadata.json"
     registrar_address: "0x0123456789abcdef0123456789ABCDEF01234567"

--- a/config/contexts/v0.0.2.yaml
+++ b/config/contexts/v0.0.2.yaml
@@ -1,0 +1,58 @@
+# Devnet context to be used for local deployments against Anvil chain
+version: 0.0.2
+context:
+  # Name of the context
+  name: "devnet"
+  # Chains available to this context
+  chains:
+    l1: 
+      chain_id: 31337
+      rpc_url: "http://localhost:8545"
+      fork:
+        block: 22475020
+        url: "https://eth.llamarpc.com"
+    l2:
+      chain_id: 31337
+      rpc_url: "http://localhost:8545"
+      fork:
+        block: 22475020
+        url: "https://eth.llamarpc.com"
+  # All key material (BLS and ECDSA) within this file should be used for local testing ONLY
+  # ECDSA keys used are from Anvil's private key set
+  # BLS keystores are deterministically pre-generated and embedded. These are NOT derived from a secure seed
+  # Available private keys for deploying
+  deployer_private_key: "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80" # Anvil Private Key 0
+  app_private_key: "0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a" # Anvil Private Key 2
+  # List of Operators and their private keys / stake details
+  operators:
+    - address: "0x90F79bf6EB2c4f870365E785982E1f101E93b906"
+      ecdsa_key: "0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6" # Anvil Private Key 3
+      bls_keystore_path: "keystores/operator1.keystore.json"
+      bls_keystore_password: "testpass"
+      stake: "1000ETH"
+    - address: "0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65"
+      ecdsa_key: "0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a" # Anvil Private Key 4
+      bls_keystore_path: "keystores/operator2.keystore.json"
+      bls_keystore_password: "testpass"
+      stake: "1000ETH"
+    - address: "0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc"
+      ecdsa_key: "0x8b3a350cf5c34c9194ca85829a2df0ec3153be0318b5e2d3348e872092edffba" # Anvil Private Key 5
+      bls_keystore_path: "keystores/operator3.keystore.json"
+      bls_keystore_password: "testpass"
+      stake: "1000ETH"
+    - address: "0x976EA74026E726554dB657fA54763abd0C3a0aa9"
+      ecdsa_key: "0x92db14e403b83dfe3df233f83dfa3a0d7096f21ca9b0d6d6b8d88b2b4ec1564e" # Anvil Private Key 6
+      bls_keystore_path: "keystores/operator4.keystore.json"
+      bls_keystore_password: "testpass"
+      stake: "1000ETH"
+    - address: "0x14dC79964da2C08b23698B3D3cc7Ca32193d9955"
+      ecdsa_key: "0x4bbbf85ce3377467afe5d46f804f221813b2bb87f24d81f60f1fcdbf7cbf4356" # Anvil Private Key 7
+      bls_keystore_path: "keystores/operator5.keystore.json"
+      bls_keystore_password: "testpass"
+      stake: "1000ETH"
+  # AVS configuration
+  avs:
+    address: "0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
+    avs_private_key: "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d" # Anvil Private Key 1
+    metadata_url: "https://my-org.com/avs/metadata.json"
+    registrar_address: "0x0123456789abcdef0123456789ABCDEF01234567"

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ go 1.23.6
 
 toolchain go1.24.2
 
+replace github.com/Layr-Labs/devkit-cli => ./
+
 require (
 	github.com/Layr-Labs/eigenlayer-contracts v1.4.2
 	github.com/Layr-Labs/hourglass-monorepo/ponos v0.0.0-20250430200448-e0f09ac951eb

--- a/pkg/commands/basic_e2e_test.go
+++ b/pkg/commands/basic_e2e_test.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/Layr-Labs/devkit-cli/config"
+	"github.com/Layr-Labs/devkit-cli/config/configs"
 	"github.com/Layr-Labs/devkit-cli/pkg/hooks"
 
 	"github.com/stretchr/testify/assert"
@@ -59,7 +59,7 @@ func setupBasicProject(t *testing.T, dir string) {
 	assert.NoError(t, err)
 
 	// Create config.yaml (needed to identify project root)
-	eigenContent := config.DefaultConfigYaml
+	eigenContent := configs.ConfigYamls[configs.LatestVersion]
 	if err := os.WriteFile(filepath.Join(configDir, "config.yaml"), []byte(eigenContent), 0644); err != nil {
 		t.Fatalf("Failed to write config.yaml: %v", err)
 	}

--- a/pkg/commands/config_list_test.go
+++ b/pkg/commands/config_list_test.go
@@ -2,10 +2,13 @@ package commands
 
 import (
 	"bytes"
-	"github.com/Layr-Labs/devkit-cli/pkg/common"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/Layr-Labs/devkit-cli/config/configs"
+	"github.com/Layr-Labs/devkit-cli/config/contexts"
+	"github.com/Layr-Labs/devkit-cli/pkg/common"
 
 	"github.com/stretchr/testify/require"
 	"github.com/urfave/cli/v2"
@@ -14,12 +17,9 @@ import (
 func TestConfigCommand_ListOutput(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	defaultConfigPath := filepath.Join("..", "..", "config")
-	defaultConfigFile, err := os.ReadFile(filepath.Join(defaultConfigPath, common.BaseConfig))
-	require.NoError(t, err)
+	defaultConfigFile := configs.ConfigYamls[configs.LatestVersion]
+	defaultDevnetConfigFile := contexts.ContextYamls[contexts.LatestVersion]
 
-	defaultDevnetConfigFile, err := os.ReadFile(filepath.Join(defaultConfigPath, "contexts", "devnet.yaml"))
-	require.NoError(t, err)
 	configPath := filepath.Join(tmpDir, "config")
 	require.NoError(t, os.MkdirAll(configPath, 0755))
 	require.NoError(t, os.WriteFile(filepath.Join(configPath, common.BaseConfig), defaultConfigFile, 0644))
@@ -64,7 +64,7 @@ telemetry_enabled: true
 			},
 		},
 	}
-	err = app.Run([]string{"devkit", "avs", "config", "--list"})
+	err := app.Run([]string{"devkit", "avs", "config", "--list"})
 	require.NoError(t, err)
 
 	// 📤 Finish capturing output

--- a/pkg/commands/create.go
+++ b/pkg/commands/create.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 
 	"github.com/Layr-Labs/devkit-cli/config"
+	"github.com/Layr-Labs/devkit-cli/config/configs"
+	"github.com/Layr-Labs/devkit-cli/config/contexts"
 	"github.com/Layr-Labs/devkit-cli/pkg/common"
 	"github.com/Layr-Labs/devkit-cli/pkg/common/logger"
 	"github.com/Layr-Labs/devkit-cli/pkg/template"
@@ -276,7 +278,7 @@ func copyDefaultConfigToProject(targetDir, projectName string, verbose bool) err
 	}
 
 	// Read config.yaml from config embed and write to target
-	newContent := strings.Replace(config.DefaultConfigYaml, `name: "my-avs"`, fmt.Sprintf(`name: "%s"`, projectName), 1)
+	newContent := strings.Replace(string(configs.ConfigYamls[configs.LatestVersion]), `name: "my-avs"`, fmt.Sprintf(`name: "%s"`, projectName), 1)
 	err := os.WriteFile(filepath.Join(destConfigDir, common.BaseConfig), []byte(newContent), 0644)
 	if err != nil {
 		return fmt.Errorf("failed to write %s: %w", common.BaseConfig, err)
@@ -291,8 +293,9 @@ func copyDefaultConfigToProject(targetDir, projectName string, verbose bool) err
 	if err := os.MkdirAll(destContextsDir, 0755); err != nil {
 		return fmt.Errorf("failed to create target contexts directory: %w", err)
 	}
-	for name, yaml := range config.ContextYamls {
-		content := yaml
+	// copy latest version of context to project for default contexts
+	for _, name := range contexts.DefaultContexts {
+		content := contexts.ContextYamls[contexts.LatestVersion]
 		entryName := fmt.Sprintf("%s.yaml", name)
 
 		err := os.WriteFile(filepath.Join(destContextsDir, entryName), []byte(content), 0644)

--- a/pkg/commands/create_test.go
+++ b/pkg/commands/create_test.go
@@ -2,15 +2,18 @@ package commands
 
 import (
 	"context"
+
 	"errors"
 	"fmt"
-	"github.com/Layr-Labs/devkit-cli/config"
-	"github.com/Layr-Labs/devkit-cli/pkg/common"
-	"github.com/Layr-Labs/devkit-cli/pkg/testutils"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/Layr-Labs/devkit-cli/config/configs"
+	"github.com/Layr-Labs/devkit-cli/config/contexts"
+	"github.com/Layr-Labs/devkit-cli/pkg/common"
+	"github.com/Layr-Labs/devkit-cli/pkg/testutils"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli/v2"
@@ -19,7 +22,7 @@ import (
 func TestCreateCommand(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	mockConfigYaml := config.DefaultConfigYaml
+	mockConfigYaml := configs.ConfigYamls[configs.LatestVersion]
 	configDir := filepath.Join("config")
 	err := os.MkdirAll(configDir, 0755)
 	assert.NoError(t, err)
@@ -34,7 +37,7 @@ func TestCreateCommand(t *testing.T) {
 		}
 	}()
 
-	devnetYaml := config.ContextYamls["devnet"]
+	devnetYaml := contexts.ContextYamls[contexts.LatestVersion]
 	contextsDir := filepath.Join(configDir, "contexts")
 	err = os.MkdirAll(contextsDir, 0755)
 	assert.NoError(t, err)
@@ -208,7 +211,7 @@ func TestCreateCommand_WithTemplates(t *testing.T) {
 }
 
 func TestCreateCommand_ContextCancellation(t *testing.T) {
-	mockYaml := config.DefaultConfigYaml
+	mockYaml := configs.ConfigYamls[configs.LatestVersion]
 	if err := os.WriteFile("config.yaml", []byte(mockYaml), 0644); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/commands/devnet_actions.go
+++ b/pkg/commands/devnet_actions.go
@@ -54,7 +54,7 @@ func StartDevnetAction(cCtx *cli.Context) error {
 		if contextsMigrated == 1 {
 			suffix = ""
 		}
-		log.Info("%d context migration%s complete", suffix, contextsMigrated)
+		log.Info("%d context migration%s complete", contextsMigrated, suffix)
 	}
 
 	// Load config for devnet

--- a/pkg/commands/devnet_actions.go
+++ b/pkg/commands/devnet_actions.go
@@ -3,9 +3,8 @@ package commands
 import (
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
-	"github.com/Layr-Labs/devkit-cli/pkg/common"
-	"github.com/Layr-Labs/devkit-cli/pkg/common/devnet"
 	"math/big"
 	"os"
 	"os/exec"
@@ -13,6 +12,12 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/Layr-Labs/devkit-cli/config/configs"
+	"github.com/Layr-Labs/devkit-cli/config/contexts"
+	"github.com/Layr-Labs/devkit-cli/pkg/common"
+	"github.com/Layr-Labs/devkit-cli/pkg/common/devnet"
+	"github.com/Layr-Labs/devkit-cli/pkg/migration"
 
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -29,6 +34,28 @@ func StartDevnetAction(cCtx *cli.Context) error {
 	// Extract vars
 	skipAvsRun := cCtx.Bool("skip-avs-run")
 	skipDeployContracts := cCtx.Bool("skip-deploy-contracts")
+
+	// Migrate config
+	configMigrated, err := migrateConfig()
+	if err != nil {
+		log.Error("config migration failed: %w", err)
+	}
+	if configMigrated > 0 {
+		log.Info("Config migration complete")
+	}
+
+	// Migrate contexts
+	contextsMigrated, err := migrateContexts()
+	if err != nil {
+		log.Error("context migrations failed: %w", err)
+	}
+	if contextsMigrated > 0 {
+		suffix := "s"
+		if contextsMigrated == 1 {
+			suffix = ""
+		}
+		log.Info("%d context migration%s complete", suffix, contextsMigrated)
+	}
 
 	// Load config for devnet
 	config, err := common.LoadConfigWithContextConfig(devnet.CONTEXT)
@@ -89,7 +116,7 @@ func StartDevnetAction(cCtx *cli.Context) error {
 	rpcUrl := fmt.Sprintf("http://localhost:%d", port)
 	log.Info("Waiting for devnet to be ready...")
 
-	// Set path for context yaml
+	// Set path for context yamls
 	contextDir := filepath.Join("config", "contexts")
 	yamlPath := path.Join(contextDir, "devnet.yaml")
 
@@ -734,4 +761,79 @@ func registerOperatorAVS(cCtx *cli.Context, operatorAddress string, operatorSetI
 		[]uint32{operatorSetID},
 		payloadBytes,
 	)
+}
+
+func migrateConfig() (int, error) {
+	// Get logger
+	log, _ := common.GetLogger()
+
+	// Set path for context yamls
+	configDir := filepath.Join("config")
+	configPath := filepath.Join(configDir, "config.yaml")
+
+	// Migrate the config
+	err := migration.MigrateYaml(configPath, configs.LatestVersion, configs.MigrationChain)
+	// Check for already upto date and ignore
+	alreadyUptoDate := errors.Is(err, migration.ErrAlreadyUpToDate)
+
+	// For any other error, migration has failed
+	if err != nil && !alreadyUptoDate {
+		return 0, fmt.Errorf("failed to migrate: %v", err)
+	}
+
+	// If config was migrated
+	if !alreadyUptoDate {
+		log.Info("Migrated %s\n", configPath)
+
+		return 1, nil
+	}
+
+	return 0, nil
+}
+
+func migrateContexts() (int, error) {
+	// Get logger
+	log, _ := common.GetLogger()
+
+	// Count the number of contexts we migrate
+	contextsMigrated := 0
+
+	// Set path for context yamls
+	contextDir := filepath.Join("config", "contexts")
+
+	// Read all contexts/*.yamls
+	entries, err := os.ReadDir(contextDir)
+	if err != nil {
+		return 0, fmt.Errorf("unable to read context directory: %v", err)
+	}
+
+	// Attempt to upgrade every entry
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".yaml") {
+			continue
+		}
+		contextPath := filepath.Join(contextDir, e.Name())
+
+		// Migrate the context
+		err := migration.MigrateYaml(contextPath, contexts.LatestVersion, contexts.MigrationChain)
+		// Check for already upto date and ignore
+		alreadyUptoDate := errors.Is(err, migration.ErrAlreadyUpToDate)
+
+		// For every other error, migration failed
+		if err != nil && !alreadyUptoDate {
+			log.Error("failed to migrate: %v", err)
+			continue
+		}
+
+		// If context was migrated
+		if !alreadyUptoDate {
+			// Incr number of contextsMigrated
+			contextsMigrated += 1
+
+			// If migration succeeds
+			log.Info("Migrated %s\n", contextPath)
+		}
+	}
+
+	return contextsMigrated, nil
 }

--- a/pkg/common/config_test.go
+++ b/pkg/common/config_test.go
@@ -2,11 +2,15 @@ package common_test
 
 import (
 	"fmt"
-	"github.com/Layr-Labs/devkit-cli/config"
-	"github.com/Layr-Labs/devkit-cli/pkg/common"
+
+	"github.com/Layr-Labs/devkit-cli/config/configs"
+	"github.com/Layr-Labs/devkit-cli/config/contexts"
+
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/Layr-Labs/devkit-cli/pkg/common"
 
 	"github.com/stretchr/testify/assert"
 	"sigs.k8s.io/yaml"
@@ -18,14 +22,14 @@ func TestLoadConfigWithContextConfig_FromCopiedTempFile(t *testing.T) {
 	tmpYamlPath := filepath.Join(tmpDir, common.BaseConfig)
 
 	// Copy config/config.yaml to tempDir
-	assert.NoError(t, os.WriteFile(tmpYamlPath, []byte(config.DefaultConfigYaml), 0644))
+	assert.NoError(t, os.WriteFile(tmpYamlPath, []byte(configs.ConfigYamls[configs.LatestVersion]), 0644))
 
 	// Copy config/contexts/devnet.yaml to tempDir/config/contexts
 	tmpContextDir := filepath.Join(tmpDir, "config", "contexts")
 	assert.NoError(t, os.MkdirAll(tmpContextDir, 0755))
 
 	tmpDevnetPath := filepath.Join(tmpContextDir, "devnet.yaml")
-	assert.NoError(t, os.WriteFile(tmpDevnetPath, []byte(config.ContextYamls["devnet"]), 0644))
+	assert.NoError(t, os.WriteFile(tmpDevnetPath, []byte(contexts.ContextYamls[contexts.LatestVersion]), 0644))
 
 	// Run loader with the new base path
 	cfg, err := LoadConfigWithContextConfigFromPath("devnet", tmpDir)

--- a/pkg/common/upgrade_config.go
+++ b/pkg/common/upgrade_config.go
@@ -1,0 +1,1 @@
+package common

--- a/pkg/common/upgrade_context.go
+++ b/pkg/common/upgrade_context.go
@@ -1,0 +1,1 @@
+package common

--- a/pkg/common/yaml.go
+++ b/pkg/common/yaml.go
@@ -21,6 +21,23 @@ func LoadYAML(path string) (*yaml.Node, error) {
 	return &node, nil
 }
 
+// LoadMap loads the YAML file at path into a map[string]interface{}
+func LoadMap(path string) (map[string]interface{}, error) {
+	node, err := LoadYAML(path)
+	if err != nil {
+		return nil, err
+	}
+	iface, err := NodeToInterface(node)
+	if err != nil {
+		return nil, err
+	}
+	m, ok := iface.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("expected map at top level, got %T", iface)
+	}
+	return m, nil
+}
+
 // WriteYAML encodes a *yaml.Node to YAML and writes it to the specified file path
 func WriteYAML(path string, node *yaml.Node) error {
 	buf := &bytes.Buffer{}
@@ -31,6 +48,15 @@ func WriteYAML(path string, node *yaml.Node) error {
 	}
 	enc.Close()
 	return os.WriteFile(path, buf.Bytes(), 0644)
+}
+
+// WriteMap takes a map[string]interface{} and writes it back to a file
+func WriteMap(path string, m map[string]interface{}) error {
+	node, err := InterfaceToNode(m)
+	if err != nil {
+		return err
+	}
+	return WriteYAML(path, node)
 }
 
 // InterfaceToNode converts a Go value (typically map[string]interface{}) into a *yaml.Node

--- a/pkg/migration/migrator.go
+++ b/pkg/migration/migrator.go
@@ -1,0 +1,290 @@
+package migration
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/Layr-Labs/devkit-cli/pkg/common"
+	"gopkg.in/yaml.v3"
+)
+
+// PatchCondition defines a node-level condition
+type PatchCondition interface {
+	// ShouldApply returns true if the userNode should be patched based on oldNode
+	ShouldApply(userNode, oldNode *yaml.Node) bool
+}
+
+// Available conditions
+type Always struct{}
+type IfUnchanged struct{}
+
+// Always applies unconditionally
+func (Always) ShouldApply(_, _ *yaml.Node) bool { return true }
+
+// IfUnchanged applies only if userNode equals oldNode
+func (IfUnchanged) ShouldApply(userNode, oldNode *yaml.Node) bool {
+	ub, _ := yaml.Marshal(userNode)
+	ob, _ := yaml.Marshal(oldNode)
+	return bytes.Equal(ub, ob)
+}
+
+// PatchRule defines a YAML node patch rule
+type PatchRule struct {
+	// Path: sequence of map keys or sequence indices (as strings)
+	Path []string
+	// Condition: returns true if the patch should apply
+	Condition PatchCondition
+	// Transform: optional node-level transformation on the new node
+	Transform func(newNode *yaml.Node) *yaml.Node
+	// Remove: if true, delete the node instead of patching
+	Remove bool
+}
+
+// MigrationStep represents one version-to-version migration
+type MigrationStep struct {
+	From    string
+	To      string
+	Apply   func(user, oldDef, newDef *yaml.Node) (*yaml.Node, error)
+	OldYAML []byte
+	NewYAML []byte
+}
+
+// PatchEngine applies a set of PatchRule against a user YAML AST preserving order, comments, and anchors
+type PatchEngine struct {
+	Old   *yaml.Node
+	New   *yaml.Node
+	User  *yaml.Node
+	Rules []PatchRule
+}
+
+// VersionGreaterThan uses semantic dot-separated compare for strings
+type VersionComparator func(string, string) bool
+
+// Known errors which we can ignore
+var ErrAlreadyUpToDate = errors.New("already up to date")
+
+// Apply walks each rule, and when Condition is met, either removes the node or replaces it with a (transformed) copy
+func (e *PatchEngine) Apply() error {
+	for _, rule := range e.Rules {
+		userNode := ResolveNode(e.User, rule.Path)
+		oldNode := ResolveNode(e.Old, rule.Path)
+		newNode := ResolveNode(e.New, rule.Path)
+		if userNode == nil || oldNode == nil {
+			continue
+		}
+		if rule.Condition.ShouldApply(userNode, oldNode) {
+			parent, idx := findParent(e.User, rule.Path)
+			if rule.Remove {
+				if parent != nil {
+					deleteNode(parent, idx)
+				}
+				continue
+			}
+			// choose replacement
+			repl := newNode
+			if rule.Transform != nil {
+				repl = rule.Transform(CloneNode(newNode))
+			}
+			// overwrite in place
+			*userNode = *CloneNode(repl)
+		}
+	}
+	return nil
+}
+
+// Run all migrations after current version upto latestVersion according to migrationChain
+func MigrateYaml(path string, latestVersion string, migrationChain []MigrationStep) error {
+	// Get logger
+	log, _ := common.GetLogger()
+
+	// Load as YAML AST
+	userNode, err := common.LoadYAML(path)
+	if err != nil {
+		return fmt.Errorf("load error %s: %v", path, err)
+	}
+
+	// Extract version scalar
+	verNode := ResolveNode(userNode, []string{"version"})
+	if verNode == nil {
+		return fmt.Errorf("no version field %s", path)
+	}
+	from := verNode.Value
+	to := latestVersion
+
+	// Continue and don't say anything if the user version is latest
+	if from == to {
+		return ErrAlreadyUpToDate
+	}
+	log.Info("Migrating config.yaml v%s -> v%s", from, to)
+
+	// Perform node-based migration
+	migrated, err := MigrateNode(userNode, from, to, migrationChain)
+	if err != nil {
+		return fmt.Errorf("migration failed %s: %v", path, err)
+	}
+
+	// Write AST back to disk
+	if err := common.WriteYAML(path, migrated); err != nil {
+		return fmt.Errorf("failed to write %s: %v", path, err)
+	}
+
+	return nil
+}
+
+// MigrateNode runs all MigrationStep from 'from' to 'to' on the provided user YAML AST, returning the migrated AST
+func MigrateNode(
+	user *yaml.Node,
+	from, to string,
+	chain []MigrationStep,
+) (*yaml.Node, error) {
+	// End early if from == to
+	if from == to {
+		return user, ErrAlreadyUpToDate
+	}
+	current := from
+	for _, step := range chain {
+		if step.From != current {
+			continue
+		}
+		if versionGreaterThan(step.To, to) {
+			break
+		}
+		oldDef := &yaml.Node{}
+		yaml.Unmarshal(step.OldYAML, oldDef)
+		newDef := &yaml.Node{}
+		yaml.Unmarshal(step.NewYAML, newDef)
+
+		var err error
+		user, err = step.Apply(user, oldDef, newDef)
+		if err != nil {
+			return nil, fmt.Errorf("migration %s->%s failed: %w", step.From, step.To, err)
+		}
+		current = step.To
+	}
+	if current != to {
+		return nil, fmt.Errorf("incomplete migration: ended at %s, target %s", current, to)
+	}
+	return user, nil
+}
+
+// ResolveNode walks the YAML AST following path segments and returns the node or nil
+func ResolveNode(root *yaml.Node, path []string) *yaml.Node {
+	// if DocumentNode, unwrap
+	if root.Kind == yaml.DocumentNode && len(root.Content) > 0 {
+		root = root.Content[0]
+	}
+	curr := root
+	for i, p := range path {
+		switch curr.Kind {
+		case yaml.MappingNode:
+			for j := 0; j < len(curr.Content)-1; j += 2 {
+				if curr.Content[j].Value == p {
+					curr = curr.Content[j+1]
+					break
+				}
+			}
+		case yaml.SequenceNode:
+			idx, err := strconv.Atoi(p)
+			if err != nil || idx < 0 || idx >= len(curr.Content) {
+				return nil
+			}
+			curr = curr.Content[idx]
+		default:
+			return nil
+		}
+		if curr == nil {
+			return nil
+		}
+		if i == len(path)-1 {
+			return curr
+		}
+	}
+	return curr
+}
+
+// CloneNode deep-copies a *yaml.Node, preserving comments and anchors
+func CloneNode(n *yaml.Node) *yaml.Node {
+	if n == nil {
+		return nil
+	}
+	c := *n
+	c.Content = make([]*yaml.Node, len(n.Content))
+	for i, ch := range n.Content {
+		c.Content[i] = CloneNode(ch)
+	}
+	return &c
+}
+
+// findParent locates the parent mapping or sequence node and the index/key position
+func findParent(root *yaml.Node, path []string) (*yaml.Node, int) {
+	if len(path) == 0 {
+		return nil, -1
+	}
+	curr := root
+	for _, p := range path[:len(path)-1] {
+		switch curr.Kind {
+		case yaml.MappingNode:
+			for j := 0; j < len(curr.Content)-1; j += 2 {
+				if curr.Content[j].Value == p {
+					// next node is value
+					curr = curr.Content[j+1]
+					break
+				}
+			}
+		case yaml.SequenceNode:
+			idx, _ := strconv.Atoi(p)
+			if idx < len(curr.Content) {
+				curr = curr.Content[idx]
+			}
+		}
+	}
+	// now curr is parent of target
+	target := path[len(path)-1]
+	// mapping parent
+	if curr.Kind == yaml.MappingNode {
+		for j := 0; j < len(curr.Content)-1; j += 2 {
+			if curr.Content[j].Value == target {
+				return curr, j // delete key at j and value at j+1
+			}
+		}
+	}
+	// sequence parent
+	if curr.Kind == yaml.SequenceNode {
+		idx, _ := strconv.Atoi(target)
+		return curr, idx
+	}
+	return nil, -1
+}
+
+// deleteNode removes a key/value pair from a mapping or an element from a sequence
+func deleteNode(parent *yaml.Node, idx int) {
+	if parent.Kind == yaml.MappingNode && idx%2 == 0 {
+		// remove key and value
+		parent.Content = append(parent.Content[:idx], parent.Content[idx+2:]...)
+	} else if parent.Kind == yaml.SequenceNode {
+		// remove element
+		parent.Content = append(parent.Content[:idx], parent.Content[idx+1:]...)
+	}
+}
+
+func versionLessThan(v1, v2 string) bool {
+	s1 := strings.Split(v1, ".")
+	s2 := strings.Split(v2, ".")
+	for i := 0; i < len(s1) && i < len(s2); i++ {
+		n1, _ := strconv.Atoi(s1[i])
+		n2, _ := strconv.Atoi(s2[i])
+		if n1 < n2 {
+			return true
+		} else if n1 > n2 {
+			return false
+		}
+	}
+	return len(s1) < len(s2)
+}
+
+func versionGreaterThan(v1, v2 string) bool {
+	return versionLessThan(v2, v1)
+}

--- a/pkg/migration/migrator_test.go
+++ b/pkg/migration/migrator_test.go
@@ -95,9 +95,9 @@ param: old
 	if err := engine.Apply(); err != nil {
 		t.Fatalf("Apply failed: %v", err)
 	}
-	pn := ResolveNode(user, []string{"param"})
-	if pn == nil || pn.Value != "new" {
-		t.Errorf("Expected param=new, got %v", pn.Value)
+	on := ResolveNode(user, []string{"param"})
+	if on == nil || on.Value != "new" {
+		t.Errorf("Expected param=new, got %v", on.Value)
 	}
 }
 

--- a/pkg/migration/migrator_test.go
+++ b/pkg/migration/migrator_test.go
@@ -1,0 +1,112 @@
+package migration
+
+import (
+	"errors"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// helper to parse YAML into *yaml.Node
+func testNode(t *testing.T, input string) *yaml.Node {
+	var node yaml.Node
+	if err := yaml.Unmarshal([]byte(input), &node); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	// unwrap DocumentNode
+	if node.Kind == yaml.DocumentNode && len(node.Content) > 0 {
+		return node.Content[0]
+	}
+	return &node
+}
+
+func TestResolveNode(t *testing.T) {
+	src := `
+version: v1
+nested:
+  key: value
+list:
+  - a
+  - b
+`
+	node := testNode(t, src)
+
+	// scalar
+	vn := ResolveNode(node, []string{"version"})
+	if vn == nil || vn.Value != "v1" {
+		t.Error("ResolveNode version failed")
+	}
+
+	// nested
+	kn := ResolveNode(node, []string{"nested", "key"})
+	if kn == nil || kn.Value != "value" {
+		t.Error("ResolveNode nested.key failed")
+	}
+
+	// list
+	ln := ResolveNode(node, []string{"list", "1"})
+	if ln == nil || ln.Value != "b" {
+		t.Error("ResolveNode list[1] failed")
+	}
+}
+
+func TestCloneNode(t *testing.T) {
+	src := `key: orig`
+	n := testNode(t, src)
+	clone := CloneNode(n)
+
+	// modify clone
+	clone.Content[1].Value = "new"
+
+	orig := testNode(t, src)
+	ov := ResolveNode(orig, []string{"key"})
+	if ov == nil || ov.Value != "orig" {
+		t.Error("CloneNode did not deep copy")
+	}
+}
+
+func TestPatchEngine_Apply(t *testing.T) {
+	yamlOld := `
+version: v1
+param: old
+`
+	yamlNew := `
+version: v1
+param: new
+`
+	yamlUser := `
+version: v1
+param: old
+`
+
+	oldDef := testNode(t, yamlOld)
+	newDef := testNode(t, yamlNew)
+	user := testNode(t, yamlUser)
+
+	engine := PatchEngine{
+		Old:  oldDef,
+		New:  newDef,
+		User: user,
+		Rules: []PatchRule{{
+			Path:      []string{"param"},
+			Condition: IfUnchanged{},
+		}},
+	}
+	if err := engine.Apply(); err != nil {
+		t.Fatalf("Apply failed: %v", err)
+	}
+	pn := ResolveNode(user, []string{"param"})
+	if pn == nil || pn.Value != "new" {
+		t.Errorf("Expected param=new, got %v", pn.Value)
+	}
+}
+
+func TestMigrateNode_AlreadyUpToDate(t *testing.T) {
+	yamlUser := `version: v1`
+	node := testNode(t, yamlUser)
+	// empty chain
+	_, err := MigrateNode(node, "v1", "v1", nil)
+	if !errors.Is(err, ErrAlreadyUpToDate) {
+		t.Error("Expected ErrAlreadyUpToDate")
+	}
+}

--- a/pkg/testutils/utils.go
+++ b/pkg/testutils/utils.go
@@ -3,12 +3,15 @@ package testutils
 import (
 	"bytes"
 	"context"
+
 	"fmt"
-	"github.com/Layr-Labs/devkit-cli/config"
-	"github.com/Layr-Labs/devkit-cli/pkg/common"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/Layr-Labs/devkit-cli/config/configs"
+	"github.com/Layr-Labs/devkit-cli/config/contexts"
+	"github.com/Layr-Labs/devkit-cli/pkg/common"
 
 	"github.com/urfave/cli/v2"
 )
@@ -49,7 +52,7 @@ func CreateTempAVSProject(t *testing.T) (string, error) {
 
 	// Copy config.yaml
 	destConfigFile := filepath.Join(destConfigDir, common.BaseConfig)
-	err = os.WriteFile(destConfigFile, []byte(config.DefaultConfigYaml), 0644)
+	err = os.WriteFile(destConfigFile, []byte(configs.ConfigYamls[configs.LatestVersion]), 0644)
 	if err != nil {
 		return "", fmt.Errorf("failed to copy %s: %w", common.BaseConfig, err)
 	}
@@ -61,8 +64,8 @@ func CreateTempAVSProject(t *testing.T) (string, error) {
 	}
 
 	// Copy devnet.yaml context file
-	destDevnetFile := filepath.Join(destContextsDir, "devnet.yaml")
-	err = os.WriteFile(destDevnetFile, []byte(config.ContextYamls["devnet"]), 0644)
+	destDevnetFile := filepath.Join(destContextsDir, "devnet.yaml") // this "devnet" should be supplied by selected context
+	err = os.WriteFile(destDevnetFile, []byte(contexts.ContextYamls[contexts.LatestVersion]), 0644)
 	if err != nil {
 		return "", fmt.Errorf("failed to create config/contexts/devnet.yaml: %w", err)
 	}


### PR DESCRIPTION
## Motivation
We need a robust, flexible YAML migration engine that preserves file ordering, comments, user changes, and allows rule-based upgrades across schema versions.

## Modifications
- **Node-based core**  
  Added `PatchRule`, `PatchCondition` (`Always`/`IfUnchanged`), and `PatchEngine` in `pkg/migration` for AST-level patching
- **AST helpers**  
  Created `ResolveNode`, `CloneNode`, `findParent`, and `deleteNode`, and helpers for safe traversal, mutation, and deep copying
- **Migration runner**  
  Implemented `MigrateYaml` with version chain support and an `ErrAlreadyUpToDate` sentinel for no-op cases
- **Version registry**  
  Defined the full migration chain in `config/configs/registry.go` and `config/contexts/registry.go` using embedded YAML defaults and sequential `NodeMigrationStep` entries
- **Initial migration**  
   `v0.0.1 → v0.0.2` in `config/contexts/migrations` to handle yesterdays migration
- **Unit tests**  
  Added unit and integration tests in `pkg/migration/migrator_test.go` covering:
  - `ResolveNode` path resolution
  - `CloneNode` deep-copy
  - `PatchEngine.Apply` behaviour
  - Sentinel `ErrAlreadyUpToDate`

## Result
- AST-driven YAML migration framework
- Declarative migration rules (`Path` / `Condition` / `Transform` / `Remove`)
- Config and Context files are updated in-place without losing formatting, comments, or anchors

## Testing
1. Run `go test ./pkg/migration` to validate AST helpers and engine logic
2. Manual e2e on users `config/contexts/devnet.yaml` confirms only intended fields update, preserving all other content

## Open questions
- Should we expose a DSL for defining patch rules outside Go code?  
- Would a “dry-run” preview mode improve safety for large or complex YAMLs?
- Should we record metrics for this operation?
- Is there an approach we can take which won't bloat the binary?
