### PR TITLE
feat: add user_uuid to associate user in telemetry

### DIFF
--- a/pkg/commands/create.go
+++ b/pkg/commands/create.go
@@ -370,7 +370,6 @@ const contractsBasePath = ".devkit/contracts"
 
 // initGitRepo initializes a new Git repository in the target directory.
 func initGitRepo(ctx *cli.Context, targetDir string, logger iface.Logger) error {
-
 	logger.Debug("Removing existing .git directory in %s (if any)...", targetDir)
 
 	// remove the old .git dir

--- a/pkg/commands/create.go
+++ b/pkg/commands/create.go
@@ -167,6 +167,11 @@ var CreateCommand = &cli.Command{
 			return fmt.Errorf("could not determine application environment")
 		}
 
+		// Save the users user_uuid to global config
+		if err := common.SaveUserId(appEnv.UserUUID); err != nil {
+			return fmt.Errorf("failed to save global settings: %w", err)
+		}
+
 		// Get global telemetry preference
 		globalTelemetryEnabled, err := common.GetGlobalTelemetryPreference()
 		if err != nil {

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -12,7 +12,7 @@ const (
 	ContractsMakefile = "Makefile"
 
 	// GlobalConfigFile is the name of the global YAML used to store global config details (eg, user_id)
-	GlobalConfigFile = ".global.devkit.yaml"
+	GlobalConfigFile = "config.yaml"
 
 	// Filename for devkit project config
 	BaseConfig = "config.yaml"

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -11,6 +11,9 @@ const (
 	// ContractsMakefile is the name of the makefile used for contract level operations
 	ContractsMakefile = "Makefile"
 
+	// GlobalConfigFile is the name of the global YAML used to store global config details (eg, user_id)
+	GlobalConfigFile = ".global.devkit.yaml"
+
 	// Filename for devkit project config
 	BaseConfig = "config.yaml"
 

--- a/pkg/common/context.go
+++ b/pkg/common/context.go
@@ -57,7 +57,7 @@ func WithAppEnvironment(ctx *cli.Context) {
 }
 
 func withAppEnvironmentFromLocation(ctx *cli.Context, location string) {
-	user := getUserUUIDFromGlobalSettings()
+	user := getUserUUIDFromGlobalConfig()
 	if user == "" {
 		user = uuid.New().String()
 	}

--- a/pkg/common/context.go
+++ b/pkg/common/context.go
@@ -39,14 +39,16 @@ type AppEnvironment struct {
 	OS          string
 	Arch        string
 	ProjectUUID string
+	UserUUID    string
 }
 
-func NewAppEnvironment(os string, arch string, projectUuid string) *AppEnvironment {
+func NewAppEnvironment(os, arch, projectUuid, userUuid string) *AppEnvironment {
 	return &AppEnvironment{
 		CLIVersion:  embeddedDevkitReleaseVersion,
 		OS:          os,
 		Arch:        arch,
 		ProjectUUID: projectUuid,
+		UserUUID:    userUuid,
 	}
 }
 
@@ -55,6 +57,11 @@ func WithAppEnvironment(ctx *cli.Context) {
 }
 
 func withAppEnvironmentFromLocation(ctx *cli.Context, location string) {
+	user := getUserUUIDFromGlobalSettings()
+	if user == "" {
+		user = uuid.New().String()
+	}
+
 	id := getProjectUUIDFromLocation(location)
 	if id == "" {
 		id = uuid.New().String()
@@ -63,6 +70,7 @@ func withAppEnvironmentFromLocation(ctx *cli.Context, location string) {
 		runtime.GOOS,
 		runtime.GOARCH,
 		id,
+		user,
 	))
 }
 

--- a/pkg/common/global_config.go
+++ b/pkg/common/global_config.go
@@ -14,6 +14,8 @@ type GlobalConfig struct {
 	FirstRun bool `yaml:"first_run"`
 	// TelemetryEnabled stores the user's global telemetry preference
 	TelemetryEnabled *bool `yaml:"telemetry_enabled,omitempty"`
+	// The users uuid to identify user across projects
+	UserUUID string `yaml:"user_uuid"`
 }
 
 // GetGlobalConfigDir returns the XDG-compliant directory where global devkit config should be stored
@@ -42,7 +44,7 @@ func GetGlobalConfigPath() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(configDir, "config.yaml"), nil
+	return filepath.Join(configDir, GlobalConfigFile), nil
 }
 
 // LoadGlobalConfig loads the global configuration, creating defaults if needed

--- a/pkg/common/user_config.go
+++ b/pkg/common/user_config.go
@@ -50,7 +50,7 @@ func SaveUserId(userUuid string) error {
 	return nil
 }
 
-func getUserUUIDFromGlobalSettings() string {
+func getUserUUIDFromGlobalConfig() string {
 	config, err := LoadGlobalConfig()
 	if err != nil {
 		return ""

--- a/pkg/common/user_config.go
+++ b/pkg/common/user_config.go
@@ -1,0 +1,75 @@
+package common
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// GlobalSettings contains the user-level configuration
+type GlobalSettings struct {
+	UserUUID string `yaml:"user_uuid"`
+}
+
+// SaveUserId saves user settings to the global config, but preserves existing UUID if present
+func SaveUserId(userUuid string) error {
+	// Try to load existing settings first to preserve UUID if it exists
+	var settings GlobalSettings
+	existingSettings, err := LoadGlobalSettings()
+	if err == nil && existingSettings != nil {
+		settings = *existingSettings
+	} else {
+		// Create new settings with provided UUID
+		settings = GlobalSettings{UserUUID: userUuid}
+	}
+
+	data, err := yaml.Marshal(settings)
+	if err != nil {
+		return fmt.Errorf("failed to marshal settings: %w", err)
+	}
+
+	globalConfigDir := filepath.Join(os.Getenv("HOME"), ".devkit")
+	// Create global .devkit directory
+	if err := os.MkdirAll(globalConfigDir, 0755); err != nil {
+		return fmt.Errorf("failed to create project directory: %w", err)
+	}
+
+	globalConfigPath := filepath.Join(globalConfigDir, GlobalConfigFile)
+	if err := os.WriteFile(globalConfigPath, data, 0644); err != nil {
+		return fmt.Errorf("failed to write config file: %w", err)
+	}
+
+	return nil
+}
+
+func loadGlobalSettingsFromLocation(location string) (*GlobalSettings, error) {
+	data, err := os.ReadFile(location)
+	if err != nil {
+		return nil, err
+	}
+
+	var settings GlobalSettings
+	if err := yaml.Unmarshal(data, &settings); err != nil {
+		return nil, fmt.Errorf("failed to parse config file: %w", err)
+	}
+
+	return &settings, nil
+}
+
+// LoadGlobalSettings loads users settings from the home directory
+func LoadGlobalSettings() (*GlobalSettings, error) {
+	globalConfigPath := filepath.Join(os.Getenv("HOME"), ".devkit", GlobalConfigFile)
+
+	return loadGlobalSettingsFromLocation(globalConfigPath)
+}
+
+func getUserUUIDFromGlobalSettings() string {
+	settings, err := LoadGlobalSettings()
+	if err != nil {
+		return ""
+	}
+
+	return settings.UserUUID
+}

--- a/pkg/common/user_config_test.go
+++ b/pkg/common/user_config_test.go
@@ -76,7 +76,9 @@ func TestLoadGlobalSettings_MalformedYAML(t *testing.T) {
 
 	// Create config dir and invalid YAML
 	d := filepath.Join(tmp, ".devkit")
-	os.MkdirAll(d, 0755)
+	if err := os.MkdirAll(d, 0755); err != nil {
+		t.Fatalf("mkdir failed: %v", err)
+	}
 	cfg := filepath.Join(d, GlobalConfigFile)
 	if err := os.WriteFile(cfg, []byte("not: [valid: yaml"), 0644); err != nil {
 		t.Fatalf("write malformed YAML: %v", err)

--- a/pkg/common/user_config_test.go
+++ b/pkg/common/user_config_test.go
@@ -1,0 +1,143 @@
+package common
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestSaveUserIdAndLoadGlobalSettings(t *testing.T) {
+	// Set HOME to a temp directory
+	tmp := t.TempDir()
+	os.Setenv("HOME", tmp)
+
+	const id1 = "uuid-1234"
+	// Save first UUID
+	if err := SaveUserId(id1); err != nil {
+		t.Fatalf("SaveUserId failed: %v", err)
+	}
+
+	// Path where config should be
+	cfg := filepath.Join(tmp, ".devkit", GlobalConfigFile)
+
+	// Check file exists
+	if _, err := os.Stat(cfg); err != nil {
+		t.Fatalf("config file not found: %v", err)
+	}
+
+	// Load and verify content
+	data, err := os.ReadFile(cfg)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+
+	var s struct {
+		UserUUID string `yaml:"user_uuid"`
+	}
+	if err := yaml.Unmarshal(data, &s); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if s.UserUUID != id1 {
+		t.Errorf("expected %s, got %s", id1, s.UserUUID)
+	}
+
+	// Save a new UUID: since existing settings loads fine, code preserves the old UUID
+	const id2 = "uuid-5678"
+	if err := SaveUserId(id2); err != nil {
+		t.Fatalf("SaveUserId overwrite failed: %v", err)
+	}
+	// Reload
+	out, err := LoadGlobalSettings()
+	if err != nil {
+		t.Fatalf("LoadGlobalSettings failed: %v", err)
+	}
+	if out.UserUUID != id1 {
+		t.Errorf("expected preserved %s after overwrite attempt, got %s", id1, out.UserUUID)
+	}
+}
+
+func TestGetUserUUIDFromGlobalSettings_Empty(t *testing.T) {
+	// Unset HOME
+	os.Unsetenv("HOME")
+
+	// Ensure no config and HOME unset
+	uuid := getUserUUIDFromGlobalSettings()
+	if uuid != "" {
+		t.Errorf("expected empty UUID when HOME unset, got %q", uuid)
+	}
+}
+
+func TestLoadGlobalSettings_MalformedYAML(t *testing.T) {
+	// Set HOME to temp
+	tmp := t.TempDir()
+	os.Setenv("HOME", tmp)
+
+	// Create config dir and invalid YAML
+	d := filepath.Join(tmp, ".devkit")
+	os.MkdirAll(d, 0755)
+	cfg := filepath.Join(d, GlobalConfigFile)
+	if err := os.WriteFile(cfg, []byte("not: [valid: yaml"), 0644); err != nil {
+		t.Fatalf("write malformed YAML: %v", err)
+	}
+
+	// Load should error
+	if _, err := LoadGlobalSettings(); err == nil {
+		t.Error("expected error loading malformed YAML, got nil")
+	}
+
+	// SaveUserId should overwrite malformed and succeed
+	const id = "uuid-0000"
+	if err := SaveUserId(id); err != nil {
+		t.Fatalf("SaveUserId did not overwrite malformed YAML: %v", err)
+	}
+	// Verify valid YAML now
+	data, err := os.ReadFile(cfg)
+	if err != nil {
+		t.Fatalf("read config after overwrite: %v", err)
+	}
+	var s struct {
+		UserUUID string `yaml:"user_uuid"`
+	}
+	if err := yaml.Unmarshal(data, &s); err != nil {
+		t.Fatalf("unmarshal after overwrite: %v", err)
+	}
+	if s.UserUUID != id {
+		t.Errorf("expected %s after overwrite, got %s", id, s.UserUUID)
+	}
+}
+
+func TestSaveUserId_PermissionsError(t *testing.T) {
+	// Set HOME to temp
+	tmp := t.TempDir()
+	os.Setenv("HOME", tmp)
+
+	// Create file where directory should be to block MkdirAll
+	block := filepath.Join(tmp, ".devkit")
+	if err := os.WriteFile(block, []byte(""), 0644); err != nil {
+		t.Fatalf("setup block file: %v", err)
+	}
+
+	// Now SaveUserId should fail on MkdirAll
+	if err := SaveUserId("any"); err == nil {
+		t.Error("expected error when MkdirAll fails, got nil")
+	}
+}
+
+func TestSaveUserId_WriteFileError(t *testing.T) {
+	// Set HOME to temp
+	tmp := t.TempDir()
+	os.Setenv("HOME", tmp)
+
+	// Create directory and make it read-only
+	d := filepath.Join(tmp, ".devkit")
+	if err := os.MkdirAll(d, 0555); err != nil {
+		t.Fatalf("setup readonly dir: %v", err)
+	}
+
+	// Attempt write should fail
+	if err := SaveUserId("uuid-error"); err == nil {
+		t.Error("expected write error due to permissions, got nil")
+	}
+}

--- a/pkg/common/user_config_test.go
+++ b/pkg/common/user_config_test.go
@@ -9,8 +9,8 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func TestSaveUserIdAndLoadGlobalSettings(t *testing.T) {
-	// Set HOME to a temp directory
+func TestSaveUserIdAndLoadGlobalConfig(t *testing.T) {
+	// Set XDG_CONFIG_HOME to a temp directory
 	tmp := t.TempDir()
 	os.Setenv("XDG_CONFIG_HOME", tmp)
 
@@ -66,8 +66,8 @@ func TestSaveUserIdAndLoadGlobalSettings(t *testing.T) {
 	}
 }
 
-func TestgetUserUUIDFromGlobalConfig_Empty(t *testing.T) {
-	// Unset HOME
+func TestGetUserUUIDFromGlobalConfig_Empty(t *testing.T) {
+	// Unset XDG_CONFIG_HOME
 	os.Unsetenv("XDG_CONFIG_HOME")
 
 	// Ensure no config and HOME unset
@@ -77,8 +77,8 @@ func TestgetUserUUIDFromGlobalConfig_Empty(t *testing.T) {
 	}
 }
 
-func TestLoadGlobalSettings_MalformedYAML(t *testing.T) {
-	// Set HOME to temp
+func TestLoadGlobalConfig_MalformedYAML(t *testing.T) {
+	// Set XDG_CONFIG_HOME to temp
 	tmp := t.TempDir()
 	os.Setenv("XDG_CONFIG_HOME", tmp)
 
@@ -124,7 +124,7 @@ func TestLoadGlobalSettings_MalformedYAML(t *testing.T) {
 }
 
 func TestSaveUserId_PermissionsError(t *testing.T) {
-	// Set HOME to temp
+	// Set XDG_CONFIG_HOME to temp
 	tmp := t.TempDir()
 	os.Setenv("XDG_CONFIG_HOME", tmp)
 
@@ -146,7 +146,7 @@ func TestSaveUserId_PermissionsError(t *testing.T) {
 }
 
 func TestSaveUserId_WriteFileError(t *testing.T) {
-	// Set HOME to temp
+	// Set XDG_CONFIG_HOME to temp
 	tmp := t.TempDir()
 	os.Setenv("XDG_CONFIG_HOME", tmp)
 

--- a/pkg/common/user_config_test.go
+++ b/pkg/common/user_config_test.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -11,7 +12,13 @@ import (
 func TestSaveUserIdAndLoadGlobalSettings(t *testing.T) {
 	// Set HOME to a temp directory
 	tmp := t.TempDir()
-	os.Setenv("HOME", tmp)
+	os.Setenv("XDG_CONFIG_HOME", tmp)
+
+	// Get the global config dir so that we can create it
+	globalConfigDir, err := GetGlobalConfigDir()
+	if err != nil {
+		t.Fatalf("could not locate global config: %v", err)
+	}
 
 	const id1 = "uuid-1234"
 	// Save first UUID
@@ -20,7 +27,7 @@ func TestSaveUserIdAndLoadGlobalSettings(t *testing.T) {
 	}
 
 	// Path where config should be
-	cfg := filepath.Join(tmp, ".devkit", GlobalConfigFile)
+	cfg := filepath.Join(globalConfigDir, GlobalConfigFile)
 
 	// Check file exists
 	if _, err := os.Stat(cfg); err != nil {
@@ -33,6 +40,7 @@ func TestSaveUserIdAndLoadGlobalSettings(t *testing.T) {
 		t.Fatalf("read config: %v", err)
 	}
 
+	fmt.Printf("what %s", string(data))
 	var s struct {
 		UserUUID string `yaml:"user_uuid"`
 	}
@@ -49,9 +57,9 @@ func TestSaveUserIdAndLoadGlobalSettings(t *testing.T) {
 		t.Fatalf("SaveUserId overwrite failed: %v", err)
 	}
 	// Reload
-	out, err := LoadGlobalSettings()
+	out, err := LoadGlobalConfig()
 	if err != nil {
-		t.Fatalf("LoadGlobalSettings failed: %v", err)
+		t.Fatalf("LoadGlobalConfig failed: %v", err)
 	}
 	if out.UserUUID != id1 {
 		t.Errorf("expected preserved %s after overwrite attempt, got %s", id1, out.UserUUID)
@@ -60,32 +68,37 @@ func TestSaveUserIdAndLoadGlobalSettings(t *testing.T) {
 
 func TestGetUserUUIDFromGlobalSettings_Empty(t *testing.T) {
 	// Unset HOME
-	os.Unsetenv("HOME")
+	os.Unsetenv("XDG_CONFIG_HOME")
 
 	// Ensure no config and HOME unset
 	uuid := getUserUUIDFromGlobalSettings()
 	if uuid != "" {
-		t.Errorf("expected empty UUID when HOME unset, got %q", uuid)
+		t.Errorf("expected empty UUID when XDG_CONFIG_HOME unset, got %q", uuid)
 	}
 }
 
 func TestLoadGlobalSettings_MalformedYAML(t *testing.T) {
 	// Set HOME to temp
 	tmp := t.TempDir()
-	os.Setenv("HOME", tmp)
+	os.Setenv("XDG_CONFIG_HOME", tmp)
+
+	// Get the global config dir so that we can create it
+	globalConfigDir, err := GetGlobalConfigDir()
+	if err != nil {
+		t.Fatalf("could not locate global config: %v", err)
+	}
 
 	// Create config dir and invalid YAML
-	d := filepath.Join(tmp, ".devkit")
-	if err := os.MkdirAll(d, 0755); err != nil {
+	if err := os.MkdirAll(globalConfigDir, 0755); err != nil {
 		t.Fatalf("mkdir failed: %v", err)
 	}
-	cfg := filepath.Join(d, GlobalConfigFile)
+	cfg := filepath.Join(globalConfigDir, GlobalConfigFile)
 	if err := os.WriteFile(cfg, []byte("not: [valid: yaml"), 0644); err != nil {
 		t.Fatalf("write malformed YAML: %v", err)
 	}
 
 	// Load should error
-	if _, err := LoadGlobalSettings(); err == nil {
+	if _, err := LoadGlobalConfig(); err == nil {
 		t.Error("expected error loading malformed YAML, got nil")
 	}
 
@@ -113,11 +126,16 @@ func TestLoadGlobalSettings_MalformedYAML(t *testing.T) {
 func TestSaveUserId_PermissionsError(t *testing.T) {
 	// Set HOME to temp
 	tmp := t.TempDir()
-	os.Setenv("HOME", tmp)
+	os.Setenv("XDG_CONFIG_HOME", tmp)
+
+	// Get the global config dir so that we can create it
+	globalConfigDir, err := GetGlobalConfigDir()
+	if err != nil {
+		t.Fatalf("could not locate global config: %v", err)
+	}
 
 	// Create file where directory should be to block MkdirAll
-	block := filepath.Join(tmp, ".devkit")
-	if err := os.WriteFile(block, []byte(""), 0644); err != nil {
+	if err := os.WriteFile(globalConfigDir, []byte(""), 0644); err != nil {
 		t.Fatalf("setup block file: %v", err)
 	}
 
@@ -130,11 +148,16 @@ func TestSaveUserId_PermissionsError(t *testing.T) {
 func TestSaveUserId_WriteFileError(t *testing.T) {
 	// Set HOME to temp
 	tmp := t.TempDir()
-	os.Setenv("HOME", tmp)
+	os.Setenv("XDG_CONFIG_HOME", tmp)
+
+	// Get the global config dir so that we can create it
+	globalConfigDir, err := GetGlobalConfigDir()
+	if err != nil {
+		t.Fatalf("could not locate global config: %v", err)
+	}
 
 	// Create directory and make it read-only
-	d := filepath.Join(tmp, ".devkit")
-	if err := os.MkdirAll(d, 0555); err != nil {
+	if err := os.MkdirAll(globalConfigDir, 0555); err != nil {
 		t.Fatalf("setup readonly dir: %v", err)
 	}
 

--- a/pkg/common/user_config_test.go
+++ b/pkg/common/user_config_test.go
@@ -66,12 +66,12 @@ func TestSaveUserIdAndLoadGlobalSettings(t *testing.T) {
 	}
 }
 
-func TestGetUserUUIDFromGlobalSettings_Empty(t *testing.T) {
+func TestgetUserUUIDFromGlobalConfig_Empty(t *testing.T) {
 	// Unset HOME
 	os.Unsetenv("XDG_CONFIG_HOME")
 
 	// Ensure no config and HOME unset
-	uuid := getUserUUIDFromGlobalSettings()
+	uuid := getUserUUIDFromGlobalConfig()
 	if uuid != "" {
 		t.Errorf("expected empty UUID when XDG_CONFIG_HOME unset, got %q", uuid)
 	}

--- a/pkg/hooks/hooks.go
+++ b/pkg/hooks/hooks.go
@@ -252,6 +252,7 @@ func WithCommandMetricsContext(ctx *cli.Context) error {
 		metrics.Properties["os"] = appEnv.OS
 		metrics.Properties["arch"] = appEnv.Arch
 		metrics.Properties["project_uuid"] = appEnv.ProjectUUID
+		metrics.Properties["user_uuid"] = appEnv.UserUUID
 	}
 
 	for k, v := range collectFlagValues(ctx) {

--- a/pkg/hooks/hooks_test.go
+++ b/pkg/hooks/hooks_test.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/Layr-Labs/devkit-cli/pkg/telemetry"
 	"runtime"
 	"testing"
+
+	"github.com/Layr-Labs/devkit-cli/pkg/telemetry"
 
 	"github.com/urfave/cli/v2"
 )
@@ -40,6 +41,7 @@ func MockWithTelemetry(action cli.ActionFunc, mockClient telemetry.Client) cli.A
 		metrics.Properties["os"] = runtime.GOOS
 		metrics.Properties["arch"] = runtime.GOARCH
 		metrics.Properties["project_uuid"] = "test-uuid"
+		metrics.Properties["user_uuid"] = "user-uuid"
 
 		// Add command flags as properties
 		flags := collectFlagValues(ctx)

--- a/pkg/telemetry/telemetry_test.go
+++ b/pkg/telemetry/telemetry_test.go
@@ -2,8 +2,9 @@ package telemetry
 
 import (
 	"context"
-	"github.com/Layr-Labs/devkit-cli/pkg/common"
 	"testing"
+
+	"github.com/Layr-Labs/devkit-cli/pkg/common"
 )
 
 func TestNoopClient(t *testing.T) {
@@ -48,7 +49,7 @@ func TestContext(t *testing.T) {
 }
 
 func TestProperties(t *testing.T) {
-	props := common.NewAppEnvironment("darwin", "amd64", "test-uuid")
+	props := common.NewAppEnvironment("darwin", "amd64", "test-uuid", "user-uuid")
 	if props.CLIVersion == "" {
 		t.Error("Version not using default")
 	}


### PR DESCRIPTION
**Motivation:**  
Storing a unique user identifier at the global level enables consistent telemetry, usage tracking, and personalisation across multiple project invocations of `devkit`. Previously, telemetry was only tracked at project-level, which could be shared by multiple users and a single user might have multiple projects. By persisting `user_uuid` in `~/.config/devkit/config.yaml`,  we can share user context across all commands and improve telemetry tracking accuracy - ensuring that metrics are attributed to the correct individual rather than to individual projects, reducing duplicate records, and enabling richer, longitudinal insights into feature adoption and usage patterns.

**Modifications:**  
- Extend `GlobalConfig` struct and YAML file to hold `user_uuid`.
- Update CLI command `devkit avs create` to call `SaveUserId(newUUID)` when no existing global UUID is found.
- On subsequent invocations, `LoadGlobalConfig()` reads and returns the existing `user_uuid` instead of generating a new one.
- Added unit tests for `SaveUserId` and `LoadGlobalConfig` covering:
  1. First-time creation of global config directory and file
  2. Preservation of existing UUID on repeat calls
  3. Error handling for malformed YAML, directory-permissions errors, and write-permissions errors

**Result:**  
- A single, persistent `user_uuid` is generated once and stored globally.
- All `devkit avs create` invocations reuse the same identifier, enabling consistent user-level settings and telemetry.
- The new global config file path is `~/.config/devkit/config.yaml`.

**Testing:**  
- **Automated unit tests** verify:  
  1. Creation of `~/.config/devkit` directory and `config.yaml` on first create
  2. Correct YAML marshalling and unmarshalling of `user_uuid`
  3. Preservation of existing UUID across multiple saves
  4. Behaviour when `$HOME` is unset (returns empty UUID)
  5. Overwriting malformed YAML and recovery
  6. Error propagation when directory creation or file write fails
- **Manual end-to-end**:
  1. Remove or rename existing `~/.config/devkit`
  2. Run `devkit avs create` and confirm new file contains a UUID
  3. Run `devkit avs create` again and confirm same UUID is used

**Open questions:**  
- Should we expose a CLI command to explicitly rotate or clear the global `user_uuid`?
