### PR TITLE
docs: use make install for build from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,11 @@ To add the binary to your path, run:
 export PATH=$PATH:~/bin
 ```
 
-To build and install the devkit cli locally:
+To build and install the devkit cli from source:
 ```bash
 git clone https://github.com/Layr-Labs/devkit-cli
 cd devkit-cli
-go build -o devkit ./cmd/devkit
+make install
 export PATH=$PATH:~/bin
 ```
 


### PR DESCRIPTION
<!-- 
    🚨 ATTENTION! 🚨 
    
    This PR template is REQUIRED. PRs not following this format will be closed without review.
    
    Requirements:
    - PR title must follow commit conventions: https://www.conventionalcommits.org/en/v1.0.0/
    - Label your PR with the correct type (e.g., 🐛 Bug, ✨ Enhancement, 🧪 Test, etc.)
    - Provide clear and specific details in each section
-->

**Motivation:**
<!--
Explain here the context, and why you're making that change. What is the problem you're trying to solve.
-->
In the docs we instruct the user to build from source using `go build` this skips the `ldflags` we inject on `make install` and leaves certain things unset (such as the version/commit).

**Modifications:**
<!--
Describe the modifications you've done from a high level. What are the key technical decisions and why were they made?
-->
- Change instructions for building from source to use `make install`

**Result:**
<!--
*After your change, what will change.
-->
- Users building from source will see the correct version/commit when they run `devkit version`

**Testing:**
<!--
*List testing procedures taken and useful artifacts.
-->
- Test locally
