### PR TITLE
fix: expose ssh agent to unblock build step

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,6 +21,11 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Set up SSH agent
+        uses: webfactory/ssh-agent@v0.5.4
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
@@ -65,11 +70,14 @@ jobs:
 
       - name: Build & push performer image
         uses: docker/build-push-action@v4
+        env:
+          DOCKER_BUILDKIT: 1
         with:
           context: .
           file: ./my-awesome-avs/Dockerfile
           push: true
           tags: ghcr.io/${{ env.OWNER }}/performer:${{ github.sha }}
+          ssh: default
 
       - name: Seed mirror (local pull-through)
         run: |
@@ -78,6 +86,8 @@ jobs:
           && docker push localhost:5000/performer:${{ github.sha }}
 
       - name: Run devkit avs build
+        env:
+            DOCKER_BUILDKIT: 1
         run: |
           eval "$(ssh-agent -s)"
           echo "${{ secrets.SSH_PRIVATE_KEY }}" | ssh-add -

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -74,7 +74,6 @@ jobs:
           DOCKER_BUILDKIT: 1
         with:
           context: ./my-awesome-avs
-          file: Dockerfile
           push: true
           tags: ghcr.io/${{ env.OWNER }}/performer:${{ github.sha }}
           ssh: default

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Start devnet
         run: |
           cd ./my-awesome-avs/
-          devkit avs devnet start
+          DOCKER_HOST=localhost devkit avs devnet start
           sleep 10
 
       - name: Check devnet RPC is live

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -78,19 +78,6 @@ jobs:
           tags: ghcr.io/${{ env.OWNER }}/performer:${{ github.sha }}
           ssh: default
 
-      - name: Start pull-through mirror
-        run: |
-          docker run -d --name registry-mirror -p 5000:5000 registry:2
-          # points Docker to mirror for *all* hub pulls (optional)
-          echo '{"registry-mirrors":["http://localhost:5000"]}' | sudo tee /etc/docker/daemon.json
-          sudo systemctl restart docker
-          
-      - name: Seed mirror (local pull-through)
-        run: |
-          docker pull ghcr.io/${{ env.OWNER }}/performer:${{ github.sha }} \
-          && docker tag ghcr.io/${{ env.OWNER }}/performer:${{ github.sha }} localhost:5000/performer:${{ github.sha }} \
-          && docker push localhost:5000/performer:${{ github.sha }}
-
       - name: Run devkit avs build
         env:
             DOCKER_BUILDKIT: 1

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -73,8 +73,8 @@ jobs:
         env:
           DOCKER_BUILDKIT: 1
         with:
-          context: .
-          file: ./my-awesome-avs/Dockerfile
+          context: ./my-awesome-avs
+          file: Dockerfile
           push: true
           tags: ghcr.io/${{ env.OWNER }}/performer:${{ github.sha }}
           ssh: default

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,11 +21,6 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Set up SSH agent
-        uses: webfactory/ssh-agent@v0.5.4
-        with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-
       - name: Set up Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -31,6 +31,13 @@ jobs:
           git config --global url."https://${{ secrets.HOURGLASS_TOKEN }}:x-oauth-basic@github.com/".insteadOf "https://github.com/"
           echo "machine github.com login ${{ secrets.HOURGLASS_TOKEN }}" > ~/.netrc
 
+      - name: Log in to GHCR
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.HOURGLASS_TOKEN }}
+
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
@@ -52,6 +59,20 @@ jobs:
             exit 1
           fi
           echo "✅ AVS project created successfully at ${GITHUB_WORKSPACE}/my-awesome-avs/"
+
+      - name: Build & push performer image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ./my-awesome-avs/Dockerfile
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/performer:${{ github.sha }}
+
+      - name: Seed mirror (local pull-through)
+        run: |
+          docker pull ghcr.io/${{ github.repository_owner }}/performer:${{ github.sha }} \
+          && docker tag ghcr.io/${{ github.repository_owner }}/performer:${{ github.sha }} localhost:5000/performer:${{ github.sha }} \
+          && docker push localhost:5000/performer:${{ github.sha }}
 
       - name: Run devkit avs build
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Start devnet
         run: |
           cd ./my-awesome-avs/
-          DOCKER_HOST=localhost devkit avs devnet start
+          devkit avs devnet start
           sleep 10
 
       - name: Check devnet RPC is live

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -35,8 +35,8 @@ jobs:
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.HOURGLASS_TOKEN }}
+          username: grezle
+          password: ${{ secrets.GHCR_PAT_TOKEN }}
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -31,13 +31,6 @@ jobs:
           git config --global url."https://${{ secrets.HOURGLASS_TOKEN }}:x-oauth-basic@github.com/".insteadOf "https://github.com/"
           echo "machine github.com login ${{ secrets.HOURGLASS_TOKEN }}" > ~/.netrc
 
-      - name: Start SSH agent
-        run: |
-          eval "$(ssh-agent -s)"
-          echo "${{ secrets.SSH_PRIVATE_KEY }}" | ssh-add -
-          mkdir -p ~/.ssh
-          ssh-keyscan github.com >> ~/.ssh/known_hosts
-          
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
@@ -62,6 +55,11 @@ jobs:
 
       - name: Run devkit avs build
         run: |
+          eval "$(ssh-agent -s)"
+          echo "${{ secrets.SSH_PRIVATE_KEY }}" | ssh-add -
+          mkdir -p ~/.ssh
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+
           cd ./my-awesome-avs/
           devkit avs build
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -78,6 +78,13 @@ jobs:
           tags: ghcr.io/${{ env.OWNER }}/performer:${{ github.sha }}
           ssh: default
 
