### PR TITLE
feat: save contract artefacts to ./contracts/outputs/<context>/<name>.json

### DIFF
--- a/pkg/commands/create.go
+++ b/pkg/commands/create.go
@@ -102,7 +102,7 @@ var CreateCommand = &cli.Command{
 		}
 
 		// Create project directories
-		if err := createProjectDir(logger, targetDir, cCtx.Bool("overwrite"), cCtx.Bool("verbose")); err != nil {
+		if err := createProjectDir(logger, targetDir, cCtx.Bool("overwrite")); err != nil {
 			return err
 		}
 
@@ -225,8 +225,7 @@ func getTemplateURLs(cCtx *cli.Context) (string, string, error) {
 	return mainBaseURL, mainVersion, nil
 }
 
-func createProjectDir(logger iface.Logger, targetDir string, overwrite, verbose bool) error {
-
+func createProjectDir(logger iface.Logger, targetDir string, overwrite bool) error {
 	// Check if directory exists and handle overwrite
 	if _, err := os.Stat(targetDir); !os.IsNotExist(err) {
 

--- a/pkg/commands/devnet_actions.go
+++ b/pkg/commands/devnet_actions.go
@@ -922,6 +922,11 @@ func extractContractOutputs(cCtx *cli.Context, context string, contractsList []D
 			return fmt.Errorf("unmarshal artifact JSON: %w", err)
 		}
 
+		// Check if provided abi is valid
+		if err := common.IsValidABI(abi.ABI); err != nil {
+			return fmt.Errorf("ABI is invalid: %v", err)
+		}
+
 		// Build the output struct
 		out := DeployContractJson{
 			Name:    nameVal,

--- a/pkg/commands/devnet_actions.go
+++ b/pkg/commands/devnet_actions.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/fs"
 	"math/big"
 	"os"
 	"os/exec"
@@ -29,6 +30,12 @@ import (
 	allocationmanager "github.com/Layr-Labs/eigenlayer-contracts/pkg/bindings/AllocationManager"
 	"gopkg.in/yaml.v3"
 )
+
+type DeployContractOutput struct {
+	Name    string      `json:"name"`
+	Address string      `json:"address"`
+	ABI     interface{} `json:"abi"`
+}
 
 func StartDevnetAction(cCtx *cli.Context) error {
 
@@ -281,13 +288,14 @@ func DeployContractsAction(cCtx *cli.Context) error {
 
 	// Run scriptPath from cwd
 	const dir = ""
+	const context = "devnet" // @TODO: use selected context name
 
 	// Set path for .devkit scripts
 	scriptsDir := filepath.Join(".devkit", "scripts")
 
 	// Set path for context yaml
 	contextDir := filepath.Join("config", "contexts")
-	yamlPath := path.Join(contextDir, "devnet.yaml") // @TODO: use selected context name
+	yamlPath := path.Join(contextDir, fmt.Sprintf("%s.%s", context, "yaml"))
 
 	// Load YAML as *yaml.Node
 	rootNode, err := common.LoadYAML(yamlPath)
@@ -312,7 +320,7 @@ func DeployContractsAction(cCtx *cli.Context) error {
 	// Check for context
 	contextNode := common.GetChildByKey(rootNode.Content[0], "context")
 	if contextNode == nil {
-		return fmt.Errorf("missing 'context' key in ./config/contexts/devnet.yaml")
+		return fmt.Errorf("missing 'context' key in ./config/contexts/%s.yaml", context)
 	}
 
 	// Loop scripts with cloned context
@@ -354,6 +362,22 @@ func DeployContractsAction(cCtx *cli.Context) error {
 
 		// Merge output into original context node
 		common.DeepMerge(contextNode, outNode)
+	}
+
+	// Create output .json files for each of the deployed contracts
+	contracts := common.GetChildByKey(contextNode, "deployed_contracts")
+	if contracts == nil {
+		return fmt.Errorf("deployed_contracts node not found")
+	}
+	var contractsList []map[string]interface{}
+	if err := contracts.Decode(&contractsList); err != nil {
+		return fmt.Errorf("decode deployed_contracts: %w", err)
+	}
+	// Empty log line to split these logs from the main body for easy identification
+	logger.Info("")
+	err = extractContractOutputs(cCtx, context, contractsList)
+	if err != nil {
+		return fmt.Errorf("failed to write contract artefacts: %w", err)
 	}
 
 	// Write yaml back to project directory
@@ -502,15 +526,6 @@ func ListDevnetContainersAction(cCtx *cli.Context) error {
 		)
 	}
 	return nil
-}
-
-func extractHostPort(portStr string) string {
-	if strings.Contains(portStr, "->") {
-		beforeArrow := strings.Split(portStr, "->")[0]
-		hostPort := strings.Split(beforeArrow, ":")
-		return hostPort[len(hostPort)-1]
-	}
-	return portStr
 }
 
 func UpdateAVSMetadataAction(cCtx *cli.Context, logger iface.Logger) error {
@@ -693,6 +708,62 @@ func RegisterOperatorsFromConfigAction(cCtx *cli.Context, logger iface.Logger) e
 	return nil
 }
 
+func FetchZeusAddressesAction(cCtx *cli.Context) error {
+	logger, _ := common.GetLoggerFromCLIContext(cCtx)
+	contextName := cCtx.String("context")
+
+	// Load config for the specified context
+	config, err := common.LoadConfigWithContextConfig(contextName)
+	if err != nil {
+		return fmt.Errorf("failed to load config for context %s: %w", contextName, err)
+	}
+
+	// Fetch addresses from Zeus
+	logger.Info("Fetching EigenLayer core addresses from Zeus...")
+	addresses, err := common.GetZeusAddresses(logger)
+	if err != nil {
+		return fmt.Errorf("failed to get addresses from Zeus: %w", err)
+	}
+
+	// Print the fetched addresses
+	logger.Info("Found addresses:")
+	logger.Info("AllocationManager: %s", addresses.AllocationManager)
+	logger.Info("DelegationManager: %s", addresses.DelegationManager)
+
+	// Update the context with the fetched addresses
+	err = common.UpdateContextWithZeusAddresses(logger, config, contextName)
+	if err != nil {
+		return fmt.Errorf("failed to update context with Zeus addresses: %w", err)
+	}
+
+	// Write the updated config to disk
+	contextFile := filepath.Join("config", "contexts", contextName+".yaml")
+	yamlData, err := yaml.Marshal(map[string]interface{}{
+		"version": "0.0.4", // This should ideally use the latest version dynamically
+		"context": config.Context[contextName],
+	})
+	if err != nil {
+		return fmt.Errorf("failed to marshal updated context: %w", err)
+	}
+
+	err = os.WriteFile(contextFile, yamlData, 0644)
+	if err != nil {
+		return fmt.Errorf("failed to write updated context file: %w", err)
+	}
+
+	logger.Info("Successfully updated %s context with EigenLayer core addresses", contextName)
+	return nil
+}
+
+func extractHostPort(portStr string) string {
+	if strings.Contains(portStr, "->") {
+		beforeArrow := strings.Split(portStr, "->")[0]
+		hostPort := strings.Split(beforeArrow, ":")
+		return hostPort[len(hostPort)-1]
+	}
+	return portStr
+}
+
 func registerOperatorEL(cCtx *cli.Context, operatorAddress string, logger iface.Logger) error {
 	if operatorAddress == "" {
 		return fmt.Errorf("operatorAddress parameter is required and cannot be empty")
@@ -822,6 +893,59 @@ func registerOperatorAVS(cCtx *cli.Context, logger iface.Logger, operatorAddress
 	)
 }
 
+func extractContractOutputs(cCtx *cli.Context, context string, contractsList []map[string]interface{}) error {
+	logger, _ := common.GetLoggerFromCLIContext(cCtx)
+
+	// Push contract artefacts to ./contracts/outputs
+	outDir := filepath.Join("contracts", "outputs", context)
+	if err := os.MkdirAll(outDir, fs.ModePerm); err != nil {
+		return fmt.Errorf("create output dir: %w", err)
+	}
+
+	// For each contract extract details and produce json file in outputs/<context>/<contract.name>.json
+	for _, contract := range contractsList {
+		nameVal, _ := contract["name"].(string)
+		addressVal, _ := contract["address"].(string)
+		abiPath, _ := contract["abi"].(string)
+
+		// Read the ABI file
+		raw, err := os.ReadFile(abiPath)
+		if err != nil {
+			return fmt.Errorf("read ABI %q: %w", abiPath, err)
+		}
+
+		// Temporary struct to pick only the "abi" field from the artifact
+		var abi struct {
+			ABI interface{} `json:"abi"`
+		}
+		if err := json.Unmarshal(raw, &abi); err != nil {
+			return fmt.Errorf("unmarshal artifact JSON: %w", err)
+		}
+
+		// Build the output struct
+		out := DeployContractOutput{
+			Name:    nameVal,
+			Address: addressVal,
+			ABI:     abi.ABI,
+		}
+
+		// Marshal with indentation
+		data, err := json.MarshalIndent(out, "", "  ")
+		if err != nil {
+			return fmt.Errorf("marshal output for %s: %w", nameVal, err)
+		}
+
+		// Write to ./contracts/outputs/<context>/<name>.json
+		outPath := filepath.Join(outDir, nameVal+".json")
+		if err := os.WriteFile(outPath, data, 0o644); err != nil {
+			return fmt.Errorf("write %s: %w", outPath, err)
+		}
+
+		logger.Info("Written contract output: %s\n", outPath)
+	}
+	return nil
+}
+
 func migrateConfig(logger iface.Logger) (int, error) {
 
 	// Set path for context yamls
@@ -849,7 +973,6 @@ func migrateConfig(logger iface.Logger) (int, error) {
 }
 
 func migrateContexts(logger iface.Logger) (int, error) {
-
 	// Count the number of contexts we migrate
 	contextsMigrated := 0
 
@@ -891,51 +1014,4 @@ func migrateContexts(logger iface.Logger) (int, error) {
 	}
 
 	return contextsMigrated, nil
-}
-
-func FetchZeusAddressesAction(cCtx *cli.Context) error {
-	logger, _ := common.GetLoggerFromCLIContext(cCtx)
-	contextName := cCtx.String("context")
-
-	// Load config for the specified context
-	config, err := common.LoadConfigWithContextConfig(contextName)
-	if err != nil {
-		return fmt.Errorf("failed to load config for context %s: %w", contextName, err)
-	}
-
-	// Fetch addresses from Zeus
-	logger.Info("Fetching EigenLayer core addresses from Zeus...")
-	addresses, err := common.GetZeusAddresses(logger)
-	if err != nil {
-		return fmt.Errorf("failed to get addresses from Zeus: %w", err)
-	}
-
-	// Print the fetched addresses
-	logger.Info("Found addresses:")
-	logger.Info("AllocationManager: %s", addresses.AllocationManager)
-	logger.Info("DelegationManager: %s", addresses.DelegationManager)
-
-	// Update the context with the fetched addresses
-	err = common.UpdateContextWithZeusAddresses(logger, config, contextName)
-	if err != nil {
-		return fmt.Errorf("failed to update context with Zeus addresses: %w", err)
-	}
-
-	// Write the updated config to disk
-	contextFile := filepath.Join("config", "contexts", contextName+".yaml")
-	yamlData, err := yaml.Marshal(map[string]interface{}{
-		"version": "0.0.4", // This should ideally use the latest version dynamically
-		"context": config.Context[contextName],
-	})
-	if err != nil {
-		return fmt.Errorf("failed to marshal updated context: %w", err)
-	}
-
-	err = os.WriteFile(contextFile, yamlData, 0644)
-	if err != nil {
-		return fmt.Errorf("failed to write updated context file: %w", err)
-	}
-
-	logger.Info("Successfully updated %s context with EigenLayer core addresses", contextName)
-	return nil
 }

--- a/pkg/commands/devnet_test.go
+++ b/pkg/commands/devnet_test.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -17,6 +18,7 @@ import (
 	"github.com/Layr-Labs/devkit-cli/pkg/testutils"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/urfave/cli/v2"
 	"sigs.k8s.io/yaml"
 )
@@ -560,6 +562,109 @@ func TestDeployContracts(t *testing.T) {
 	}
 	err = stopApp.Run([]string{"devkit", "--port", port, "--verbose"})
 	assert.NoError(t, err)
+}
+
+func TestDeployContracts_ExtractContractOutputs(t *testing.T) {
+	type fixture struct {
+		name     string
+		setup    func(baseDir string) ([]map[string]interface{}, error)
+		context  string
+		wantErr  bool
+		validate func(t *testing.T, baseDir string)
+	}
+
+	tests := []fixture{
+		{
+			name:    "successfully writes JSON output",
+			context: "devnet",
+			setup: func(baseDir string) ([]map[string]interface{}, error) {
+				// create a fake ABI file
+				abiDir := filepath.Join(baseDir, "artifacts")
+				require.NoError(t, os.MkdirAll(abiDir, 0o755))
+				abiPath := filepath.Join(abiDir, "MyToken.json")
+				rawABI := map[string]interface{}{
+					"abi": []interface{}{
+						map[string]interface{}{
+							"type": "function",
+							"name": "balanceOf",
+						},
+					},
+				}
+				data, err := json.Marshal(rawABI)
+				if err != nil {
+					return nil, err
+				}
+				require.NoError(t, os.WriteFile(abiPath, data, 0o644))
+
+				// build the contractsList
+				return []map[string]interface{}{
+					{
+						"name":    "MyToken",
+						"address": "0x1234ABCD",
+						"abi":     abiPath,
+					},
+				}, nil
+			},
+			wantErr: false,
+			validate: func(t *testing.T, baseDir string) {
+				outPath := filepath.Join(baseDir, "contracts", "outputs", "devnet", "MyToken.json")
+				b, err := os.ReadFile(outPath)
+				require.NoError(t, err, "output file must exist and be readable")
+
+				var out DeployContractOutput
+				require.NoError(t, json.Unmarshal(b, &out), "output JSON must unmarshal")
+
+				require.Equal(t, "MyToken", out.Name)
+				require.Equal(t, "0x1234ABCD", out.Address)
+				// ABI should match what we wrote
+				abiSlice, ok := out.ABI.([]interface{})
+				require.True(t, ok, "ABI should be a slice")
+				require.Len(t, abiSlice, 1)
+				entry, ok := abiSlice[0].(map[string]interface{})
+				require.True(t, ok)
+				require.Equal(t, "balanceOf", entry["name"])
+			},
+		},
+		{
+			name:    "error when ABI file missing",
+			context: "testnet",
+			setup: func(baseDir string) ([]map[string]interface{}, error) {
+				return []map[string]interface{}{
+					{
+						"name":    "NoAbiContract",
+						"address": "0xDEADBEEF",
+						"abi":     filepath.Join(baseDir, "no_such.json"),
+					},
+				}, nil
+			},
+			wantErr: true,
+			validate: func(t *testing.T, baseDir string) {
+				// nothing to validate on disk
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// each test in its own temp workspace
+			baseDir := t.TempDir()
+			require.NoError(t, os.Chdir(baseDir))
+
+			contractsList, err := tc.setup(baseDir)
+			require.NoError(t, err)
+
+			// use a minimal cli.Context
+			cCtx := cli.NewContext(nil, nil, nil)
+			err = extractContractOutputs(cCtx, tc.context, contractsList)
+			if tc.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "read ABI")
+			} else {
+				require.NoError(t, err)
+				tc.validate(t, baseDir)
+			}
+		})
+	}
 }
 
 func TestStartDevnet_ContextCancellation(t *testing.T) {

--- a/pkg/commands/devnet_test.go
+++ b/pkg/commands/devnet_test.go
@@ -646,6 +646,9 @@ func TestDeployContracts_ExtractContractOutputs(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			originalCwd, err := os.Getwd()
+			assert.NoError(t, err)
+			t.Cleanup(func() { _ = os.Chdir(originalCwd) })
 			// each test in its own temp workspace
 			baseDir := t.TempDir()
 			require.NoError(t, os.Chdir(baseDir))

--- a/pkg/common/contract_caller.go
+++ b/pkg/common/contract_caller.go
@@ -1,9 +1,11 @@
 package common
 
 import (
+	"bytes"
 	"context"
 	"crypto/ecdsa"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"math/big"
 	"strings"
@@ -11,6 +13,7 @@ import (
 	"github.com/Layr-Labs/devkit-cli/pkg/common/iface"
 	allocationmanager "github.com/Layr-Labs/eigenlayer-contracts/pkg/bindings/AllocationManager"
 	delegationmanager "github.com/Layr-Labs/eigenlayer-contracts/pkg/bindings/DelegationManager"
+	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -215,5 +218,14 @@ func (cc *ContractCaller) RegisterForOperatorSets(ctx context.Context, operatorA
 		}
 		return tx, err
 	})
+	return err
+}
+
+func IsValidABI(v interface{}) error {
+	b, err := json.Marshal(v) // serialize ABI field
+	if err != nil {
+		return fmt.Errorf("marshal ABI: %w", err)
+	}
+	_, err = abi.JSON(bytes.NewReader(b)) // parse it
 	return err
 }

--- a/pkg/common/iface/logger.go
+++ b/pkg/common/iface/logger.go
@@ -1,6 +1,7 @@
 package iface
 
 type Logger interface {
+	Title(msg string, args ...any)
 	Info(msg string, args ...any)
 	Warn(msg string, args ...any)
 	Error(msg string, args ...any)
@@ -8,6 +9,7 @@ type Logger interface {
 }
 
 type ProgressLogger interface {
+	Title(msg string, args ...any)
 	Info(msg string, args ...any)
 	Warn(msg string, args ...any)
 	Error(msg string, args ...any)

--- a/pkg/common/logger/basic_logger.go
+++ b/pkg/common/logger/basic_logger.go
@@ -16,6 +16,19 @@ func NewLogger(verbose bool) *BasicLogger {
 	}
 }
 
+func (l *BasicLogger) Title(msg string, args ...any) {
+	// format the message once
+	formatted := fmt.Sprintf("\n"+msg+"\n", args...)
+
+	// split into lines
+	lines := strings.Split(formatted, "\n")
+
+	// print the lines with log
+	for _, line := range lines {
+		log.Printf("%s", line)
+	}
+}
+
 func (l *BasicLogger) Info(msg string, args ...any) {
 	// format the message once
 	formatted := fmt.Sprintf(msg, args...)

--- a/pkg/common/logger/progress_logger.go
+++ b/pkg/common/logger/progress_logger.go
@@ -20,6 +20,10 @@ func (p *ProgressLogger) ProgressRows() []iface.ProgressRow {
 	return p.tracker.ProgressRows()
 }
 
+func (p *ProgressLogger) Title(msg string, args ...any) {
+	p.base.Title(msg, args...)
+}
+
 func (p *ProgressLogger) Info(msg string, args ...any) {
 	p.base.Info(msg, args...)
 }

--- a/pkg/common/logger/zap_logger.go
+++ b/pkg/common/logger/zap_logger.go
@@ -1,6 +1,7 @@
 package logger
 
 import (
+	"fmt"
 	"strings"
 
 	"go.uber.org/zap"
@@ -20,6 +21,19 @@ func NewZapLogger(verbose bool) *ZapLogger {
 	}
 
 	return &ZapLogger{log: logger.Sugar()}
+}
+
+func (l *ZapLogger) Title(msg string, args ...any) {
+	// format the message once
+	formatted := fmt.Sprintf("\n"+msg+"\n", args...)
+
+	// split into lines
+	lines := strings.Split(formatted, "\n")
+
+	// print the lines with log
+	for _, line := range lines {
+		l.log.Infof("%s", line)
+	}
 }
 
 func (l *ZapLogger) Info(msg string, args ...any) {

--- a/pkg/common/yaml.go
+++ b/pkg/common/yaml.go
@@ -336,3 +336,24 @@ func ListYaml(filePath string, logger iface.Logger) error {
 
 	return nil
 }
+
+// SetMappingValue sets mapNode[keyNode.Value] = valNode, replacing existing or appending if missing.
+func SetMappingValue(mapNode, keyNode, valNode *yaml.Node) {
+	// Ensure mapNode is a MappingNode
+	if mapNode.Kind != yaml.MappingNode {
+		return
+	}
+
+	// Scan existing entries (Content holds [key, value, key, value, …])
+	for i := 0; i < len(mapNode.Content); i += 2 {
+		existingKey := mapNode.Content[i]
+		if existingKey.Value == keyNode.Value {
+			// replace the paired value node
+			mapNode.Content[i+1] = valNode
+			return
+		}
+	}
+
+	// Not found: append key and value
+	mapNode.Content = append(mapNode.Content, keyNode, valNode)
+}


### PR DESCRIPTION
**Motivation:**

We need a standardised way to consume deployed contract information (name, address, ABI) in our frontends and scripts. Previously this data was only buried inside the `./config/context.yaml` file along with information that isn't required to drive an app. By generating JSON files under `./contracts/outputs/<context>/<contractName>.json`, we can:
- Keep downstream tools in sync without manual steps
- Avoid hard-coding addresses in multiple places
- Provide a clear, per-context mapping of deployed artifacts


**Modifications:**
- Added `extractContractOutputs()` that:
  1. Reads the response from the `deployContracts` script
  2. For each deployed contract, extracts:
     - `name` (contract identifier)
     - `address` (deployed address)
     - `abi` (ABI location on disk, which we read the ABI array from)
  3. Ensures the target directory `./contracts/outputs/<context>/` exists
  4. Writes one JSON file per contract named `<contractName>.json`


**Result:**
- New folder structure:
  ```
  contracts/
    outputs/
      devnet/
        TaskMailbox.json
        HelloWorld.json
        ...
  ```
- Each file looks like:
  ```
  {
    "name": "TaskMailbox",
    "address": "0x4B7099FD879435a087C364aD2f9E7B3f94d20bBe",
    "abi": [
      { "inputs": […], "name": "createTask", … },
      …
    ]
  }
  ```
- Downstream consumers can now import these JSON files directly.

**Testing**

Tests added in `devnet_test.go` covering both success and failure paths:

1. **"successfully writes JSON output"**
  - Creates a fake ABI file containing a minimal `{"abi": [...]}` payload
  - Calls `extractContractOutputs()` with a single‐entry `contractsList` for `MyToken`
  - Asserts no error, then reads `./contracts/outputs/devnet/MyToken.json` and unmarshals it into `DeployContractOutput`
  - Verifies that `Name == "MyToken"`, `Address == "0x1234ABCD"`, and that the `ABI` slice contains the expected `"balanceOf"` entry

2. **"error when ABI file missing"**
  - Points `contractsList[0]["abi"]` to a non-existent file
  - Expects `extractContractOutputs()` to return an error containing `"read ABI"`
  - Confirms no output file is created

**Open questions:**

- Do we want to include `bytecode` or `deployedBytecode` in these outputs, or keep them strictly name/address/ABI?
