### PR TITLE
fix: ensure --set works against seqs and maps and allow filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,20 +171,20 @@ You can view or modify these configurations using the DevKit CLI or by editing t
 
 #### Set values via CLI flags
 
-- **Project-level**  
-  ```bash  
-  devkit avs config --set project.name="My new name" project.version="0.0.2"  
+- **Project-level**
+  ```bash
+  devkit avs config --set project.name="My new name" project.version="0.0.2"
   ```
 
-- **Context-specific**  
-  ```bash  
-  devkit avs context --set operator.key="0xabc…" context.timeout=30  
-  devkit avs context --context devnet --set operator.key="0xabc…" context.timeout=30  
+- **Context-specific**
+  ```bash
+  devkit avs context --set operators.0.address="0xabc..." operators.0.ecdsa_key="0x123..."
+  devkit avs context --context devnet --set operators.0.address="0xabc..." operators.0.ecdsa_key="0x123..."
   ```
 
 Alternatively, you can manually edit `config.yaml` or the `contexts/*.yaml` files in the text editor of your choice.
 
-> [!IMPORTANT]  
+> [!IMPORTANT]
 > All `devkit avs` commands must be run from the **root of your AVS project** — the directory containing the `config` folder.
 
 Before launching your local devnet, you must set valid Ethereum fork URLs to define the chain state your AVS will simulate against. These values are loaded from your `.env` file and automatically applied to your environment.

--- a/pkg/commands/config/config.go
+++ b/pkg/commands/config/config.go
@@ -64,22 +64,22 @@ var Command = &cli.Command{
 			}
 			for _, item := range items {
 				// Split into "key.path.to.field" and "value"
-				parts := strings.SplitN(item, "=", 2)
-				if len(parts) != 2 {
+				idx := strings.LastIndex(item, "=")
+				if idx < 0 {
 					return fmt.Errorf("invalid --set syntax %q (want key=val)", item)
 				}
+				pathStr := item[:idx]
+				val := item[idx+1:]
 
 				// Break the key path into segments
-				path := strings.Split(parts[0], ".")
-				val := parts[1]
+				path := strings.Split(pathStr, ".")
 
 				// Set val at path
 				configNode, err = common.WriteToPath(configNode, path, val)
 				if err != nil {
 					return fmt.Errorf("setting value %s failed: %w", item, err)
 				}
-				logger.Info("Set %s = %s", parts[0], val)
-
+				logger.Info("Set %s = %s", pathStr, val)
 			}
 			if err := common.WriteYAML(cfgPath, rootDoc); err != nil {
 				return fmt.Errorf("write config YAML: %w", err)

--- a/pkg/commands/context/context.go
+++ b/pkg/commands/context/context.go
@@ -105,22 +105,22 @@ var Command = &cli.Command{
 			}
 			for _, item := range items {
 				// Split into "key.path.to.field" and "value"
-				parts := strings.SplitN(item, "=", 2)
-				if len(parts) != 2 {
+				idx := strings.LastIndex(item, "=")
+				if idx < 0 {
 					return fmt.Errorf("invalid --set syntax %q (want key=val)", item)
 				}
+				pathStr := item[:idx]
+				val := item[idx+1:]
 
 				// Break the key path into segments
-				path := strings.Split(parts[0], ".")
-				val := parts[1]
+				path := strings.Split(pathStr, ".")
 
 				// Set val at path
 				configNode, err = common.WriteToPath(configNode, path, val)
 				if err != nil {
 					return fmt.Errorf("setting value %s failed: %w", item, err)
 				}
-				logger.Info("Set %s = %s", parts[0], val)
-
+				logger.Info("Set %s = %s", pathStr, val)
 			}
 			if err := common.WriteYAML(contextPath, rootDoc); err != nil {
 				return fmt.Errorf("write context YAML: %w", err)

--- a/pkg/common/yaml_test.go
+++ b/pkg/common/yaml_test.go
@@ -241,16 +241,29 @@ func TestWriteToPath_SequenceIndex(t *testing.T) {
 		},
 	})
 	// overwrite index 1
-	WriteToPath(root, []string{"ops", "1", "a"}, "42")
-	out, _ := NodeToInterface(root)
+	withOpsNode, err := WriteToPath(root, []string{"ops", "1", "a"}, "42")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	out, err := NodeToInterface(withOpsNode)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	arr := out.(map[string]interface{})["ops"].([]interface{})
 	if arr[1].(map[string]interface{})["a"] != 42 {
 		t.Errorf("expected 42 at ops[1].a, got %v", arr[1])
 	}
 
 	// append a third entry
-	WriteToPath(root, []string{"ops", "2", "a"}, "99")
-	out, _ = NodeToInterface(root)
+	withOpsNode, err = WriteToPath(withOpsNode, []string{"ops", "2", "a"}, "99")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	out, err = NodeToInterface(withOpsNode)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	arr = out.(map[string]interface{})["ops"].([]interface{})
 	if len(arr) != 3 || arr[2].(map[string]interface{})["a"] != 99 {
 		t.Errorf("expected appended ops[2].a=99, got %#v", arr)
@@ -263,8 +276,14 @@ func TestWriteToPath_BracketIndex(t *testing.T) {
 			map[string]interface{}{"a": "foo"},
 		},
 	})
-	WriteToPath(root, []string{"ops[0]", "a"}, "bar")
-	out, _ := NodeToInterface(root)
+	withOpsNode, err := WriteToPath(root, []string{"ops[0]", "a"}, "bar")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	out, err := NodeToInterface(withOpsNode)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	a := out.(map[string]interface{})["ops"].([]interface{})[0].(map[string]interface{})["a"]
 	if a != "bar" {
 		t.Errorf("expected ops[0].a=bar, got %v", a)
@@ -278,8 +297,14 @@ func TestWriteToPath_FilterByKey(t *testing.T) {
 			map[string]interface{}{"id": "y", "name": "Bob"},
 		},
 	})
