### PR TITLE
feat: make setting fork_url a required step

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Starts a local devnet to simulate the full AVS environment. This step deploys co
 > Add them to your `.env` (copied from `.env.example`) or to `config/context/devnet.yaml`.
 
 
-* Forks Ethereum mainnet using a fork URL (provided by you) and a block number. These URLs CAN be set in the `config/context/devnet.yaml`, but we recommend placing them in a `.env` file. Please see `.env.example`.
+* Forks Ethereum mainnet using a fork URL (provided by you) and a block number. These URLs CAN be set in the `config/context/devnet.yaml`, but we recommend placing them in a `.env` file which will take precedence over `config/context/devnet.yaml`. Please see `.env.example`.
 * Automatically funds wallets (`operator_keys` and `submit_wallet`) if balances are below `10 ether`.
 * Setup required `AVS` contracts.
 * Register `AVS` and `Operators`.

--- a/README.md
+++ b/README.md
@@ -127,14 +127,23 @@ devkit avs build
 
 Starts a local devnet to simulate the full AVS environment. This step deploys contracts, registers operators, and runs offchain infrastructure, allowing you to test and iterate without needing to interact with testnet or mainnet.
 
+> 🚨 **IMPORTANT:** You **must** set a valid `*_FORK_URL`s before running this command.  
+> Add them to your `.env` (copied from `.env.example`) or to `config/context/devnet.yaml`.
+
+
 * Forks Ethereum mainnet using a fork URL (provided by you) and a block number. These URLs CAN be set in the `config/context/devnet.yaml`, but we recommend placing them in a `.env` file. Please see `.env.example`.
 * Automatically funds wallets (`operator_keys` and `submit_wallet`) if balances are below `10 ether`.
 * Setup required `AVS` contracts.
 * Register `AVS` and `Operators`.
 
-> Note: You must provide a fork URL that forks from Ethereum mainnet. You can use any popular RPC provider such as QuickNode or Alchemy.
+> **Note:** Use any popular RPC provider (e.g. QuickNode, Alchemy) for `FORK_URL`.
 
 This step is essential for simulating your AVS environment in a fully self-contained way, enabling fast iteration on your AVS business logic without needing to deploy to testnet/mainnet or coordinate with live operators.
+
+```
+$ cp .env.example .env
+# edit `.env` and set your L1_FORK_URL and L2_FORK_URL before proceeding
+```
 
 Run this from your project directory:
 

