### PR TITLE
chore(devnet): set base fee and gas limit similar to a cheap L2

### DIFF
--- a/pkg/common/devnet/constants.go
+++ b/pkg/common/devnet/constants.go
@@ -2,7 +2,7 @@ package devnet
 
 // Foundry Image Date : 21 April 2025
 const FOUNDRY_IMAGE = "ghcr.io/foundry-rs/foundry:stable"
-const CHAIN_ARGS = "--chain-id 31337"
+const CHAIN_ARGS = "--chain-id 31337 --gas-limit 140000000 --base-fee 9400000"
 const FUND_VALUE = "10000000000000000000"
 const CONTEXT = "devnet"
 const L1 = "l1"


### PR DESCRIPTION
closes #137 

**Motivation:**

We want to run the devnet such that users feel they are deploying on a L2 testnet
**Modifications:**

Add gas limit to 140000000 and base fee to 9400000

**Result:**
L2 emulation


**Testing:**

Manual
**Open questions:**
<!--
(optional) Any open questions or feedback on design desired?
-->