### PR TITLE
chore(release): v0.0.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,15 @@ Projects are created by default in the current directory from where the below co
 ```bash
 devkit avs create my-avs-project ./
 cd my-avs-project
+# If dependencies we're installed during the creation process, you will need to source your bash/zsh profile:
+#  - if you use bashrc
+source ~/.bashrc
+#  - if you use bash_profile
+source ~/.bash_profile
+#  - if you use zshrc
+source ~/.zshrc
+#  - if you use zprofile
+source ~/.zprofile
 ```
 
 > Note: Projects are created with a specific template version. You can view your current template version with `devkit avs template info` and upgrade later using `devkit avs template upgrade`.
@@ -120,7 +129,7 @@ Within `main.go`, you'll find two critical methods on the `TaskWorker` type:
   This is where you implement your AVS's core business logic. It processes an incoming task and returns a `TaskResponse`. Replace the placeholder comment with the actual logic you want to run during task execution.
 
 - **`ValidateTask(*TaskRequest)`**  
-  This method allows you to pre-validate a task before executing it. Use this to ensure your task meets your AVS’s criteria (e.g., argument format, access control, etc.).
+  This method allows you to pre-validate a task before executing it. Use this to ensure your task meets your AVS's criteria (e.g., argument format, access control, etc.).
 
 These functions will be invoked automatically when using `devkit avs call`, enabling you to quickly test and iterate on your AVS logic.
 
@@ -133,7 +142,7 @@ These functions will be invoked automatically when using `devkit avs call`, enab
 Also, keep stuff at the top about introducing config yaml files and what they do.
 -->
 
-Before running your AVS, you’ll need to configure both project-level and context-specific settings. This is done through two configuration files:
+Before running your AVS, you'll need to configure both project-level and context-specific settings. This is done through two configuration files:
 
 - **`config.yaml`**  
   Defines project-wide settings such as AVS name, version, and available context names.  
@@ -378,7 +387,7 @@ devkit avs template info
 2025/05/22 14:42:36 Project template information:
 2025/05/22 14:42:36   Project name: <your project>
 2025/05/22 14:42:36   Template URL: https://github.com/Layr-Labs/hourglass-avs-template