--- a/config/contexts/migrations/v0.0.1-v0.0.2.go
+++ b/config/contexts/migrations/v0.0.1-v0.0.2.go
@@ -12,6 +12,8 @@ func Migration_0_0_1_to_0_0_2(user, old, new *yaml.Node) (*yaml.Node, error) {
 		New:  new,
 		User: user,
 		Rules: []migration.PatchRule{
+			{Path: []string{"context", "chains", "l1", "fork", "url"}, Condition: migration.IfUnchanged{}},
+			{Path: []string{"context", "chains", "l2", "fork", "url"}, Condition: migration.IfUnchanged{}},
 			{Path: []string{"context", "app_private_key"}, Condition: migration.IfUnchanged{}},
 			{Path: []string{"context", "operators", "0", "address"}, Condition: migration.IfUnchanged{}},
 			{Path: []string{"context", "operators", "0", "ecdsa_key"}, Condition: migration.IfUnchanged{}},

--- a/config/contexts/v0.0.2.yaml
+++ b/config/contexts/v0.0.2.yaml
@@ -10,13 +10,13 @@ context:
       rpc_url: "http://localhost:8545"
       fork:
         block: 22475020
-        url: "https://eth.llamarpc.com"
+        url: ""
     l2:
       chain_id: 31337
       rpc_url: "http://localhost:8545"
       fork:
         block: 22475020
-        url: "https://eth.llamarpc.com"
+        url: ""
   # All key material (BLS and ECDSA) within this file should be used for local testing ONLY
   # ECDSA keys used are from Anvil's private key set
   # BLS keystores are deterministically pre-generated and embedded. These are NOT derived from a secure seed

--- a/pkg/commands/devnet_actions.go
+++ b/pkg/commands/devnet_actions.go
@@ -94,6 +94,11 @@ func StartDevnetAction(cCtx *cli.Context) error {
 		return fmt.Errorf("%w", err)
 	}
 
+	// Error if the fork_url has not been modified
+	if fork_url == "https://eth.llamarpc.com" {
+		return fmt.Errorf("fork-url not set; set fork-url in ./config/context/devnet.yaml or .env and consult README for guidance")
+	}
+
 	// Run docker compose up for anvil devnet
 	cmd := exec.CommandContext(cCtx.Context, "docker", "compose", "-p", config.Config.Project.Name, "-f", composePath, "up", "-d")
 

--- a/pkg/commands/devnet_actions.go
+++ b/pkg/commands/devnet_actions.go
@@ -95,7 +95,7 @@ func StartDevnetAction(cCtx *cli.Context) error {
 	}
 
 	// Error if the fork_url has not been modified
-	if fork_url == "https://eth.llamarpc.com" {
+	if fork_url == "" {
 		return fmt.Errorf("fork-url not set; set fork-url in ./config/context/devnet.yaml or .env and consult README for guidance")
 	}
 

--- a/pkg/common/devnet/getters.go
+++ b/pkg/common/devnet/getters.go
@@ -53,7 +53,7 @@ func GetDevnetForkUrlDefault(cfg *common.ConfigWithContextConfig, chainName stri
 		return "", fmt.Errorf("failed to get chainConfig for chainName : %s", chainName)
 	}
 	if chainConfig.Fork.Url == "" {
-		return "", fmt.Errorf("no fork URL configured for chain: %s", chainName)
+		return "", fmt.Errorf("fork-url not set for %s; set fork-url in ./config/context/devnet.yaml or .env and consult README for guidance", chainName)
 	}
 	return chainConfig.Fork.Url, nil
 }

--- a/pkg/testutils/utils.go
+++ b/pkg/testutils/utils.go
@@ -3,7 +3,6 @@ package testutils
 import (
 	"bytes"
 	"context"
-
 	"fmt"
 	"os"
 	"path/filepath"
@@ -63,8 +62,12 @@ func CreateTempAVSProject(t *testing.T) (string, error) {
 		return "", fmt.Errorf("failed to create config/contexts dir: %w", err)
 	}
 
+	// Set fork_urls as envs
+	os.Setenv("L1_FORK_URL", "https://eth.llamarpc.com")
+	os.Setenv("L2_FORK_URL", "https://eth.llamarpc.com")
+
 	// Copy devnet.yaml context file
-	destDevnetFile := filepath.Join(destContextsDir, "devnet.yaml") // this "devnet" should be supplied by selected context
+	destDevnetFile := filepath.Join(destContextsDir, "devnet.yaml")
 	err = os.WriteFile(destDevnetFile, []byte(contexts.ContextYamls[contexts.LatestVersion]), 0644)
 	if err != nil {
 		return "", fmt.Errorf("failed to create config/contexts/devnet.yaml: %w", err)


### PR DESCRIPTION
<!-- 
    🚨 ATTENTION! 🚨 
    
    This PR template is REQUIRED. PRs not following this format will be closed without review.
    
    Requirements:
    - PR title must follow commit conventions: https://www.conventionalcommits.org/en/v1.0.0/
    - Label your PR with the correct type (e.g., 🐛 Bug, ✨ Enhancement, 🧪 Test, etc.)
    - Provide clear and specific details in each section
-->

**Motivation:**
<!--
Explain here the context, and why you're making that change. What is the problem you're trying to solve.
-->
Having `https://eth.llamarpc.com` as the default `fork_url` is causing intermittent failures. We should make it a required step to move away from this value before starting devnet.

**Modifications:**
<!--
Describe the modifications you've done from a high level. What are the key technical decisions and why were they made?
-->
- Adds a check for if the `fork_url` is still holding the default value

**Result:**
<!--
*After your change, what will change.
-->
- User cannot proceed with the default `fork_url`

**Testing:**
<!--
*List testing procedures taken and useful artifacts.
-->
- Tested manually with a fresh project
