### PR TITLE
fix: apply migration via transform to prevent skipping on insert

### DIFF
--- a/config/contexts/migrations/v0.0.2-v0.0.3.go
+++ b/config/contexts/migrations/v0.0.2-v0.0.3.go
@@ -12,8 +12,32 @@ func Migration_0_0_2_to_0_0_3(user, old, new *yaml.Node) (*yaml.Node, error) {
 		New:  new,
 		User: user,
 		Rules: []migration.PatchRule{
-			{Path: []string{"context", "chains", "l1", "fork", "block_time"}, Condition: migration.Always{}},
-			{Path: []string{"context", "chains", "l2", "fork", "block_time"}, Condition: migration.Always{}},
+			{
+				Path:      []string{"context", "chains", "l1", "fork"},
+				Condition: migration.Always{},
+				Transform: func(_ *yaml.Node) *yaml.Node {
+					// build the key node and scalar node
+					key := &yaml.Node{Kind: yaml.ScalarNode, Value: "block_time"}
+					val := &yaml.Node{Kind: yaml.ScalarNode, Value: migration.ResolveNode(new, []string{"context", "chains", "l1", "fork", "block_time"}).Value}
+					// clone the existing fork mapping, then append our new pair
+					forkMap := migration.CloneNode(migration.ResolveNode(user, []string{"context", "chains", "l1", "fork"}))
+					forkMap.Content = append(forkMap.Content, key, val)
+					return forkMap
+				},
+			},
+			{
+				Path:      []string{"context", "chains", "l2", "fork"},
+				Condition: migration.Always{},
+				Transform: func(_ *yaml.Node) *yaml.Node {
+					// build the key node and scalar node
+					key := &yaml.Node{Kind: yaml.ScalarNode, Value: "block_time"}
+					val := &yaml.Node{Kind: yaml.ScalarNode, Value: migration.ResolveNode(new, []string{"context", "chains", "l2", "fork", "block_time"}).Value}
+					// clone the existing fork mapping, then append our new pair
+					forkMap := migration.CloneNode(migration.ResolveNode(user, []string{"context", "chains", "l2", "fork"}))
+					forkMap.Content = append(forkMap.Content, key, val)
+					return forkMap
+				},
+			},
 		},
 	}
 	err := engine.Apply()


### PR DESCRIPTION
<!-- 
    🚨 ATTENTION! 🚨 
    
    This PR template is REQUIRED. PRs not following this format will be closed without review.
    
    Requirements:
    - PR title must follow commit conventions: https://www.conventionalcommits.org/en/v1.0.0/
    - Label your PR with the correct type (e.g., 🐛 Bug, ✨ Enhancement, 🧪 Test, etc.)
    - Provide clear and specific details in each section
-->

**Motivation:**
<!--
Explain here the context, and why you're making that change. What is the problem you're trying to solve.
-->
During migration from v0.0.2 to v0.0.3, we attempted to patch `fork.block_time` by replacing the scalar node directly, resulting in YAML like:

```
fork:
  3
```

which caused yaml.Unmarshal errors when decoding into common.ForkConfig (expecting a mapping). We need to insert new keys within existing mappings rather than overriding the entire mapping.

**Modifications:**
<!--
Describe the modifications you've done from a high level. What are the key technical decisions and why were they made?
-->
- We are now manually performing a transform which will place the new `block_time` into the users `fork` node

**Result:**
<!--
*After your change, what will change.
-->
- Migration is handled correctly

**Testing:**
<!--
*List testing procedures taken and useful artifacts.
-->
- Tested manually