+      - name: Start pull-through mirror
+        run: |
+          docker run -d --name registry-mirror -p 5000:5000 registry:2
+          # points Docker to mirror for *all* hub pulls (optional)
+          echo '{"registry-mirrors":["http://localhost:5000"]}' | sudo tee /etc/docker/daemon.json
+          sudo systemctl restart docker
+          
       - name: Seed mirror (local pull-through)
         run: |
           docker pull ghcr.io/${{ env.OWNER }}/performer:${{ github.sha }} \

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -60,18 +60,21 @@ jobs:
           fi
           echo "✅ AVS project created successfully at ${GITHUB_WORKSPACE}/my-awesome-avs/"
 
+      - name: Lowercase owner
+        run: echo "OWNER=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+
       - name: Build & push performer image
         uses: docker/build-push-action@v4
         with:
           context: .
           file: ./my-awesome-avs/Dockerfile
           push: true
-          tags: ghcr.io/${{ github.repository_owner }}/performer:${{ github.sha }}
+          tags: ghcr.io/${{ env.OWNER }}/performer:${{ github.sha }}
 
       - name: Seed mirror (local pull-through)
         run: |
-          docker pull ghcr.io/${{ github.repository_owner }}/performer:${{ github.sha }} \
-          && docker tag ghcr.io/${{ github.repository_owner }}/performer:${{ github.sha }} localhost:5000/performer:${{ github.sha }} \
+          docker pull ghcr.io/${{ env.OWNER }}/performer:${{ github.sha }} \
+          && docker tag ghcr.io/${{ env.OWNER }}/performer:${{ github.sha }} localhost:5000/performer:${{ github.sha }} \
           && docker push localhost:5000/performer:${{ github.sha }}
 
       - name: Run devkit avs build

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -31,6 +31,13 @@ jobs:
           git config --global url."https://${{ secrets.HOURGLASS_TOKEN }}:x-oauth-basic@github.com/".insteadOf "https://github.com/"
           echo "machine github.com login ${{ secrets.HOURGLASS_TOKEN }}" > ~/.netrc
 
+      - name: Start SSH agent
+        run: |
+          eval "$(ssh-agent -s)"
+          echo "${{ secrets.SSH_PRIVATE_KEY }}" | ssh-add -
+          mkdir -p ~/.ssh
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+          
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -36,13 +36,6 @@ jobs:
           git config --global url."https://${{ secrets.HOURGLASS_TOKEN }}:x-oauth-basic@github.com/".insteadOf "https://github.com/"
           echo "machine github.com login ${{ secrets.HOURGLASS_TOKEN }}" > ~/.netrc
 
-      - name: Log in to GHCR
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: grezle
-          password: ${{ secrets.GHCR_PAT_TOKEN }}
-
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
@@ -65,19 +58,6 @@ jobs:
           fi
           echo "✅ AVS project created successfully at ${GITHUB_WORKSPACE}/my-awesome-avs/"
 
-      - name: Lowercase owner
-        run: echo "OWNER=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
-
-      - name: Build & push performer image
-        uses: docker/build-push-action@v4
-        env:
-          DOCKER_BUILDKIT: 1
-        with:
-          context: ./my-awesome-avs
-          push: true
-          tags: ghcr.io/${{ env.OWNER }}/performer:${{ github.sha }}
-          ssh: default
-
       - name: Run devkit avs build
         env:
             DOCKER_BUILDKIT: 1
@@ -93,7 +73,7 @@ jobs:
       - name: Start devnet
         run: |
           cd ./my-awesome-avs/
-          devkit avs devnet start
+          DOCKERS_HOST=localhost devkit avs devnet start --skip-avs-run
           sleep 10
 
       - name: Check devnet RPC is live

--- a/config/contexts/v0.0.3.yaml
+++ b/config/contexts/v0.0.3.yaml
@@ -1,5 +1,5 @@
 # Devnet context to be used for local deployments against Anvil chain
-version: 0.0.2
+version: 0.0.3
 context:
   # Name of the context
   name: "devnet"

--- a/config/templates.yaml
+++ b/config/templates.yaml
@@ -3,7 +3,7 @@ architectures:
     languages:
       go:
         baseUrl: "https://github.com/Layr-Labs/hourglass-avs-template"
-        version: "v0.0.4"
+        version: "v0.0.5"
       ts:
         baseUrl: ""
         version: ""

--- a/pkg/template/config_test.go
+++ b/pkg/template/config_test.go
@@ -17,7 +17,7 @@ func TestLoadConfig(t *testing.T) {
 	}
 
 	expectedBaseURL := "https://github.com/Layr-Labs/hourglass-avs-template"
-	expectedVersion := "v0.0.4"
+	expectedVersion := "v0.0.5"
 
 	if mainBaseURL != expectedBaseURL {
 		t.Errorf("Unexpected main template base URL: got %s, want %s", mainBaseURL, expectedBaseURL)


### PR DESCRIPTION
<!-- 
    🚨 ATTENTION! 🚨 
    
    This PR template is REQUIRED. PRs not following this format will be closed without review.
    
    Requirements:
    - PR title must follow commit conventions: https://www.conventionalcommits.org/en/v1.0.0/
    - Label your PR with the correct type (e.g., 🐛 Bug, ✨ Enhancement, 🧪 Test, etc.)
    - Provide clear and specific details in each section
-->

**Motivation:**
<!--
Explain here the context, and why you're making that change. What is the problem you're trying to solve.
-->
Since adding `set -e` to `build.sh` our e2e has been failing on the build step as we do not have an ssh-agent running.

**Modifications:**
<!--
Describe the modifications you've done from a high level. What are the key technical decisions and why were they made?
-->
- adds a deploy key to our repo
- starts and authenticates an ssh-agent

**Result:**
<!--
*After your change, what will change.
-->
- fixes build step in e2e test