### PR TITLE
chore: bump hourglass default to v0.0.2

### DIFF
--- a/config/templates.yaml
+++ b/config/templates.yaml
@@ -2,7 +2,7 @@ architectures:
   task:
     languages:
       go:
-        template: "https://github.com/Layr-Labs/hourglass-avs-template/tree/v0.0.1"
+        template: "https://github.com/Layr-Labs/hourglass-avs-template/tree/v0.0.2"
       ts:
         template: ""
       rust:

--- a/pkg/template/config_test.go
+++ b/pkg/template/config_test.go
@@ -15,7 +15,7 @@ func TestLoadConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to get template URL: %v", err)
 	}
-	expected := "https://github.com/Layr-Labs/hourglass-avs-template/tree/v0.0.1"
+	expected := "https://github.com/Layr-Labs/hourglass-avs-template/tree/v0.0.2"
 	if url != expected {
 		t.Errorf("Unexpected template URL: got %s, want %s", url, expected)
 	}


### PR DESCRIPTION
Bumps the hourglass template to `v0.0.2`