### PR TITLE
fix: only warn/log non-empty outputs for ExpectJSONResponse

### DIFF
--- a/pkg/common/scripts_caller.go
+++ b/pkg/common/scripts_caller.go
@@ -45,13 +45,16 @@ func CallTemplateScript(cmdCtx context.Context, dir string, scriptPath string, e
 
 	// Clean and validate stdout
 	raw := bytes.TrimSpace(stdout.Bytes())
-	if len(raw) == 0 {
-		log.Warn("Empty output from %s; returning empty result", scriptPath)
-		return map[string]interface{}{}, nil
-	}
 
 	// Return the result as JSON if expected
 	if expect == ExpectJSONResponse {
+		// End early for empty response
+		if len(raw) == 0 {
+			log.Warn("Empty output from %s; returning empty result", scriptPath)
+			return map[string]interface{}{}, nil
+		}
+
+		// Unmarshal response and return unless err
 		var result map[string]interface{}
 		if err := json.Unmarshal(raw, &result); err != nil {
 			log.Warn("Invalid or non-JSON script output: %s; returning empty result: %v", string(raw), err)
@@ -61,7 +64,9 @@ func CallTemplateScript(cmdCtx context.Context, dir string, scriptPath string, e
 	}
 
 	// Log the raw stdout
-	log.Info("%s", string(raw))
+	if len(raw) > 0 {
+		log.Info("%s", string(raw))
+	}
 
 	return nil, nil
 }

--- a/pkg/common/scripts_caller_test.go
+++ b/pkg/common/scripts_caller_test.go
@@ -3,9 +3,11 @@ package common
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -64,5 +66,43 @@ echo "This is plain text output"`
 	}
 	if out != nil {
 		t.Errorf("expected nil output for non-JSON response, got: %v", out)
+	}
+
+	// Empty response case
+	empty := `#!/bin/bash`
+
+	emptyPath := filepath.Join(tmpDir, "empty.sh")
+	if err := os.WriteFile(emptyPath, []byte(empty), 0755); err != nil {
+		t.Fatalf("failed to write empty test script: %v", err)
+	}
+
+	// Prepare pipes
+	oldOut, oldErr := os.Stdout, os.Stderr
+	rOut, wOut, _ := os.Pipe()
+	rErr, wErr, _ := os.Pipe()
+	os.Stdout, os.Stderr = wOut, wErr
+
+	// Run the empty script
+	out, err = CallTemplateScript(context.Background(), "", textScriptPath, ExpectNonJSONResponse)
+	if err != nil {
+		t.Fatalf("CallTemplateScript (non-JSON) failed: %v", err)
+	}
+	if out != nil {
+		t.Errorf("expected nil output for non-JSON response, got: %v", out)
+	}
+
+	// Restore and close writers
+	wOut.Close()
+	wErr.Close()
+	os.Stdout, os.Stderr = oldOut, oldErr
+
+	// Read captured output
+	bufOut, _ := io.ReadAll(rOut)
+	bufErr, _ := io.ReadAll(rErr)
+	captured := string(bufOut) + string(bufErr)
+
+	// Assert no warning
+	if strings.Contains(captured, "returning empty result") {
+		t.Errorf("unexpected warning in output: %q", captured)
 	}
 }


### PR DESCRIPTION
<!-- 
    🚨 ATTENTION! 🚨 
    
    This PR template is REQUIRED. PRs not following this format will be closed without review.
    
    Requirements:
    - PR title must follow commit conventions: https://www.conventionalcommits.org/en/v1.0.0/
    - Label your PR with the correct type (e.g., 🐛 Bug, ✨ Enhancement, 🧪 Test, etc.)
    - Provide clear and specific details in each section
-->

**Motivation:**
<!--
Explain here the context, and why you're making that change. What is the problem you're trying to solve.
-->
The build step logs: `Warning: Empty output from .devkit/scripts/build; returning empty result`

**Modifications:**
<!--
Describe the modifications you've done from a high level. What are the key technical decisions and why were they made?
-->
- Only warn/log non-empty outputs for `ExpectJSONResponse`

**Result:**
<!--
*After your change, what will change.
-->
- Doesn't show a warning for the expected empty response on `avs build`

**Testing:**
<!--
*List testing procedures taken and useful artifacts.
-->
- Added integration test for testcase
