### PR TITLE
feat: add call step to e2e test

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -77,6 +77,11 @@ jobs:
           echo "❌ Devnet failed to start"
           exit 1
 
+      - name: Call AVS
+        run: |
+          cd ./my-awesome-avs/
+          devkit avs call -- signature="(uint256,string)" args='(5,"hello")'
+
       - name: Stop devnet
         run: |
           cd ./my-awesome-avs/


### PR DESCRIPTION
<!-- 
    🚨 ATTENTION! 🚨 
    
    This PR template is REQUIRED. PRs not following this format will be closed without review.
    
    Requirements:
    - PR title must follow commit conventions: https://www.conventionalcommits.org/en/v1.0.0/
    - Label your PR with the correct type (e.g., 🐛 Bug, ✨ Enhancement, 🧪 Test, etc.)
    - Provide clear and specific details in each section
-->

**Motivation:**
<!--
Explain here the context, and why you're making that change. What is the problem you're trying to solve.
-->
Our e2e tests stop after starting devnet. This misses a crucial step from the e2e process, submitting a task to the `TaskMailBox`.

**Modifications:**
<!--
Describe the modifications you've done from a high level. What are the key technical decisions and why were they made?
-->
- This PR adds an additional step to the e2e process to run `devkit avs call`

**Result:**
<!--
*After your change, what will change.
-->
- e2e now covers all processes e2e

**Open questions:**
<!--
(optional) Any open questions or feedback on design desired?
-->
- Once the mailbox is returning results on stdout we can verify in devkit that the call worked correctly and throw accordingly.