### PR TITLE
fix: check for dir instead of readme in contracts

### DIFF
--- a/pkg/commands/create.go
+++ b/pkg/commands/create.go
@@ -184,10 +184,9 @@ var CreateCommand = &cli.Command{
 		// Check for contracts template and fetch if missing
 		if contractsFullURL != "" {
 			contractsDir := filepath.Join(targetDir, common.ContractsDir)
-			contractsDirReadme := filepath.Join(contractsDir, "README.md")
 
 			// Fetch the contracts directory if it does not exist in the template
-			if _, err := os.Stat(contractsDirReadme); os.IsNotExist(err) {
+			if _, err := os.Stat(contractsDir); os.IsNotExist(err) {
 				if err := fetcher.Fetch(cCtx.Context, contractsFullURL, contractsDir); err != nil {
 					log.Warn("Failed to fetch contracts template: %v", err)
 				}


### PR DESCRIPTION
<!-- 
    🚨 ATTENTION! 🚨 
    
    This PR template is REQUIRED. PRs not following this format will be closed without review.
    
    Requirements:
    - PR title must follow commit conventions: https://www.conventionalcommits.org/en/v1.0.0/
    - Label your PR with the correct type (e.g., 🐛 Bug, ✨ Enhancement, 🧪 Test, etc.)
    - Provide clear and specific details in each section
-->

**Motivation:**
<!--
Explain here the context, and why you're making that change. What is the problem you're trying to solve.
-->
We are checking for the existence of a `README.md` in the contracts dir, but the readme has been removed from the template.

**Modifications:**
<!--
Describe the modifications you've done from a high level. What are the key technical decisions and why were they made?
-->
- Checks if the dir exists instead

**Result:**
<!--
*After your change, what will change.
-->
- Shouldn't attempt to install the contracts directly