-	WriteToPath(root, []string{"users[id=y]", "name"}, "Bobbert")
-	out, _ := NodeToInterface(root)
+	withOpsNode, err := WriteToPath(root, []string{"users[id=y]", "name"}, "Bobbert")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	out, err := NodeToInterface(withOpsNode)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	name := out.(map[string]interface{})["users"].([]interface{})[1].(map[string]interface{})["name"]
 	if name != "Bobbert" {
 		t.Errorf("expected users[id=y].name=Bobbert, got %v", name)
@@ -288,8 +313,14 @@ func TestWriteToPath_FilterByKey(t *testing.T) {
 
 func TestWriteToPath_MappingCreation(t *testing.T) {
 	root, _ := InterfaceToNode(map[string]interface{}{})
-	WriteToPath(root, []string{"foo", "bar"}, "baz")
-	out, _ := NodeToInterface(root)
+	withOpsNode, err := WriteToPath(root, []string{"foo", "bar"}, "baz")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	out, err := NodeToInterface(withOpsNode)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	m := out.(map[string]interface{})["foo"].(map[string]interface{})["bar"]
 	if m != "baz" {
 		t.Errorf("expected foo.bar=baz, got %v", m)


### PR DESCRIPTION
<!-- 
    🚨 ATTENTION! 🚨 
    
    This PR template is REQUIRED. PRs not following this format will be closed without review.
    
    Requirements:
    - PR title must follow commit conventions: https://www.conventionalcommits.org/en/v1.0.0/
    - Label your PR with the correct type (e.g., 🐛 Bug, ✨ Enhancement, 🧪 Test, etc.)
    - Provide clear and specific details in each section
-->

**Motivation:**
Our existing `WriteToPath` was brittle when updating YAML sequences by index or key, and didn’t support bare numeric segments or auto-appending new items. This led to `"index out of range"` errors when targeting the next index and failure to write to a sequence by index.

**Modifications:**
- Refactored `WriteToPath` into focused helpers (`tryBracketIndex`, `tryNumericIndex`, `tryFilterSeq`, `handleMapping`, etc.).
- Added `sanitizeValue` to strip user-provided quotes
- Made sequence handlers auto-append new mapping nodes when targeting the next index
- Centralised scalar writes in `writeScalar` and key/value appends in `appendKeyValue`

**Result:**
- Supports paths:  
  - `operators.0.field=…`  
  - `'operators[0].field=…'`  
  - `'operators[address=0x…].field=…'`  
  - Auto-appending at the next index  
- Cleaner, more maintainable code

**Testing:**
- Manual verification of YAML updates for all path styles
- Ran existing unit tests against `avs context` and `avs config`
- Added tests covering bracketed, numeric, and filter indexing

