### PR TITLE
fix: allow multiple --params to be supplied to call

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Triggers task execution through your AVS, simulating how a task would be submitt
 Run this from your project directory:
 
 ```bash
-devkit avs call
+devkit avs call -- signature="(uint256,string)" args='(5,"hello")'
 ```
 
 Optionally, submit tasks directly to the on-chain TaskMailBox contract via a frontend or another method for more realistic testing scenarios.

--- a/pkg/commands/call.go
+++ b/pkg/commands/call.go
@@ -16,13 +16,7 @@ import (
 var CallCommand = &cli.Command{
 	Name:  "call",
 	Usage: "Submits tasks to the local devnet, triggers off-chain execution, and aggregates results",
-	Flags: append([]cli.Flag{
-		&cli.BoolFlag{
-			Name:     "params",
-			Usage:    "parameters for the call (e.g., payload=\"<payload>\")",
-			Required: true,
-		},
-	}, common.GlobalFlags...),
+	Flags: common.GlobalFlags,
 	Action: func(cCtx *cli.Context) error {
 		// Get logger
 		log, _ := common.GetLogger()
@@ -46,12 +40,10 @@ var CallCommand = &cli.Command{
 		// Set path for .devkit scripts
 		scriptPath := filepath.Join(".devkit", "scripts", "call")
 
-		// Drop the dummy --params if present, collect the rest
+		// Check that args are provided
 		parts := cCtx.Args().Slice()
-		if cCtx.Bool("params") {
-			if len(parts) == 0 {
-				return fmt.Errorf("no parameters supplied after --params")
-			}
+		if len(parts) == 0 {
+			return fmt.Errorf("no parameters supplied")
 		}
 
 		// Parse the params from the provided args

--- a/pkg/commands/call.go
+++ b/pkg/commands/call.go
@@ -3,10 +3,11 @@ package commands
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/Layr-Labs/devkit-cli/pkg/common"
 	"path"
 	"path/filepath"
 	"strings"
+
+	"github.com/Layr-Labs/devkit-cli/pkg/common"
 
 	"github.com/urfave/cli/v2"
 )
@@ -16,7 +17,7 @@ var CallCommand = &cli.Command{
 	Name:  "call",
 	Usage: "Submits tasks to the local devnet, triggers off-chain execution, and aggregates results",
 	Flags: append([]cli.Flag{
-		&cli.StringFlag{
+		&cli.BoolFlag{
 			Name:     "params",
 			Usage:    "parameters for the call (e.g., payload=\"<payload>\")",
 			Required: true,
@@ -45,9 +46,16 @@ var CallCommand = &cli.Command{
 		// Set path for .devkit scripts
 		scriptPath := filepath.Join(".devkit", "scripts", "call")
 
-		// Extract params from flag
-		paramsStr := cCtx.String("params")
-		paramsMap, err := parseParams(paramsStr)
+		// Drop the dummy --params if present, collect the rest
+		parts := cCtx.Args().Slice()
+		if cCtx.Bool("params") {
+			if len(parts) == 0 {
+				return fmt.Errorf("no parameters supplied after --params")
+			}
+		}
+
+		// Parse the params from the provided args
+		paramsMap, err := parseParams(strings.Join(parts, " "))
 		if err != nil {
 			return err
 		}

--- a/pkg/commands/call_test.go
+++ b/pkg/commands/call_test.go
@@ -40,7 +40,7 @@ func TestCallCommand_ExecutesSuccessfully(t *testing.T) {
 	_, restore, app := setupCallApp(t)
 	defer restore()
 
-	err := app.Run([]string{"app", "call", "--params", "payload=0x1"})
+	err := app.Run([]string{"app", "call", "--", "payload=0x1"})
 	assert.NoError(t, err)
 }
 
@@ -50,7 +50,7 @@ func TestCallCommand_MissingDevnetYAML(t *testing.T) {
 
 	os.Remove(filepath.Join(tmpDir, "config", "contexts", "devnet.yaml"))
 
-	err := app.Run([]string{"app", "call", "--params", "payload=0x1"})
+	err := app.Run([]string{"app", "call", "--", "payload=0x1"})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to load context")
 }
@@ -61,7 +61,7 @@ func TestCallCommand_MissingParams(t *testing.T) {
 
 	err := app.Run([]string{"app", "call"})
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), `Required flag "params"`)
+	assert.Contains(t, err.Error(), "no parameters supplied")
 }
 
 func TestParseParams_MultipleParams(t *testing.T) {
@@ -76,7 +76,7 @@ func TestCallCommand_MalformedParams(t *testing.T) {
 	_, restore, app := setupCallApp(t)
 	defer restore()
 
-	err := app.Run([]string{"app", "call", "--params", "badparam"})
+	err := app.Run([]string{"app", "call", "--", "badparam"})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid param")
 }
@@ -89,7 +89,7 @@ func TestCallCommand_MalformedYAML(t *testing.T) {
 	err := os.WriteFile(yamlPath, []byte(":\n  - bad"), 0644)
 	assert.NoError(t, err)
 
-	err = app.Run([]string{"app", "call", "--params", "payload=0x1"})
+	err = app.Run([]string{"app", "call", "--", "payload=0x1"})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to load context")
 }
@@ -101,7 +101,7 @@ func TestCallCommand_MissingScript(t *testing.T) {
 	err := os.Remove(filepath.Join(tmpDir, ".devkit", "scripts", "call"))
 	assert.NoError(t, err)
 
-	err = app.Run([]string{"app", "call", "--params", "payload=0x1"})
+	err = app.Run([]string{"app", "call", "--", "payload=0x1"})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "no such file or directory")
 }
@@ -115,7 +115,7 @@ func TestCallCommand_ScriptReturnsNonZero(t *testing.T) {
 	err := os.WriteFile(scriptPath, []byte(failScript), 0755)
 	assert.NoError(t, err)
 
-	err = app.Run([]string{"app", "call", "--params", "payload=0x1"})
+	err = app.Run([]string{"app", "call", "--", "payload=0x1"})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "call failed")
 }
@@ -130,7 +130,7 @@ func TestCallCommand_ScriptOutputsInvalidJSON(t *testing.T) {
 	assert.NoError(t, err)
 
 	stdout, stderr := testutils.CaptureOutput(func() {
-		err := app.Run([]string{"app", "call", "--params", "payload=0x1"})
+		err := app.Run([]string{"app", "call", "--", "payload=0x1"})
 		assert.NoError(t, err)
 	})
 
@@ -145,7 +145,7 @@ func TestCallCommand_Cancelled(t *testing.T) {
 	result := make(chan error)
 
 	go func() {
-		result <- app.RunContext(ctx, []string{"app", "call", "--params", "payload=0x1"})
+		result <- app.RunContext(ctx, []string{"app", "call", "--", "payload=0x1"})
 	}()
 	cancel()
 

--- a/pkg/commands/call_test.go
+++ b/pkg/commands/call_test.go
@@ -3,13 +3,15 @@ package commands
 import (
 	"context"
 	"errors"
-	"github.com/Layr-Labs/devkit-cli/pkg/testutils"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/Layr-Labs/devkit-cli/pkg/testutils"
+
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/urfave/cli/v2"
 )
 
@@ -60,6 +62,14 @@ func TestCallCommand_MissingParams(t *testing.T) {
 	err := app.Run([]string{"app", "call"})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), `Required flag "params"`)
+}
+
+func TestParseParams_MultipleParams(t *testing.T) {
+	input := `signature="(uint256,string)" args='(5,"hello")'`
+	m, err := parseParams(input)
+	require.NoError(t, err)
+	assert.Equal(t, "(uint256,string)", m["signature"])
+	assert.Equal(t, `(5,"hello")`, m["args"])
 }
 
 func TestCallCommand_MalformedParams(t *testing.T) {


### PR DESCRIPTION
<!-- 
    🚨 ATTENTION! 🚨 
    
    This PR template is REQUIRED. PRs not following this format will be closed without review.
    
    Requirements:
    - PR title must follow commit conventions: https://www.conventionalcommits.org/en/v1.0.0/
    - Label your PR with the correct type (e.g., 🐛 Bug, ✨ Enhancement, 🧪 Test, etc.)
    - Provide clear and specific details in each section
-->

**Motivation:**
<!--
Explain here the context, and why you're making that change. What is the problem you're trying to solve.
-->
`urfave/cli/v2` doesn't allow multiple values following a flag without repeating the flag. We should ~~switch to a bool flag and then~~ use the args to construct the params string.

**Modifications:**
<!--
Describe the modifications you've done from a high level. What are the key technical decisions and why were they made?
-->
- ~~Alters the `--params` flag to be a bool and c~~ Collects params from args instead

**Result:**
<!--
*After your change, what will change.
-->
- Accepts any number of params without modifying command signature

**Testing:**
<!--
*List testing procedures taken and useful artifacts.
-->
- Added a unit test and tested manually
