### PR TITLE
fix: lower default block_time

### DIFF
--- a/config/contexts/v0.0.3.yaml
+++ b/config/contexts/v0.0.3.yaml
@@ -11,14 +11,14 @@ context:
       fork:
         block: 22475020
         url: ""
-        block_time: 12
+        block_time: 3
     l2:
       chain_id: 31337
       rpc_url: "http://localhost:8545"
       fork:
         block: 22475020
         url: ""
-        block_time: 12
+        block_time: 3
   # All key material (BLS and ECDSA) within this file should be used for local testing ONLY
   # ECDSA keys used are from Anvil's private key set
   # BLS keystores are deterministically pre-generated and embedded. These are NOT derived from a secure seed


### PR DESCRIPTION
<!-- 
    🚨 ATTENTION! 🚨 
    
    This PR template is REQUIRED. PRs not following this format will be closed without review.
    
    Requirements:
    - PR title must follow commit conventions: https://www.conventionalcommits.org/en/v1.0.0/
    - Label your PR with the correct type (e.g., 🐛 Bug, ✨ Enhancement, 🧪 Test, etc.)
    - Provide clear and specific details in each section
-->

**Motivation:**
<!--
Explain here the context, and why you're making that change. What is the problem you're trying to solve.
-->
The default block_time of 12s was a work around on the nightly version of anvil, this brings the block_time back down to 3s.

**Modifications:**
<!--
Describe the modifications you've done from a high level. What are the key technical decisions and why were they made?
-->
- Reduce default `blockTime` to 3s from 12s

**Result:**
<!--
*After your change, what will change.
-->
- Default `blockTime` will be 3s

**Testing:**
<!--
*List testing procedures taken and useful artifacts.
-->
- Tested manually