### PR TITLE
feat: add autocompletion for zsh and bash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,12 +37,45 @@ lint: ## Run linter
 	@go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
 	@golangci-lint run $(GO_PACKAGES)
 
-install: build ## Install binary to ~/bin
+install: build ## Install binary and completion scripts
 	@mkdir -p ~/bin
 	@cp $(BIN)/$(APP_NAME) ~/bin/
 	@if ! npm list -g @layr-labs/zeus@1.5.2 >/dev/null 2>&1; then \
 		echo "Installing @layr-labs/zeus@1.5.2..."; \
 		npm install -g @layr-labs/zeus@1.5.2; \
+	fi
+	@mkdir -p ~/.local/share/bash-completion/completions
+	@mkdir -p ~/.zsh/completions
+	@cp autocomplete/bash_autocomplete ~/.local/share/bash-completion/completions/devkit
+	@cp autocomplete/zsh_autocomplete ~/.zsh/completions/_devkit
+	@if [ "$(shell echo $$SHELL)" = "/bin/zsh" ] || [ "$(shell echo $$SHELL)" = "/usr/bin/zsh" ]; then \
+		if ! grep -q "# DevKit CLI completions" ~/.zshrc 2>/dev/null; then \
+			echo "" >> ~/.zshrc; \
+			echo "# DevKit CLI completions" >> ~/.zshrc; \
+			echo "fpath=(~/.zsh/completions \$$fpath)" >> ~/.zshrc; \
+			echo "autoload -U compinit && compinit" >> ~/.zshrc; \
+			echo "PROG=devkit" >> ~/.zshrc; \
+			echo "source ~/.zsh/completions/_devkit" >> ~/.zshrc; \
+			echo "Restart your shell or Run: source ~/.zshrc to enable completions in current shell"; \
+		fi; \
+	elif [ "$(shell echo $$SHELL)" = "/bin/bash" ] || [ "$(shell echo $$SHELL)" = "/usr/bin/bash" ]; then \
+		if ! grep -q "# DevKit CLI completions" ~/.bashrc 2>/dev/null; then \
+			echo "" >> ~/.bashrc; \
+			echo "# DevKit CLI completions" >> ~/.bashrc; \
+			echo "PROG=devkit" >> ~/.bashrc; \
+			echo "source ~/.local/share/bash-completion/completions/devkit" >> ~/.bashrc; \
+			echo "Restart your shell or Run: source ~/.bashrc to enable completions in current shell"; \
+		fi; \
+	fi
+	@echo ""
+
+install-completion: ## Install shell completion for current session
+	@if [ "$(shell echo $$0)" = "zsh" ] || [ "$(shell echo $$SHELL)" = "/bin/zsh" ] || [ "$(shell echo $$SHELL)" = "/usr/bin/zsh" ]; then \
+		echo "Setting up Zsh completion for current session..."; \
+		echo "Run: PROG=devkit source $(PWD)/autocomplete/zsh_autocomplete"; \
+	else \
+		echo "Setting up Bash completion for current session..."; \
+		echo "Run: PROG=devkit source $(PWD)/autocomplete/bash_autocomplete"; \
 	fi
 
 clean: ## Remove binary

--- a/README.md
+++ b/README.md
@@ -96,24 +96,28 @@ devkit avs <TAB>      # Should show subcommands
 
 **For Zsh (recommended for macOS):**
 ```bash
-# Add to your ~/.zshrc
-fpath=(~/.zsh/completions $fpath)
-autoload -U compinit && compinit
+# Add to your ~/.zshrc:
 PROG=devkit
 source <(curl -s https://raw.githubusercontent.com/Layr-Labs/devkit-cli/main/autocomplete/zsh_autocomplete)
 
-# Then restart your shell
 exec zsh
 ```
 
 **For Bash:**
 ```bash
-# Add to your ~/.bashrc or ~/.bash_profile
+# Add to your ~/.bashrc or ~/.bash_profile:
 PROG=devkit
 source <(curl -s https://raw.githubusercontent.com/Layr-Labs/devkit-cli/main/autocomplete/bash_autocomplete)
 
-# Then restart your shell
 source ~/.bashrc
+```
+
+**For local development/testing:**
+```bash
+# If you have the devkit-cli repo locally
+cd /path/to/devkit-cli
+PROG=devkit source autocomplete/zsh_autocomplete  # for zsh
+PROG=devkit source autocomplete/bash_autocomplete # for bash
 ```
 
 After setup, you can use tab completion:

