### PR TITLE
docs: ensure the $HOME/bin exists before installing to it

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,16 +49,16 @@ Before you begin, ensure you have:
 To download a binary for the latest release, run:
 ```bash
 # MacOS (Apple Silicon)
-curl -sL https://s3.amazonaws.com/eigenlayer-devkit-releases/v0.0.8/devkit-darwin-arm64-v0.0.8.tar.gz | tar xv -C "$HOME/bin"
+mkdir -p $HOME/bin && curl -sL https://s3.amazonaws.com/eigenlayer-devkit-releases/v0.0.8/devkit-darwin-arm64-v0.0.8.tar.gz | tar xv -C "$HOME/bin"
 
 # MacOS (Intel)
-curl -sL https://s3.amazonaws.com/eigenlayer-devkit-releases/v0.0.8/devkit-darwin-amd64-v0.0.8.tar.gz | tar xv -C "$HOME/bin"
+mkdir -p $HOME/bin && curl -sL https://s3.amazonaws.com/eigenlayer-devkit-releases/v0.0.8/devkit-darwin-amd64-v0.0.8.tar.gz | tar xv -C "$HOME/bin"
 
 # Linux (x86_64 / AMD64)
-curl -sL https://s3.amazonaws.com/eigenlayer-devkit-releases/v0.0.8/devkit-linux-amd64-v0.0.8.tar.gz | tar xv -C "$HOME/bin"
+mkdir -p $HOME/bin && curl -sL https://s3.amazonaws.com/eigenlayer-devkit-releases/v0.0.8/devkit-linux-amd64-v0.0.8.tar.gz | tar xv -C "$HOME/bin"
 
 # Linux (ARM64 / aarch64)
-curl -sL https://s3.amazonaws.com/eigenlayer-devkit-releases/v0.0.8/devkit-linux-arm64-v0.0.8.tar.gz | tar xv -C "$HOME/bin"
+mkdir -p $HOME/bin && curl -sL https://s3.amazonaws.com/eigenlayer-devkit-releases/v0.0.8/devkit-linux-arm64-v0.0.8.tar.gz | tar xv -C "$HOME/bin"
 ```
 
 The binary will be installed inside the ~/bin directory.
@@ -70,6 +70,7 @@ export PATH=$PATH:~/bin
 
 To build and install the devkit cli from source:
 ```bash
+mkdir -p $HOME/bin
 git clone https://github.com/Layr-Labs/devkit-cli
 cd devkit-cli
 make install
@@ -360,6 +361,7 @@ VERSION=v0.0.8
 ARCH=$(uname -m | tr '[:upper:]' '[:lower:]')
 DISTRO=$(uname -s | tr '[:upper:]' '[:lower:]')
 
+mkdir -p $HOME/bin
 curl -sL "https://s3.amazonaws.com/eigenlayer-devkit-releases/${VERSION}/devkit-${DISTRO}-${ARCH}-${VERSION}.tar.gz" | tar xv -C "$HOME/bin"
 
 ```


### PR DESCRIPTION
<!-- 
    🚨 ATTENTION! 🚨 
    
    This PR template is REQUIRED. PRs not following this format will be closed without review.
    
    Requirements:
    - PR title must follow commit conventions: https://www.conventionalcommits.org/en/v1.0.0/
    - Label your PR with the correct type (e.g., 🐛 Bug, ✨ Enhancement, 🧪 Test, etc.)
    - Provide clear and specific details in each section
-->

**Motivation:**
<!--
Explain here the context, and why you're making that change. What is the problem you're trying to solve.
-->
On a fresh ubuntu instance the `$HOME/bin` directory may not exist, we should ensure it does before we install to the bin

**Modifications:**
<!--
Describe the modifications you've done from a high level. What are the key technical decisions and why were they made?
-->
- Adds `mkdir -p $HOME/bin` before we unpack to the bin

**Result:**
<!--
*After your change, what will change.
-->
- Installs will not fail with:

  ```tar: /home/<use>/bin: Cannot open: No such file or directory```
  
**Testing:**
<!--
*List testing procedures taken and useful artifacts.
-->
- Test command locally
