### PR TITLE
feat: teardown anvil container when run script is cancelled

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -57,8 +57,8 @@ jobs:
       - name: Start devnet
         run: |
           cd ./my-awesome-avs/
-          devkit avs devnet start
-          sleep 10
+          DOCKERS_HOST=172.17.0.1 devkit avs devnet start &
+          sleep 60
 
       - name: Check devnet RPC is live
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -58,7 +58,10 @@ jobs:
         run: |
           cd ./my-awesome-avs/
           devkit avs devnet start &
-          sleep 60
+          # wait until executor and aggregator are available
+          until nc -z localhost 9090 && nc -z localhost 8081; do
+            sleep 1
+          done
 
       - name: Check devnet RPC is live
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Start devnet
         run: |
           cd ./my-awesome-avs/
-          DOCKERS_HOST=172.17.0.1 devkit avs devnet start &
+          devkit avs devnet start &
           sleep 60
 
       - name: Check devnet RPC is live

--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ devkit avs template info
 2025/05/22 14:42:36 Project template information:
 2025/05/22 14:42:36   Project name: <your project>
 2025/05/22 14:42:36   Template URL: https://github.com/Layr-Labs/hourglass-avs-template
-2025/05/22 14:42:36   Version: v0.0.10
+2025/05/22 14:42:36   Version: v0.0.11
 ```
 
 **_Upgrade to a newer version_**

--- a/config/templates.yaml
+++ b/config/templates.yaml
@@ -3,7 +3,7 @@ architectures:
     languages:
       go:
         baseUrl: "https://github.com/Layr-Labs/hourglass-avs-template"
-        version: "v0.0.10"
+        version: "v0.0.11"
       ts:
         baseUrl: ""
         version: ""

--- a/pkg/commands/create_test.go
+++ b/pkg/commands/create_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Layr-Labs/devkit-cli/config/configs"
 	"github.com/Layr-Labs/devkit-cli/config/contexts"
 	"github.com/Layr-Labs/devkit-cli/pkg/common"
+	"github.com/Layr-Labs/devkit-cli/pkg/template"
 	"github.com/Layr-Labs/devkit-cli/pkg/testutils"
 
 	"github.com/stretchr/testify/assert"
@@ -92,8 +93,20 @@ func TestCreateCommand(t *testing.T) {
 			return err
 		}
 
+		// Load the current config
+		config, err := template.LoadConfig()
+		if err != nil {
+			t.Fatalf("Failed to load config: %v", err)
+		}
+
+		// Test template URL lookup
+		mainBaseURL, mainVersion, err := template.GetTemplateURLs(config, "task", "go")
+		if err != nil {
+			t.Fatalf("Failed to get template URLs: %v", err)
+		}
+
 		// Create config.yaml
-		return copyDefaultConfigToProject(logger, targetDir, projectName, "https://github.com/Layr-Labs/hourglass-avs-template", "v0.0.11")
+		return copyDefaultConfigToProject(logger, targetDir, projectName, mainBaseURL, mainVersion)
 	}
 
 	app := &cli.App{

--- a/pkg/commands/create_test.go
+++ b/pkg/commands/create_test.go
@@ -93,7 +93,7 @@ func TestCreateCommand(t *testing.T) {
 		}
 
 		// Create config.yaml
-		return copyDefaultConfigToProject(logger, targetDir, projectName, "https://github.com/Layr-Labs/hourglass-avs-template", "v0.0.10")
+		return copyDefaultConfigToProject(logger, targetDir, projectName, "https://github.com/Layr-Labs/hourglass-avs-template", "v0.0.11")
 	}
 
 	app := &cli.App{

--- a/pkg/commands/devnet_actions.go
+++ b/pkg/commands/devnet_actions.go
@@ -934,12 +934,12 @@ func extractContractOutputs(cCtx *cli.Context, context string, contractsList []D
 			ABI interface{} `json:"abi"`
 		}
 		if err := json.Unmarshal(raw, &abi); err != nil {
-			return fmt.Errorf("unmarshal artifact JSON: %w", err)
+			return fmt.Errorf("unmarshal artifact JSON for %s (%s) failed: %w", nameVal, addressVal, err)
 		}
 
 		// Check if provided abi is valid
 		if err := common.IsValidABI(abi.ABI); err != nil {
-			return fmt.Errorf("ABI is invalid: %v", err)
+			return fmt.Errorf("ABI for %s (%s) is invalid: %v", nameVal, addressVal, err)
 		}
 
 		// Build the output struct
@@ -952,13 +952,13 @@ func extractContractOutputs(cCtx *cli.Context, context string, contractsList []D
 		// Marshal with indentation
 		data, err := json.MarshalIndent(out, "", "  ")
 		if err != nil {
-			return fmt.Errorf("marshal output for %s: %w", nameVal, err)
+			return fmt.Errorf("marshal output for %s (%s): %w", nameVal, addressVal, err)
 		}
 
 		// Write to ./contracts/outputs/<context>/<name>.json
 		outPath := filepath.Join(outDir, nameVal+".json")
 		if err := os.WriteFile(outPath, data, 0o644); err != nil {
-			return fmt.Errorf("write %s: %w", outPath, err)
+			return fmt.Errorf("write output to %s (%s): %w", outPath, addressVal, err)
 		}
 
 		logger.Info("Written contract output: %s\n", outPath)

--- a/pkg/commands/devnet_actions.go
+++ b/pkg/commands/devnet_actions.go
@@ -193,7 +193,7 @@ func StartDevnetAction(cCtx *cli.Context) error {
 	}
 
 	// On cancel, always call down if skipAvsRun=false
-	if !skipAvsRun {
+	if !skipDeployContracts && !skipAvsRun {
 		defer func() {
 			logger.Info("Stopping containers")
 			// clone cCtx but overwrite the context to Background

--- a/pkg/commands/devnet_actions.go
+++ b/pkg/commands/devnet_actions.go
@@ -205,7 +205,7 @@ func StartDevnetAction(cCtx *cli.Context) error {
 		}()
 	}
 
-	// Constuct RPC url to pass to scripts
+	// Construct RPC url to pass to scripts
 	rpcUrl := devnet.GetRPCURL(port)
 	logger.Info("Waiting for devnet to be ready...")
 

--- a/pkg/commands/devnet_test.go
+++ b/pkg/commands/devnet_test.go
@@ -136,6 +136,7 @@ func TestStartDevnetOnUsedPort_ShouldFail(t *testing.T) {
 	}
 	_ = stopApp.Run([]string{"devkit", "--port", port, "--verbose"})
 }
+
 func TestStartDevnet_WithDeployContracts(t *testing.T) {
 	os.Setenv("SKIP_DEVNET_FUNDING", "true")
 	originalCwd, err := os.Getwd()

--- a/pkg/common/devnet/utils.go
+++ b/pkg/common/devnet/utils.go
@@ -2,7 +2,6 @@ package devnet
 
 import (
 	"fmt"
-	"log"
 	"net"
 	"net/url"
 	"os"
@@ -12,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Layr-Labs/devkit-cli/pkg/common"
 	"github.com/urfave/cli/v2"
 )
 
@@ -29,15 +29,17 @@ func IsPortAvailable(port int) bool {
 
 // / Stops the container and removes it
 func StopAndRemoveContainer(ctx *cli.Context, containerName string) {
+	logger := common.LoggerFromContext(ctx.Context)
+
 	if err := exec.CommandContext(ctx.Context, "docker", "stop", containerName).Run(); err != nil {
-		log.Printf("⚠️ Failed to stop container %s: %v", containerName, err)
+		logger.Error("⚠️  Failed to stop container %s: %v", containerName, err)
 	} else {
-		log.Printf("✅ Stopped container %s", containerName)
+		logger.Info("✅ Stopped container %s", containerName)
 	}
 	if err := exec.CommandContext(ctx.Context, "docker", "rm", containerName).Run(); err != nil {
-		log.Printf("⚠️ Failed to remove container %s: %v", containerName, err)
+		logger.Error("⚠️  Failed to remove container %s: %v", containerName, err)
 	} else {
-		log.Printf("✅ Removed container %s", containerName)
+		logger.Info("✅ Removed container %s", containerName)
 	}
 }
 
@@ -64,7 +66,7 @@ func GetDockerHost() string {
 
 	// Detect OS and set appropriate default
 	if runtime.GOOS == "linux" {
-		return "localhost"
+		return "172.17.0.1"
 	} else {
 		return "host.docker.internal"
 	}

--- a/pkg/common/devnet/utils.go
+++ b/pkg/common/devnet/utils.go
@@ -57,7 +57,7 @@ func GetDockerPsDevnetArgs() []string {
 
 // GetDockerHost returns the appropriate Docker host based on environment and platform.
 // Uses DOCKERS_HOST environment variable if set, otherwise detects OS:
-// - Linux: defaults to localhost (Docker containers can access host via localhost)
+// - Linux: defaults to 172.17.0.1 (Docker containers can access host via localhost)
 // - macOS/Windows: defaults to host.docker.internal (required for Docker Desktop)
 func GetDockerHost() string {
 	if dockersHost := os.Getenv("DOCKERS_HOST"); dockersHost != "" {

--- a/pkg/common/devnet/utils_test.go
+++ b/pkg/common/devnet/utils_test.go
@@ -52,7 +52,7 @@ func TestGetDockerHost(t *testing.T) {
 				assert.Equal(t, tt.expected, result)
 			} else {
 				// When DOCKERS_HOST is empty, should return platform-specific default
-				assert.Contains(t, []string{"localhost", "host.docker.internal"}, result)
+				assert.Contains(t, []string{"172.17.0.1", "host.docker.internal"}, result)
 			}
 		})
 	}

--- a/pkg/common/scripts_caller.go
+++ b/pkg/common/scripts_caller.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"syscall"
 
 	"github.com/Layr-Labs/devkit-cli/pkg/common/iface"
 )
@@ -35,10 +36,26 @@ func CallTemplateScript(cmdCtx context.Context, logger iface.Logger, dir string,
 	cmd.Stdout = &stdout
 	cmd.Stderr = os.Stderr
 
+	// Run the command in its own group
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	// When context is canceled, forward SIGINT
+	go func() {
+		<-cmdCtx.Done()
+		// kill the whole group: negative PID means process group
+		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGINT)
+	}()
+
 	// Exec the command
 	if err := cmd.Run(); err != nil {
+		// if it’s an ExitError, check if it was killed by a signal
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {
+			if ws, ok := exitErr.ProcessState.Sys().(syscall.WaitStatus); ok && ws.Signaled() {
+				// killed by signal -> treat as cancellation
+				return nil, cmdCtx.Err()
+			}
+			// nonzero exit code
 			return nil, fmt.Errorf("script %s exited with code %d", scriptPath, exitErr.ExitCode())
 		}
 		return nil, fmt.Errorf("failed to run script %s: %w", scriptPath, err)

--- a/pkg/common/scripts_caller.go
+++ b/pkg/common/scripts_caller.go
@@ -39,11 +39,12 @@ func CallTemplateScript(cmdCtx context.Context, logger iface.Logger, dir string,
 	// Run the command in its own group
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
-	// When context is canceled, forward SIGINT
+	// When context is canceled, forward SIGINT (but only if the process is running)
 	go func() {
 		<-cmdCtx.Done()
-		// kill the whole group: negative PID means process group
-		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGINT)
+		if cmd.Process != nil {
+			_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGINT)
+		}
 	}()
 
 	// Exec the command

--- a/pkg/template/config_test.go
+++ b/pkg/template/config_test.go
@@ -17,7 +17,7 @@ func TestLoadConfig(t *testing.T) {
 	}
 
 	expectedBaseURL := "https://github.com/Layr-Labs/hourglass-avs-template"
-	expectedVersion := "v0.0.10"
+	expectedVersion := "v0.0.11"
 
 	if mainBaseURL != expectedBaseURL {
 		t.Errorf("Unexpected main template base URL: got %s, want %s", mainBaseURL, expectedBaseURL)


### PR DESCRIPTION
<!-- 
    🚨 ATTENTION! 🚨 
    
    This PR template is REQUIRED. PRs not following this format will be closed without review.
    
    Requirements:
    - PR title must follow commit conventions: https://www.conventionalcommits.org/en/v1.0.0/
    - Label your PR with the correct type (e.g., 🐛 Bug, ✨ Enhancement, 🧪 Test, etc.)
    - Provide clear and specific details in each section
-->

**Motivation:**
<!--
Explain here the context, and why you're making that change. What is the problem you're trying to solve.
-->
When the user cancels after a `devnet start` we teardown the offchain infra, but we do not kill the anvil instance.

**Modifications:**
<!--
Describe the modifications you've done from a high level. What are the key technical decisions and why were they made?
-->
- Propagate `AvsRun` cancellation to anvil container

**Result:**
<!--
*After your change, what will change.
-->
- All containers will close following a cancellation on `devnet start` UNLESS `--skip-avs-run` is provided

**Testing:**
<!--
*List testing procedures taken and useful artifacts.
-->
- Tested manually
