### PR TITLE
docs: lightweight fix for installation step in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,16 +49,16 @@ Before you begin, ensure you have:
 To download a binary for the latest release, run:
 ```bash
 # MacOS (Apple Silicon)
-sudo curl -s -L https://s3.amazonaws.com/eigenlayer-devkit-releases/v0.0.7/devkit-darwin-arm64-v0.0.7.tar.gz | sudo tar xvz -C /usr/local/bin
+curl -sL https://s3.amazonaws.com/eigenlayer-devkit-releases/v0.0.7/devkit-darwin-arm64-v0.0.7.tar.gz | sudo tar xv -C "$HOME/bin"
 
 # MacOS (Intel)
-sudo curl -s -L https://s3.amazonaws.com/eigenlayer-devkit-releases/v0.0.7/devkit-darwin-amd64-v0.0.7.tar.gz | sudo tar xvz -C /usr/local/bin
+curl -sL https://s3.amazonaws.com/eigenlayer-devkit-releases/v0.0.7/devkit-darwin-amd64-v0.0.7.tar.gz | sudo tar xv -C "$HOME/bin"
 
 # Linux (x86_64 / AMD64)
-sudo curl -s -L https://s3.amazonaws.com/eigenlayer-devkit-releases/v0.0.7/devkit-linux-amd64-v0.0.7.tar.gz | sudo tar xvz -C /usr/local/bin
+curl -sL https://s3.amazonaws.com/eigenlayer-devkit-releases/v0.0.7/devkit-linux-amd64-v0.0.7.tar.gz | sudo tar xv -C "$HOME/bin"
 
 # Linux (ARM64 / aarch64)
-sudo curl -s -L https://s3.amazonaws.com/eigenlayer-devkit-releases/v0.0.7/devkit-linux-arm64-v0.0.7.tar.gz | sudo tar xvz -C /usr/local/bin
+curl -sL https://s3.amazonaws.com/eigenlayer-devkit-releases/v0.0.7/devkit-linux-arm64-v0.0.7.tar.gz | sudo tar xv -C "$HOME/bin"
 ```
 
 The binary will be installed inside the ~/bin directory.
@@ -360,7 +360,8 @@ VERSION=v0.0.7
 ARCH=$(uname -m | tr '[:upper:]' '[:lower:]')
 DISTRO=$(uname -s | tr '[:upper:]' '[:lower:]')
 
-curl -s -L "https://s3.amazonaws.com/eigenlayer-devkit-releases/${VERSION}/devkit-${DISTRO}-${ARCH}-${VERSION}.tar.gz" | sudo tar xv -C /usr/local/bin
+curl -sL "https://s3.amazonaws.com/eigenlayer-devkit-releases/${VERSION}/devkit-${DISTRO}-${ARCH}-${VERSION}.tar.gz" | sudo tar xv -C "$HOME/bin"
+
 ```
 
 ### Upgrading your template

--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ VERSION=v0.0.7
 ARCH=$(uname -m | tr '[:upper:]' '[:lower:]')
 DISTRO=$(uname -s | tr '[:upper:]' '[:lower:]')
 
-curl -s -L "https://s3.amazonaws.com/eigenlayer-devkit-releases/${VERSION}/devkit-${DISTRO}-${ARCH}-${VERSION}.tar.gz" | sudo tar xvz -C /usr/local/bin
+curl -s -L "https://s3.amazonaws.com/eigenlayer-devkit-releases/${VERSION}/devkit-${DISTRO}-${ARCH}-${VERSION}.tar.gz" | sudo tar xv -C /usr/local/bin
 ```
 
 ### Upgrading your template

--- a/README.md
+++ b/README.md
@@ -49,16 +49,16 @@ Before you begin, ensure you have:
 To download a binary for the latest release, run:
 ```bash
 # MacOS (Apple Silicon)
-curl -sL https://s3.amazonaws.com/eigenlayer-devkit-releases/v0.0.7/devkit-darwin-arm64-v0.0.7.tar.gz | sudo tar xv -C "$HOME/bin"
+curl -sL https://s3.amazonaws.com/eigenlayer-devkit-releases/v0.0.7/devkit-darwin-arm64-v0.0.7.tar.gz | tar xv -C "$HOME/bin"
 
 # MacOS (Intel)
-curl -sL https://s3.amazonaws.com/eigenlayer-devkit-releases/v0.0.7/devkit-darwin-amd64-v0.0.7.tar.gz | sudo tar xv -C "$HOME/bin"
+curl -sL https://s3.amazonaws.com/eigenlayer-devkit-releases/v0.0.7/devkit-darwin-amd64-v0.0.7.tar.gz | tar xv -C "$HOME/bin"
 
 # Linux (x86_64 / AMD64)
-curl -sL https://s3.amazonaws.com/eigenlayer-devkit-releases/v0.0.7/devkit-linux-amd64-v0.0.7.tar.gz | sudo tar xv -C "$HOME/bin"
+curl -sL https://s3.amazonaws.com/eigenlayer-devkit-releases/v0.0.7/devkit-linux-amd64-v0.0.7.tar.gz | tar xv -C "$HOME/bin"
 
 # Linux (ARM64 / aarch64)
-curl -sL https://s3.amazonaws.com/eigenlayer-devkit-releases/v0.0.7/devkit-linux-arm64-v0.0.7.tar.gz | sudo tar xv -C "$HOME/bin"
+curl -sL https://s3.amazonaws.com/eigenlayer-devkit-releases/v0.0.7/devkit-linux-arm64-v0.0.7.tar.gz | tar xv -C "$HOME/bin"
 ```
 
 The binary will be installed inside the ~/bin directory.
@@ -360,7 +360,7 @@ VERSION=v0.0.7
 ARCH=$(uname -m | tr '[:upper:]' '[:lower:]')
 DISTRO=$(uname -s | tr '[:upper:]' '[:lower:]')
 
-curl -sL "https://s3.amazonaws.com/eigenlayer-devkit-releases/${VERSION}/devkit-${DISTRO}-${ARCH}-${VERSION}.tar.gz" | sudo tar xv -C "$HOME/bin"
+curl -sL "https://s3.amazonaws.com/eigenlayer-devkit-releases/${VERSION}/devkit-${DISTRO}-${ARCH}-${VERSION}.tar.gz" | tar xv -C "$HOME/bin"
 
 ```
 


### PR DESCRIPTION
<!-- 
    🚨 ATTENTION! 🚨 
    
    This PR template is REQUIRED. PRs not following this format will be closed without review.
    
    Requirements:
    - PR title must follow commit conventions: https://www.conventionalcommits.org/en/v1.0.0/
    - Label your PR with the correct type (e.g., 🐛 Bug, ✨ Enhancement, 🧪 Test, etc.)
    - Provide clear and specific details in each section
-->

**Motivation:**
<!--
Explain here the context, and why you're making that change. What is the problem you're trying to solve.
-->
Provided `.tar.gz` binary file is  a `tar` archive and incorrectly labeled as gzip compressed tar, the Installation command in the readme is using the `-z` flag and fails due to mismatched file format.

**Modifications:**
<!--
Describe the modifications you've done from a high level. What are the key technical decisions and why were they made?
-->
- updates documentation to remove the -z flag from the installation tar command

**Result:**
<!--
*After your change, what will change.
-->
- installation from the tar will work
