### PR TITLE
chore: more informative error if fork url fails to fork a mainnet block

### DIFF
--- a/pkg/commands/devnet_actions.go
+++ b/pkg/commands/devnet_actions.go
@@ -137,7 +137,10 @@ func StartDevnetAction(cCtx *cli.Context) error {
 	time.Sleep(4 * time.Second)
 
 	// Fund the wallets defined in config
-	devnet.FundWalletsDevnet(config, rpcUrl)
+	err = devnet.FundWalletsDevnet(config, rpcUrl)
+	if err != nil {
+		return err
+	}
 	elapsed := time.Since(startTime).Round(time.Second)
 
 	// Sleep for 1 second to make sure wallets are funded

--- a/pkg/commands/devnet_test.go
+++ b/pkg/commands/devnet_test.go
@@ -21,6 +21,7 @@ import (
 )
 
 func TestStartAndStopDevnet(t *testing.T) {
+		os.Setenv("SKIP_DEVNET_FUNDING", "true")
 	// Save current working directory
 	originalCwd, err := os.Getwd()
 	assert.NoError(t, err)
@@ -67,6 +68,7 @@ func TestStartAndStopDevnet(t *testing.T) {
 }
 
 func TestStartDevnetOnUsedPort_ShouldFail(t *testing.T) {
+		os.Setenv("SKIP_DEVNET_FUNDING", "true")
 	// Save current working directory
 	originalCwd, err := os.Getwd()
 	assert.NoError(t, err)
@@ -132,6 +134,7 @@ func TestStartDevnetOnUsedPort_ShouldFail(t *testing.T) {
 	_ = stopApp.Run([]string{"devkit", "--port", port, "--verbose"})
 }
 func TestStartDevnet_WithDeployContracts(t *testing.T) {
+		os.Setenv("SKIP_DEVNET_FUNDING", "true")
 	originalCwd, err := os.Getwd()
 	assert.NoError(t, err)
 	t.Cleanup(func() { _ = os.Chdir(originalCwd) })
@@ -185,6 +188,7 @@ func TestStartDevnet_WithDeployContracts(t *testing.T) {
 }
 
 func TestStartDevnet_SkipDeployContracts(t *testing.T) {
+		os.Setenv("SKIP_DEVNET_FUNDING", "true")
 	originalCwd, err := os.Getwd()
 	assert.NoError(t, err)
 	t.Cleanup(func() { _ = os.Chdir(originalCwd) })
@@ -237,6 +241,7 @@ func TestStartDevnet_SkipDeployContracts(t *testing.T) {
 }
 
 func TestStartDevnet_SkipAVSRun(t *testing.T) {
+	os.Setenv("SKIP_DEVNET_FUNDING", "true")
 	originalCwd, err := os.Getwd()
 	assert.NoError(t, err)
 	t.Cleanup(func() { _ = os.Chdir(originalCwd) })
@@ -300,6 +305,7 @@ func getFreePort() (string, error) {
 }
 
 func TestListRunningDevnets(t *testing.T) {
+		os.Setenv("SKIP_DEVNET_FUNDING", "true")
 	// Save original working directory
 	originalCwd, err := os.Getwd()
 	assert.NoError(t, err)
@@ -367,6 +373,7 @@ func TestListRunningDevnets(t *testing.T) {
 }
 
 func TestStopDevnetAll(t *testing.T) {
+	os.Setenv("SKIP_DEVNET_FUNDING", "true")
 	// Save working directory
 	originalCwd, err := os.Getwd()
 	assert.NoError(t, err)
@@ -427,6 +434,7 @@ func TestStopDevnetAll(t *testing.T) {
 }
 
 func TestStopDevnetContainerFlag(t *testing.T) {
+	os.Setenv("SKIP_DEVNET_FUNDING", "true")
 	// Save working directory
 	originalCwd, err := os.Getwd()
 	assert.NoError(t, err)
@@ -483,6 +491,7 @@ func TestStopDevnetContainerFlag(t *testing.T) {
 }
 
 func TestDeployContracts(t *testing.T) {
+	os.Setenv("SKIP_DEVNET_FUNDING", "true")
 	// Save working dir
 	originalCwd, err := os.Getwd()
 	assert.NoError(t, err)

--- a/pkg/commands/devnet_test.go
+++ b/pkg/commands/devnet_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestStartAndStopDevnet(t *testing.T) {
-		os.Setenv("SKIP_DEVNET_FUNDING", "true")
+	os.Setenv("SKIP_DEVNET_FUNDING", "true")
 	// Save current working directory
 	originalCwd, err := os.Getwd()
 	assert.NoError(t, err)
@@ -68,7 +68,7 @@ func TestStartAndStopDevnet(t *testing.T) {
 }
 
 func TestStartDevnetOnUsedPort_ShouldFail(t *testing.T) {
-		os.Setenv("SKIP_DEVNET_FUNDING", "true")
+	os.Setenv("SKIP_DEVNET_FUNDING", "true")
 	// Save current working directory
 	originalCwd, err := os.Getwd()
 	assert.NoError(t, err)
@@ -134,7 +134,7 @@ func TestStartDevnetOnUsedPort_ShouldFail(t *testing.T) {
 	_ = stopApp.Run([]string{"devkit", "--port", port, "--verbose"})
 }
 func TestStartDevnet_WithDeployContracts(t *testing.T) {
-		os.Setenv("SKIP_DEVNET_FUNDING", "true")
+	os.Setenv("SKIP_DEVNET_FUNDING", "true")
 	originalCwd, err := os.Getwd()
 	assert.NoError(t, err)
 	t.Cleanup(func() { _ = os.Chdir(originalCwd) })
@@ -188,7 +188,7 @@ func TestStartDevnet_WithDeployContracts(t *testing.T) {
 }
 
 func TestStartDevnet_SkipDeployContracts(t *testing.T) {
-		os.Setenv("SKIP_DEVNET_FUNDING", "true")
+	os.Setenv("SKIP_DEVNET_FUNDING", "true")
 	originalCwd, err := os.Getwd()
 	assert.NoError(t, err)
 	t.Cleanup(func() { _ = os.Chdir(originalCwd) })
@@ -305,7 +305,7 @@ func getFreePort() (string, error) {
 }
 
 func TestListRunningDevnets(t *testing.T) {
-		os.Setenv("SKIP_DEVNET_FUNDING", "true")
+	os.Setenv("SKIP_DEVNET_FUNDING", "true")
 	// Save original working directory
 	originalCwd, err := os.Getwd()
 	assert.NoError(t, err)

--- a/pkg/common/devnet/funding.go
+++ b/pkg/common/devnet/funding.go
@@ -1,40 +1,22 @@
 package devnet
 
 import (
-	devkitcommon "github.com/Layr-Labs/devkit-cli/pkg/common"
+	"fmt"
 	"log"
 	"math/big"
 	"os"
 	"os/exec"
 	"strings"
-	"time"
+
+	devkitcommon "github.com/Layr-Labs/devkit-cli/pkg/common"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/ethclient"
 )
 
 // FundWallets sends ETH to a list of addresses using `cast send`
 // Only funds wallets with balance < 10 ether.
-func FundWalletsDevnet(cfg *devkitcommon.ConfigWithContextConfig, rpcURL string) {
-	var client *ethclient.Client
-	var err error
-
-	// Retry with exponential backoff up to 5 times
-	for retries := 0; retries < 5; retries++ {
-		client, err = ethclient.Dial(rpcURL)
-		if err == nil {
-			break
-		}
-		log.Printf("⚠️  Waiting for devnet to be ready (%d/5)...", retries+1)
-		time.Sleep(time.Duration(1<<retries) * time.Second) // 1s, 2s, 4s, 8s, 16s
-	}
-
-	if err != nil {
-		log.Printf("❌ Could not connect to devnet RPC after retries: %v", err)
-		return
-	}
-	defer client.Close()
+func FundWalletsDevnet(cfg *devkitcommon.ConfigWithContextConfig, rpcURL string) error {
 
 	// All operator keys from [operator]
 	// We only intend to fund for devnet, so hardcoding to `CONTEXT` is fine
@@ -44,43 +26,53 @@ func FundWalletsDevnet(cfg *devkitcommon.ConfigWithContextConfig, rpcURL string)
 		if err != nil {
 			log.Fatalf("invalid private key %q: %v", key.ECDSAKey, err)
 		}
-		fundIfNeeded(client, crypto.PubkeyToAddress(privateKey.PublicKey), key.ECDSAKey, rpcURL)
+		err = fundIfNeeded(crypto.PubkeyToAddress(privateKey.PublicKey), key.ECDSAKey, rpcURL)
+		if err != nil {
+			return err
+		}
 	}
-
+	return nil
 }
 
-func fundIfNeeded(client *ethclient.Client, to common.Address, fromKey string, rpcURL string) {
-	log.Printf("rpc_devnet %s", rpcURL)
-	balanceCmd := exec.Command("cast", "balance",
-		to.String(),
-		"--rpc-url", rpcURL,
-	)
-	balanceOutput, err := balanceCmd.Output()
+func fundIfNeeded(to common.Address, fromKey string, rpcURL string) error {
+	balanceCmd := exec.Command("cast", "balance", to.String(), "--rpc-url", rpcURL)
+	balanceCmd.Env = append(os.Environ(), "FOUNDRY_DISABLE_NIGHTLY_WARNING=1")
+	output, err := balanceCmd.CombinedOutput()
 	if err != nil {
-		log.Printf("❌ Failed to get balance for %s: %v", to.String(), err)
-		return
+		if strings.Contains(string(output), "Error: error sending request for url") {
+			log.Printf(" Please check if your mainnet fork rpc url is up")
+		}
+		return fmt.Errorf("failed to get balance for account%s", to.String())
 	}
 	threshold := new(big.Int)
 	threshold.SetString(FUND_VALUE, 10)
+
+	balanceStr := strings.TrimSpace(string(output))
 	balance := new(big.Int)
-	balance.SetString(string(balanceOutput), 10)
+	if _, ok := balance.SetString(balanceStr, 10); !ok {
+		return fmt.Errorf("failed to parse balance from cast output: %s", balanceStr)
+	}
+	balance.SetString(string(output), 10)
 	if balance.Cmp(threshold) >= 0 {
 		log.Printf("✅ %s already has sufficient balance (%s wei)", to, balance.String())
-		return
+		return nil
 	}
 
-	log.Printf("Funding %s with %s from %s", to, FUND_VALUE, fromKey)
+	log.Printf("💸 Funding %s with %s from private key", to, FUND_VALUE)
 	cmd := exec.Command("cast", "send",
 		to.String(),
 		"--value", FUND_VALUE,
 		"--rpc-url", rpcURL,
 		"--private-key", fromKey,
 	)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
+
+	_, err = cmd.CombinedOutput()
+
+	if err != nil {
 		log.Printf("❌ Failed to fund %s: %v", to, err)
+		return err
 	} else {
 		log.Printf("✅ Funded %s", to)
 	}
+	return nil
 }

--- a/pkg/common/devnet/funding.go
+++ b/pkg/common/devnet/funding.go
@@ -18,6 +18,11 @@ import (
 // Only funds wallets with balance < 10 ether.
 func FundWalletsDevnet(cfg *devkitcommon.ConfigWithContextConfig, rpcURL string) error {
 
+	if os.Getenv("SKIP_DEVNET_FUNDING") == "true" {
+		log.Println("🔧 Skipping devnet wallet funding (test mode)")
+		return nil
+	}
+
 	// All operator keys from [operator]
 	// We only intend to fund for devnet, so hardcoding to `CONTEXT` is fine
 	for _, key := range cfg.Context[CONTEXT].Operators {

--- a/pkg/common/devnet/funding.go
+++ b/pkg/common/devnet/funding.go
@@ -63,7 +63,7 @@ func fundIfNeeded(to common.Address, fromKey string, rpcURL string) error {
 		return nil
 	}
 
-	log.Printf("💸 Funding %s with %s from private key", to, FUND_VALUE)
+	log.Printf("💸 Funding %s with %s from %s", to, FUND_VALUE, fromKey)
 	cmd := exec.Command("cast", "send",
 		to.String(),
 		"--value", FUND_VALUE,


### PR DESCRIPTION


**Motivation:**

- It reads the cast output , and if it contains `Error: error sending request for url`, we print put out an error saying `Please check if your mainnet fork rpc url is up`.And we also return with error, so devnet will not execute more  if this fails.


**Modifications:**

Handle error early if checking balance or fund wallet fails , instead of executing more code.

**Result:**


**Testing:**

The devnet unit tests were failing to get the account balances that we fund underneath. I suspect its due to unreliable mainnet rpc. For now, added a workaround to not fund wallets in test.

**Open questions:**
<!--
(optional) Any open questions or feedback on design desired?
-->