--- a/README.md
+++ b/README.md
@@ -81,6 +81,48 @@ Verify your installation:
 devkit --help
 ```
 
+### 🔧 Shell Completion (Optional)
+
+Tab completion for devkit commands is automatically set up when you install with `make install`.
+
+**If you installed from source with `make install`:**
+- Completion is automatically configured and enabled! Test it immediately:
+```bash
+devkit <TAB>          # Should show: avs, keystore, version
+devkit avs <TAB>      # Should show subcommands
+```
+
+**If you downloaded the binary directly, manual setup:**
+
+**For Zsh (recommended for macOS):**
+```bash
+# Add to your ~/.zshrc
+fpath=(~/.zsh/completions $fpath)
+autoload -U compinit && compinit
+PROG=devkit
+source <(curl -s https://raw.githubusercontent.com/Layr-Labs/devkit-cli/main/autocomplete/zsh_autocomplete)
+
+# Then restart your shell
+exec zsh
+```
+
+**For Bash:**
+```bash
+# Add to your ~/.bashrc or ~/.bash_profile
+PROG=devkit
+source <(curl -s https://raw.githubusercontent.com/Layr-Labs/devkit-cli/main/autocomplete/bash_autocomplete)
+
+# Then restart your shell
+source ~/.bashrc
+```
+
+After setup, you can use tab completion:
+```bash
+devkit <TAB>          # Shows: avs, keystore, version
+devkit avs <TAB>      # Shows: create, config, context, build, devnet, run, call, release, template
+devkit avs cr<TAB>    # Completes to: devkit avs create
+```
+
 ---
 
 ## 🚧 Step-by-Step Guide
@@ -119,7 +161,7 @@ Within `main.go`, you'll find two critical methods on the `TaskWorker` type:
   This is where you implement your AVS's core business logic. It processes an incoming task and returns a `TaskResponse`. Replace the placeholder comment with the actual logic you want to run during task execution.
 
 - **`ValidateTask(*TaskRequest)`**  
-  This method allows you to pre-validate a task before executing it. Use this to ensure your task meets your AVS’s criteria (e.g., argument format, access control, etc.).
+  This method allows you to pre-validate a task before executing it. Use this to ensure your task meets your AVS's criteria (e.g., argument format, access control, etc.).
 
 These functions will be invoked automatically when using `devkit avs call`, enabling you to quickly test and iterate on your AVS logic.
 
@@ -132,7 +174,7 @@ These functions will be invoked automatically when using `devkit avs call`, enab
 Also, keep stuff at the top about introducing config yaml files and what they do.
 -->
 
-Before running your AVS, you’ll need to configure both project-level and context-specific settings. This is done through two configuration files:
+Before running your AVS, you'll need to configure both project-level and context-specific settings. This is done through two configuration files:
 
 - **`config.yaml`**  
   Defines project-wide settings such as AVS name, version, and available context names.  

--- a/autocomplete/bash_autocomplete
+++ b/autocomplete/bash_autocomplete
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+_cli_bash_autocomplete() {
+    if [[ "${COMP_WORDS[0]}" != "source" ]]; then
+        local cur opts base
+        COMPREPLY=()
+        cur="${COMP_WORDS[COMP_CWORD]}"
+        if [[ "$cur" == "-"* ]]; then
+            opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} ${cur} --generate-bash-completion )
+        else
+            opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} --generate-bash-completion )
+        fi
+        COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+        return 0
+    fi
+}
+
+complete -o bashdefault -o default -o nospace -F _cli_bash_autocomplete $PROG 

--- a/autocomplete/zsh_autocomplete
+++ b/autocomplete/zsh_autocomplete
@@ -1,0 +1,22 @@
+#!/bin/zsh
+
+_cli_zsh_autocomplete() {
+
+  local -a opts
+  local cur
+  cur=${words[-1]}
+  if [[ "$cur" == "-"* ]]; then
+    opts=("${(@f)$(_CLI_ZSH_AUTOCOMPLETE_HACK=1 ${words[@]:0:#words-1} ${cur} --generate-bash-completion)}")
+  else
+    opts=("${(@f)$(_CLI_ZSH_AUTOCOMPLETE_HACK=1 ${words[@]:0:#words-1} --generate-bash-completion)}")
+  fi
+
+  if [[ "${opts[1]}" != "" ]]; then
+    _describe 'completions' opts
+    return 0
+  fi
+
+  return 1
+}
+
+compdef _cli_zsh_autocomplete $PROG 

--- a/cmd/devkit/main.go
+++ b/cmd/devkit/main.go
@@ -18,9 +18,10 @@ func main() {
 	ctx := common.WithShutdown(context.Background())
 
 	app := &cli.App{
-		Name:  "devkit",
-		Usage: "EigenLayer Development Kit",
-		Flags: common.GlobalFlags,
+		EnableBashCompletion: true,
+		Name:                 "devkit",
+		Usage:                "EigenLayer Development Kit",
+		Flags:                common.GlobalFlags,
 		Before: func(cCtx *cli.Context) error {
 			err := hooks.LoadEnvFile(cCtx)
 			if err != nil {


### PR DESCRIPTION
~~### TODO: bash testing~~


**Motivation:**

Add CLI autocompletion for urfave/cli/v2 for zsh and bash shells to improve developer experience and productivity when using the devkit CLI.

**Modifications:**

- Added autocomplete scripts:
autocomplete/bash_autocomplete - bash completion script using urfave/cli patterns
autocomplete/zsh_autocomplete - zsh completion script using urfave/cli patterns

- Makefile:
Modified make install target to automatically install completion scripts to standard shell locations
Added automatic shell detection (zsh/bash) and configuration setup
Provides instruction for enabling completions: source ~/.zshrc

- Updated documentation:
Added shell completion section to README.md
Provided setup instructions for both automated (make install) and manual installation
Included examples of tab completion usage

- Leveraged urfave/cli built-in support:
Used existing EnableBashCompletion: true flag in main CLI app
Utilized automatic --generate-bash-completion flag for dynamic completions
**Result:**

Users can now enjoy full tab completion when using the devkit CLI:

**Testing:**

Manual for zsh


**Open questions:**
