### PR TITLE
fix: use context/env provided chainId and default if nil

### DIFF
--- a/pkg/commands/devnet_actions.go
+++ b/pkg/commands/devnet_actions.go
@@ -169,7 +169,15 @@ func StartDevnetAction(cCtx *cli.Context) error {
 	if err != nil {
 		blockTime = 12
 	}
-	// Append blockTime to chainArgs
+
+	// Get the chain_id from env/config
+	chainId, err := devnet.GetDevnetChainIdOrDefault(config, devnet.L1)
+	if err != nil {
+		chainId = 31337
+	}
+
+	// Append config defined details to chainArgs
+	chainArgs = fmt.Sprintf("%s --chain-id %d", chainArgs, chainId)
 	chainArgs = fmt.Sprintf("%s --block-time %d", chainArgs, blockTime)
 
 	// Run docker compose up for anvil devnet

--- a/pkg/commands/devnet_actions.go
+++ b/pkg/commands/devnet_actions.go
@@ -173,7 +173,7 @@ func StartDevnetAction(cCtx *cli.Context) error {
 	// Get the chain_id from env/config
 	chainId, err := devnet.GetDevnetChainIdOrDefault(config, devnet.L1)
 	if err != nil {
-		chainId = 31337
+		chainId = common.DefaultAnvilChainId
 	}
 
 	// Append config defined details to chainArgs

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -14,13 +14,18 @@ const (
 	// DevkitConfigFile is the name of the config YAML used to configure devkit operations
 	DevkitConfigFile = ".config.devkit.yml"
 
-	// Filename for the config
+	// Filename for devkit project config
 	BaseConfig = "config.yaml"
 
+	// Filename for zeus config
 	ZeusConfig = ".zeus"
+
 	// Docker open timeout
 	DockerOpenTimeoutSeconds = 10
 
 	// Docker open retry interval in milliseconds
 	DockerOpenRetryIntervalMilliseconds = 500
+
+	// Default chainId for Anvil
+	DefaultAnvilChainId = 31337
 )

--- a/pkg/common/devnet/constants.go
+++ b/pkg/common/devnet/constants.go
@@ -2,7 +2,7 @@ package devnet
 
 // Foundry Image Date : 21 April 2025
 const FOUNDRY_IMAGE = "ghcr.io/foundry-rs/foundry:stable"
-const CHAIN_ARGS = "--chain-id 31337 --gas-limit 140000000 --base-fee 9400000"
+const CHAIN_ARGS = "--gas-limit 140000000 --base-fee 9400000"
 const FUND_VALUE = "10000000000000000000"
 const CONTEXT = "devnet"
 const L1 = "l1"

--- a/pkg/common/devnet/getters.go
+++ b/pkg/common/devnet/getters.go
@@ -35,6 +35,33 @@ func FileExistsInRoot(filename string) bool {
 	return err == nil || !os.IsNotExist(err)
 }
 
+func GetDevnetChainIdOrDefault(cfg *common.ConfigWithContextConfig, chainName string) (int, error) {
+	// Check in env first for L1 chain id
+	l1ChainId := os.Getenv("L1_CHAIN_ID")
+	l1ChainIdInt, err := strconv.Atoi(l1ChainId)
+	if chainName == "l1" && err != nil && l1ChainIdInt != 0 {
+		return l1ChainIdInt, nil
+	}
+
+	// Check in env first for L2 chain id
+	l2ChainId := os.Getenv("L2_CHAIN_ID")
+	l2ChainIdInt, err := strconv.Atoi(l2ChainId)
+	if chainName == "l2" && err != nil && l2ChainIdInt != 0 {
+		return l2ChainIdInt, nil
+	}
+
+	// Fallback to context defined value or 31337 if undefined
+	chainConfig, found := cfg.Context[CONTEXT].Chains[chainName]
+	if !found {
+		return 31337, fmt.Errorf("failed to get chainConfig for chainName : %s", chainName)
+	}
+	if chainConfig.ChainID == 0 {
+		return 31337, fmt.Errorf("chain_id not set for %s; set chain_id in ./config/context/devnet.yaml or .env", chainName)
+	}
+
+	return chainConfig.ChainID, nil
+}
+
 func GetDevnetBlockTimeOrDefault(cfg *common.ConfigWithContextConfig, chainName string) (int, error) {
 	// Check in env first for L1 block time
 	l1BlockTime := os.Getenv("L1_BLOCK_TIME")

--- a/pkg/common/devnet/getters.go
+++ b/pkg/common/devnet/getters.go
@@ -50,13 +50,13 @@ func GetDevnetChainIdOrDefault(cfg *common.ConfigWithContextConfig, chainName st
 		return l2ChainIdInt, nil
 	}
 
-	// Fallback to context defined value or 31337 if undefined
+	// Fallback to context defined value or DefaultAnvilChainId if undefined
 	chainConfig, found := cfg.Context[CONTEXT].Chains[chainName]
 	if !found {
-		return 31337, fmt.Errorf("failed to get chainConfig for chainName : %s", chainName)
+		return common.DefaultAnvilChainId, fmt.Errorf("failed to get chainConfig for chainName : %s", chainName)
 	}
 	if chainConfig.ChainID == 0 {
-		return 31337, fmt.Errorf("chain_id not set for %s; set chain_id in ./config/context/devnet.yaml or .env", chainName)
+		return common.DefaultAnvilChainId, fmt.Errorf("chain_id not set for %s; set chain_id in ./config/context/devnet.yaml or .env", chainName)
 	}
 
 	return chainConfig.ChainID, nil


### PR DESCRIPTION
<!-- 
    🚨 ATTENTION! 🚨 
    
    This PR template is REQUIRED. PRs not following this format will be closed without review.
    
    Requirements:
    - PR title must follow commit conventions: https://www.conventionalcommits.org/en/v1.0.0/
    - Label your PR with the correct type (e.g., 🐛 Bug, ✨ Enhancement, 🧪 Test, etc.)
    - Provide clear and specific details in each section
-->

**Motivation:**
<!--
Explain here the context, and why you're making that change. What is the problem you're trying to solve.
-->
We always supply `31337` as the `chainId` for devnet, even if an alternative has been set in the context.

**Modifications:**
<!--
Describe the modifications you've done from a high level. What are the key technical decisions and why were they made?
-->
- Use the provided L1 `chainId` in `ANVIL_ARGS`

**Result:**
<!--
*After your change, what will change.
-->
- We correctly set the `chainId` according to the users config

**Testing:**
<!--
*List testing procedures taken and useful artifacts.
-->
- Tested manually with `chainId=1` 
  - note that the `chainId` must be valid for `keygen generate-operator-data` to succeed 
  - if `chainId` is invalid we get this error: `Error: failed to get core contracts: unsupported chain ID: <CHAIN_ID>` 
  
  
**Open questions:**
<!--
(optional) Any open questions or feedback on design desired?
-->
  - In a devnet context, do we need to check for a valid `chainId`? cc. @0xrajath @seanmcgary

--

resolves: https://github.com/Layr-Labs/devkit-cli/issues/162