### PR TITLE
fix: move all clones to fetch style clones and reinstate cached fetch

### DIFF
--- a/docker/anvil/docker-compose.yaml
+++ b/docker/anvil/docker-compose.yaml
@@ -3,6 +3,6 @@ services:
     image: ${FOUNDRY_IMAGE}
     container_name: ${AVS_CONTAINER_NAME} 
     entrypoint: anvil
-    command: "--host 0.0.0.0 --fork-url ${FORK_RPC_URL} --fork-block-number ${FORK_BLOCK_NUMBER}  ${ANVIL_ARGS}"
+    command: "--host 0.0.0.0 --fork-url ${FORK_RPC_URL} --fork-block-number ${FORK_BLOCK_NUMBER} ${ANVIL_ARGS}"
     ports:
       - "${DEVNET_PORT}:8545"

--- a/pkg/commands/create.go
+++ b/pkg/commands/create.go
@@ -213,7 +213,7 @@ var CreateCommand = &cli.Command{
 
 		// Initialize git repository in the project directory
 		if err := initGitRepo(cCtx, targetDir, cCtx.Bool("verbose")); err != nil {
-			log.Warn("Failed to initialize Git repository in %s: %v", targetDir, err)
+			return fmt.Errorf("failed to initialize Git repository in %s: %v", targetDir, err)
 		}
 
 		log.Info("\nProject %s created successfully in %s. Run 'cd %s' to get started.", projectName, targetDir, targetDir)

--- a/pkg/commands/create.go
+++ b/pkg/commands/create.go
@@ -446,12 +446,12 @@ func initGitRepo(ctx *cli.Context, targetDir string, verbose bool) error {
 	cmd = exec.CommandContext(ctx.Context, "git", "add", ".")
 	cmd.Dir = targetDir
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("❌ Failed to start devnet: %w", err)
+		log.Warn("failed to stage initial commit")
 	}
 	cmd = exec.CommandContext(ctx.Context, "git", "commit", "-m", "feat: initial commit")
 	cmd.Dir = targetDir
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("❌ Failed to start devnet: %w", err)
+		log.Warn("failed initial commit", err)
 	}
 
 	if verbose {

--- a/pkg/commands/create_test.go
+++ b/pkg/commands/create_test.go
@@ -93,7 +93,7 @@ func TestCreateCommand(t *testing.T) {
 		}
 
 		// Create config.yaml
-		return copyDefaultConfigToProject(targetDir, projectName, "https://github.com/Layr-Labs/hourglass-avs-template", "v0.0.9", false)
+		return copyDefaultConfigToProject(targetDir, projectName, "https://github.com/Layr-Labs/hourglass-avs-template", "v0.0.7", false)
 	}
 
 	app := &cli.App{
@@ -136,11 +136,11 @@ func TestCreateCommand(t *testing.T) {
 build:
 	@echo "Mock build executed"
 	`
-	t.Logf("Creating makefile path: %s", filepath.Join(projectPath, contractsBasePath))
-	if err := os.MkdirAll(filepath.Join(projectPath, contractsBasePath), 0775); err != nil {
+	t.Logf("Creating makefile path: %s", filepath.Join(projectPath, ".devkit", "contracts"))
+	if err := os.MkdirAll(filepath.Join(projectPath, ".devkit", "contracts"), 0775); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(projectPath, contractsBasePath, common.Makefile), []byte(mockMakefile), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(projectPath, ".devkit", "contracts", common.Makefile), []byte(mockMakefile), 0644); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/commands/template/upgrade_test.go
+++ b/pkg/commands/template/upgrade_test.go
@@ -138,7 +138,7 @@ func TestUpgradeCommand(t *testing.T) {
   project:
     name: template-upgrade-test
     templateBaseUrl: https://github.com/Layr-Labs/hourglass-avs-template
-    templateVersion: v0.0.3
+    templateVersion: v0.0.5
 `
 	configPath := filepath.Join(configDir, common.BaseConfig)
 	err = os.WriteFile(configPath, []byte(configContent), 0644)
@@ -150,7 +150,7 @@ func TestUpgradeCommand(t *testing.T) {
 	mockTemplateInfoGetter := &MockTemplateInfoGetter{
 		projectName:     "template-upgrade-test",
 		templateURL:     "https://github.com/Layr-Labs/hourglass-avs-template",
-		templateVersion: "v0.0.3",
+		templateVersion: "v0.0.5",
 	}
 
 	// Create the test command with mocked dependencies
@@ -181,7 +181,7 @@ func TestUpgradeCommand(t *testing.T) {
 	t.Run("Upgrade command with version", func(t *testing.T) {
 		// Create a flag set and context
 		set := flag.NewFlagSet("test", 0)
-		set.String("version", "v0.0.4", "")
+		set.String("version", "v0.0.6", "")
 		ctx := cli.NewContext(app, set, nil)
 
 		// Run the upgrade command (which is our test command with mocks)
@@ -210,8 +210,8 @@ func TestUpgradeCommand(t *testing.T) {
 			}
 		}
 
-		if templateVersion != "v0.0.4" {
-			t.Errorf("Template version not updated. Expected 'v0.0.4', got '%s'", templateVersion)
+		if templateVersion != "v0.0.6" {
+			t.Errorf("Template version not updated. Expected 'v0.0.6', got '%s'", templateVersion)
 		}
 	})
 

--- a/pkg/template/git_client.go
+++ b/pkg/template/git_client.go
@@ -181,7 +181,7 @@ func (g *execGitClient) Clone(ctx context.Context, repoURL, dest string, opts Cl
 		// prepare fetch of all heads and tags
 		fetchArgs := []string{
 			"fetch", "--depth=1", "origin",
-			"+refs/heads/*:refs/heads/*",
+			"+refs/heads/*:refs/remotes/origin/*",
 			"+refs/tags/*:refs/tags/*",
 		}
 		// conditionally append --progress
@@ -196,7 +196,7 @@ func (g *execGitClient) Clone(ctx context.Context, repoURL, dest string, opts Cl
 		// rev-parse the sha
 		if g.isSHA.MatchString(opts.Ref) {
 			sha = opts.Ref
-		} else if out, err := g.run(ctx, dest, CloneOptions{}, "rev-parse", "--verify", "refs/heads/"+opts.Ref); err == nil {
+		} else if out, err := g.run(ctx, dest, CloneOptions{}, "rev-parse", "--verify", "refs/remotes/origin/"+opts.Ref); err == nil {
 			sha = strings.TrimSpace(string(out))
 		} else if out, err := g.run(ctx, dest, CloneOptions{}, "rev-parse", "--verify", "refs/tags/"+opts.Ref+"^{}"); err == nil {
 			sha = strings.TrimSpace(string(out))

--- a/pkg/template/git_client.go
+++ b/pkg/template/git_client.go
@@ -15,12 +15,14 @@ import (
 
 type GitClient interface {
 	Clone(ctx context.Context, repoURL, dest string, opts CloneOptions) error
+	MainRepoClone(ctx context.Context, repoURL, dest string, opts CloneOptions) error
 	Checkout(ctx context.Context, repoDir, commit string) error
 	WorktreeCheckout(ctx context.Context, mirrorPath, commit, worktreePath string) error
 	SubmoduleList(ctx context.Context, repoDir string) ([]Submodule, error)
 	SubmoduleCommit(ctx context.Context, repoDir, path string) (string, error)
 	ResolveRemoteCommit(ctx context.Context, repoURL, branch string) (string, error)
 	RetryClone(ctx context.Context, repoURL, dest string, opts CloneOptions, maxRetries int) error
+	RetryMainRepoClone(ctx context.Context, repoURL, dest string, opts CloneOptions, maxRetries int) error
 	SubmoduleClone(
 		ctx context.Context,
 		submodule Submodule,
@@ -41,7 +43,6 @@ type GitClient interface {
 type CloneOptions struct {
 	// Ref is the branch, commit or tag to checkout after cloning
 	Ref         string
-	Depth       int
 	Bare        bool
 	Dissociate  bool
 	NoHardlinks bool
@@ -130,27 +131,16 @@ func (g *execGitClient) run(ctx context.Context, dir string, opts CloneOptions, 
 func (g *execGitClient) Clone(ctx context.Context, repoURL, dest string, opts CloneOptions) error {
 	args := []string{"clone"}
 
-	// TODO(seanmcgary): commented this out since this breaks when passing a commit hash
-	// since a commit hash is not a branch.
-	//
-	// the other flags also break the case of passing a commit hash
-
-	// handle flags for bare, depth, branch, dissociate, and no-hardlinks
-	//if opts.Bare {
-	//	args = append(args, "--bare")
-	//}
-	// if opts.Depth > 0 {
-	// 	args = append(args, fmt.Sprintf("--depth=%d", opts.Depth))
-	// }
-	// if opts.Ref != "" {
-	// 	args = append(args, "-b", opts.Ref)
-	// }
-	// if opts.Dissociate {
-	// 	args = append(args, "--dissociate")
-	// }
-	// if opts.NoHardlinks {
-	// 	args = append(args, "--no-hardlinks")
-	// }
+	// handle flags for bare, depth, dissociate, and no-hardlinks
+	if opts.Bare {
+		args = append(args, "--bare")
+	}
+	if opts.Dissociate {
+		args = append(args, "--dissociate")
+	}
+	if opts.NoHardlinks {
+		args = append(args, "--no-hardlinks")
+	}
 
 	// add the --progress flag for tracking progress
 	args = append(args, "--progress")
@@ -171,6 +161,44 @@ func (g *execGitClient) RetryClone(ctx context.Context, repoURL, dest string, op
 	var err error
 	for attempt := 0; attempt+1 <= maxRetries; attempt++ {
 		err = g.Clone(ctx, repoURL, dest, opts)
+		if err == nil {
+			return nil
+		}
+		time.Sleep(time.Duration(attempt+1) * 250 * time.Millisecond)
+	}
+	return fmt.Errorf("failed after %d retries: %w", maxRetries, err)
+}
+
+func (g *execGitClient) MainRepoClone(ctx context.Context, repoURL, dest string, opts CloneOptions) error {
+	// mkdir and cd
+	if err := os.MkdirAll(dest, 0755); err != nil {
+		return fmt.Errorf("mkdir %s: %v", dest, err)
+	}
+	// init bare repo
+	if out, err := g.run(ctx, dest, CloneOptions{}, "init", "--bare"); err != nil {
+		return fmt.Errorf("git init --bare: %s", out)
+	}
+	// add remote
+	if _, err := g.run(ctx, dest, CloneOptions{}, "remote", "add", "origin", repoURL); err != nil {
+		return fmt.Errorf("git remote add origin failed: %w", err)
+	}
+	// fetch only the exact ref shallowly
+	refspec := fmt.Sprintf("%s:refs/heads/tmp", opts.Ref)
+	if _, err := g.run(ctx, dest, CloneOptions{}, "fetch", "--depth", "1", "origin", refspec, "--progress"); err != nil {
+		return fmt.Errorf("git fetch %s failed: %w", refspec, err)
+	}
+	// set HEAD to tmp
+	if _, err := g.run(ctx, dest, CloneOptions{}, "symbolic-ref", "HEAD", "refs/heads/tmp"); err != nil {
+		return fmt.Errorf("git symbolic-ref HEAD failed: %w", err)
+	}
+
+	return nil
+}
+
+func (g *execGitClient) RetryMainRepoClone(ctx context.Context, repoURL, dest string, opts CloneOptions, maxRetries int) error {
+	var err error
+	for attempt := 0; attempt+1 <= maxRetries; attempt++ {
+		err = g.MainRepoClone(ctx, repoURL, dest, opts)
 		if err == nil {
 			return nil
 		}

--- a/pkg/template/git_client.go
+++ b/pkg/template/git_client.go
@@ -46,7 +46,7 @@ type CloneOptions struct {
 }
 
 type Submodule struct {
-	Name, Path, URL, Branch string
+	Name, Path, URL, Branch, Commit string
 }
 
 type SubmoduleFailure struct {

--- a/pkg/template/git_fetcher.go
+++ b/pkg/template/git_fetcher.go
@@ -111,13 +111,13 @@ func (g *GitFetcher) fetchMainRepo(ctx context.Context, repoURL, ref, commit, te
 		return false, fmt.Errorf("failed to clone into cache: %w", err)
 	}
 
+	// Checkout after cloning completes
 	if err := g.Git.Checkout(ctx, targetDir, ref); err != nil {
 		return false, fmt.Errorf("failed to checkout ref: %w", err)
 	}
-	g.Logger.Info("Checked out ref %s\n", ref)
 
 	// set progress to complete in logger if we cloned fresh
-	g.Logger.SetProgress(cachePath, 100, templateName)
+	g.Logger.SetProgress(cachePath, 100, fmt.Sprintf("%s - Checked out ref %s", templateName, ref))
 	g.Logger.PrintProgress()
 
 	// clear progress reporting

--- a/pkg/template/git_fetcher.go
+++ b/pkg/template/git_fetcher.go
@@ -77,10 +77,8 @@ func (g *GitFetcher) fetchMainRepo(ctx context.Context, repoURL, ref, commit, te
 	if g.Config.UseCache && commit != "HEAD" {
 		if _, ok := g.Cache.Get(repoURL, commit); !ok {
 			// call Clone with progress tracking
-			err := g.Git.RetryClone(ctx, repoURL, cachePath, CloneOptions{
-				Ref:   ref,
-				Depth: 1,
-				Bare:  true,
+			err := g.Git.RetryMainRepoClone(ctx, repoURL, cachePath, CloneOptions{
+				Ref: ref,
 				ProgressCB: func(p int) {
 					g.Logger.SetProgress(cachePath, p, templateName)
 					g.Logger.PrintProgress()
@@ -98,8 +96,6 @@ func (g *GitFetcher) fetchMainRepo(ctx context.Context, repoURL, ref, commit, te
 
 	// call Clone to copy cached repo to targetDir
 	err := g.Git.Clone(ctx, repoURL, targetDir, CloneOptions{
-		Ref:         ref,
-		Depth:       1,
 		Dissociate:  true,
 		NoHardlinks: true,
 		ProgressCB: func(p int) {

--- a/pkg/template/git_fetcher.go
+++ b/pkg/template/git_fetcher.go
@@ -110,13 +110,13 @@ func (g *GitFetcher) fetchMainRepo(ctx context.Context, repoURL, ref, templateNa
 	g.Logger.ClearProgress()
 
 	// always process submodules after cloning or copying from cache
-	// if err := g.fetchSubmodules(ctx, templateName, repoURL, targetDir, 0); err != nil {
-	// 	return false, fmt.Errorf("failed to fetch submodules: %w", err)
-	// }
-
-	if err := g.vanillaFetchSubmodules(ctx, targetDir); err != nil {
+	if err := g.fetchSubmodules(ctx, templateName, repoURL, targetDir, 0); err != nil {
 		return false, fmt.Errorf("failed to fetch submodules: %w", err)
 	}
+
+	// if err := g.vanillaFetchSubmodules(ctx, targetDir); err != nil {
+	// 	return false, fmt.Errorf("failed to fetch submodules: %w", err)
+	// }
 
 	return true, nil
 }

--- a/pkg/template/git_fetcher_test.go
+++ b/pkg/template/git_fetcher_test.go
@@ -2,11 +2,12 @@ package template
 
 import (
 	"context"
-	"github.com/Layr-Labs/devkit-cli/pkg/common/logger"
-	"github.com/Layr-Labs/devkit-cli/pkg/common/progress"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/Layr-Labs/devkit-cli/pkg/common/logger"
+	"github.com/Layr-Labs/devkit-cli/pkg/common/progress"
 )
 
 func TestGitFetcher_InvalidURL(t *testing.T) {
@@ -126,11 +127,11 @@ func TestGitFetcher_MaxDepth(t *testing.T) {
 	cmdCtx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	err := fetcher.Fetch(cmdCtx, repo, "master", tempDir)
+	err := fetcher.Fetch(cmdCtx, repo, "v0.0.8", tempDir)
 	if err != nil {
 		t.Fatalf("unexpected error fetching repo with depth: %v", err)
 	}
-	visited := filepath.Join(tempDir, ".devkit/contracts")
+	visited := filepath.Join(tempDir, ".devkit", "contracts")
 	if _, err := os.Stat(visited); err != nil {
 		t.Fatalf("expected top-level submodule not found")
 	}


### PR DESCRIPTION
<!-- 
    🚨 ATTENTION! 🚨 
    
    This PR template is REQUIRED. PRs not following this format will be closed without review.
    
    Requirements:
    - PR title must follow commit conventions: https://www.conventionalcommits.org/en/v1.0.0/
    - Label your PR with the correct type (e.g., 🐛 Bug, ✨ Enhancement, 🧪 Test, etc.)
    - Provide clear and specific details in each section
-->

**Motivation:**
<!--
Explain here the context, and why you're making that change. What is the problem you're trying to solve.
-->
This PR is a followup to https://github.com/Layr-Labs/devkit-cli/pull/124, it reinstates the cached fetch that was removed and tidies up the submodule associations following the deletion of the root level `.git` dir.

**Modifications:**
<!--
Describe the modifications you've done from a high level. What are the key technical decisions and why were they made?
-->
- Moves clones to use `fetch` over `clone` to allow clones from `tag`, `branch` or `commit`
- Retains the submodule setup from the template so that `./.devkit/contracts` dir isn't checked in

**Result:**
<!--
*After your change, what will change.
-->
- Clones now work from a `tag`, `branch` or `commit`
- `./.devkit/contracts` is no longer checked in

**Testing:**
<!--
*List testing procedures taken and useful artifacts.
-->
- All tests are aligned with changes and has been tested manually end to end