-2025/05/22 14:42:36   Version: v0.0.11
+2025/05/22 14:42:36   Version: v0.0.12
 ```
 
 **_Upgrade to a newer version_**

--- a/config/templates.yaml
+++ b/config/templates.yaml
@@ -3,7 +3,7 @@ architectures:
     languages:
       go:
         baseUrl: "https://github.com/Layr-Labs/hourglass-avs-template"
-        version: "v0.0.11"
+        version: "v0.0.12"
       ts:
         baseUrl: ""
         version: ""

--- a/pkg/template/config_test.go
+++ b/pkg/template/config_test.go
@@ -17,7 +17,7 @@ func TestLoadConfig(t *testing.T) {
 	}
 
 	expectedBaseURL := "https://github.com/Layr-Labs/hourglass-avs-template"
-	expectedVersion := "v0.0.11"
+	expectedVersion := "v0.0.12"
 
 	if mainBaseURL != expectedBaseURL {
 		t.Errorf("Unexpected main template base URL: got %s, want %s", mainBaseURL, expectedBaseURL)


### PR DESCRIPTION
<!-- 
    🚨 ATTENTION! 🚨 
    
    This PR template is REQUIRED. PRs not following this format will be closed without review.
    
    Requirements:
    - PR title must follow commit conventions: https://www.conventionalcommits.org/en/v1.0.0/
    - Label your PR with the correct type (e.g., 🐛 Bug, ✨ Enhancement, 🧪 Test, etc.)
    - Provide clear and specific details in each section
-->

**Motivation:**
<!--
Explain here the context, and why you're making that change. What is the problem you're trying to solve.
-->
`v0.0.8` realigns devnet base fees and gas limits to a low-cost L2, auto-saves contract outputs to `./contracts/outputs/<context>/<name>.json`, fixes README installation, tears down canceled Anvil containers, adds a release binary smoke test, respects a provided chainId, includes migration tests from 0.0.1–0.0.5, enhances --set for sequences, maps, and filtering, ensures `$HOME/bin` exists before installing, and blocks the initial Git commit unless a user profile is set.

**Modifications:**
<!--
Describe the modifications you've done from a high level. What are the key technical decisions and why were they made?
-->

9b6a44054146c5d8d971306e39bef173ceb9d7b0: chore(devnet): set base fee and gas limit similar to a cheap L2 by @supernovahs (https://github.com/Layr-Labs/devkit-cli/pull/144)
c2f3033b4fd1847b30a9fbba801e73bd9f4f1b74: feat: save contract artefacts to ./contracts/outputs/<context>/<name>.json by @grezle (https://github.com/Layr-Labs/devkit-cli/pull/143)
5dac41ef8a3d2e31a18400e14a5855bbc19566d2: docs: lightweight fix for installation step in readme by @grezle (https://github.com/Layr-Labs/devkit-cli/pull/147)
f29b3ff577bcbd2f52b108a95f05ba87dc8c136c: feat: teardown anvil container when run script is cancelled by @grezle (https://github.com/Layr-Labs/devkit-cli/pull/141)
17e35e0870f04585c0660406c1c790e68a3706d3: feat: add a smoke test to verify release binaries by @grezle (https://github.com/Layr-Labs/devkit-cli/pull/149)
fb43f53286b48b8afc456f639923197d6b6ddaf7: fix: use context/env provided chainId and default if nil by @grezle (https://github.com/Layr-Labs/devkit-cli/pull/164)
420d1171d3e32c86eeb8dcd9dcbc4b14c6379531: feat: migration unit testing(0.0.1 to 0.0.5) by @supernovahs (https://github.com/Layr-Labs/devkit-cli/pull/160)
17ef502dc861b9c3f8cd04f02739bffd97c66129: fix: ensure --set works against seqs and maps and allow filtering by @grezle (https://github.com/Layr-Labs/devkit-cli/pull/153)
936c0af4a53c44d4164e1292c7ed87f2199c039b: docs: ensure the $HOME/bin exists before installing to it by @grezle (https://github.com/Layr-Labs/devkit-cli/pull/152)
bb7c4c299f9f143f9d8765230ca69fefe88cef52: fix: ensure git profile is set before performing initial commit by @grezle (https://github.com/Layr-Labs/devkit-cli/pull/154)

### **Pre-Release Preparation**

- [x] **Versioning**
    - Update version number consistently across:
        - `README.md`
        - Codebase
        - Release notes
- [x] **Release Notes**
    - Clearly document all user-facing changes, fixes, and known issues.
- [x] **Prerelease Artifacts**
    - Ensure release pipeline generates binaries/packages for each target architecture:
        - [x]  Linux (`amd64`, `arm64`)
        - [x]  macOS (`amd64`, `arm64`)

### **Testing**

- [x] **Manual Smoke Tests** (minimum required):
    - [x]  Linux amd64
        - [x]  Installation (`curl` + unpacking, permissions)
        - [x]  Basic e2e functionality
            - [x]  `devkit version`
            - [x]  `devkit create`
            - [x]  `devkit build`
            - [x]  `devkit devnet start`
            - [x]  `devkit devnet stop`
        - [x]  If there is a config or template upgrade in this release, confirm that it has completed successfully
    - [x]  Linux arm64
        - [x]  Installation (`curl` + unpacking, permissions)
        - [x]  Basic e2e functionality
            - [x]  `devkit version`
            - [x]  `devkit create`
            - [x]  `devkit build`
            - [x]  `devkit devnet start`
            - [x]  `devkit devnet stop`
        - [x]  If there is a config or template upgrade in this release, confirm that it has completed successfully
    - [x]  macOS amd64
        - [x]  Installation (`curl` + unpacking, permissions)
        - [x]  Basic e2e functionality
            - [x]  `devkit version`
            - [x]  `devkit create`
            - [x]  `devkit build`
            - [x]  `devkit devnet start`
            - [x]  `devkit devnet stop`
        - [x]  If there is a config or template upgrade in this release, confirm that it has completed successfully
    - [x]  macOS arm64
        - [x]  Installation (`curl` + unpacking, permissions)
        - [x]  Basic e2e functionality
            - [x]  `devkit version`
            - [x]  `devkit create`
            - [x]  `devkit build`
            - [x]  `devkit devnet start`
            - [x]  `devkit devnet stop`
        - [x]  If there is a config or template upgrade in this release, confirm that it has completed successfully
- [x] **Automated CI checks**
    - [x]  All automated CI workflows are passing:
        - [x]  Unit tests
        - [x]  Integration tests
        - [x]  No unresolved build/test warnings or errors

### **Publishing**

- [x]  GitHub Release created and clearly tagged (`vX.Y.Z`).
- [x]  Verify public accessibility of uploaded artifacts.

### **Communication**

- [ ]  Announce new release internally (Slack, email, etc.) and externally as appropriate.
