### PR TITLE
feat: noop logger and tests integration

### DIFF
--- a/pkg/commands/build_test.go
+++ b/pkg/commands/build_test.go
@@ -3,12 +3,13 @@ package commands
 import (
 	"context"
 	"errors"
-	"github.com/Layr-Labs/devkit-cli/pkg/common"
-	"github.com/Layr-Labs/devkit-cli/pkg/testutils"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/Layr-Labs/devkit-cli/pkg/common"
+	"github.com/Layr-Labs/devkit-cli/pkg/testutils"
 
 	"github.com/urfave/cli/v2"
 )
@@ -57,7 +58,7 @@ build:
 
 	app := &cli.App{
 		Name:     "test",
-		Commands: []*cli.Command{testutils.WithTestConfig(BuildCommand)},
+		Commands: []*cli.Command{testutils.WithTestConfigAndNoopLogger(BuildCommand)},
 	}
 
 	if err := app.Run([]string{"app", "build"}); err != nil {
@@ -95,7 +96,7 @@ echo "Mock build executed"`
 
 	app := &cli.App{
 		Name:     "test",
-		Commands: []*cli.Command{testutils.WithTestConfig(BuildCommand)},
+		Commands: []*cli.Command{testutils.WithTestConfigAndNoopLogger(BuildCommand)},
 	}
 
 	if err := app.Run([]string{"app", "build"}); err != nil {
@@ -131,7 +132,7 @@ echo "Mock build executed"`
 
 	app := &cli.App{
 		Name:     "test",
-		Commands: []*cli.Command{testutils.WithTestConfig(BuildCommand)},
+		Commands: []*cli.Command{testutils.WithTestConfigAndNoopLogger(BuildCommand)},
 	}
 
 	done := make(chan error, 1)

--- a/pkg/commands/config/config_test.go
+++ b/pkg/commands/config/config_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Layr-Labs/devkit-cli/config/contexts"
 	"github.com/Layr-Labs/devkit-cli/pkg/common"
+	"github.com/Layr-Labs/devkit-cli/pkg/testutils"
 
 	"github.com/stretchr/testify/require"
 	"github.com/urfave/cli/v2"
@@ -52,13 +53,21 @@ config:
 	r, w, _ := os.Pipe()
 	os.Stdout = w
 
-	// ⚙️ Run the CLI app with nested subcommands
+	// ⚙️ Run the CLI app with nested subcommands and no-op logger
+	cmdWithLogger, _ := testutils.WithTestConfigAndNoopLoggerAndAccess(Command)
 	app := &cli.App{
 		Commands: []*cli.Command{
 			{
 				Name: "avs",
 				Subcommands: []*cli.Command{
-					Command,
+					cmdWithLogger,
+				},
+				Before: func(cCtx *cli.Context) error {
+					// Execute the command's Before hook to set up logger context
+					if cmdWithLogger.Before != nil {
+						return cmdWithLogger.Before(cCtx)
+					}
+					return nil
 				},
 			},
 		},

--- a/pkg/commands/create_test.go
+++ b/pkg/commands/create_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Layr-Labs/devkit-cli/config/configs"
 	"github.com/Layr-Labs/devkit-cli/config/contexts"
 	"github.com/Layr-Labs/devkit-cli/pkg/common"
+	"github.com/Layr-Labs/devkit-cli/pkg/common/logger"
 	"github.com/Layr-Labs/devkit-cli/pkg/template"
 	"github.com/Layr-Labs/devkit-cli/pkg/testutils"
 
@@ -22,7 +23,7 @@ import (
 
 func TestCreateCommand(t *testing.T) {
 	tmpDir := t.TempDir()
-	logger, _ := common.GetLogger(false)
+	logger := logger.NewNoopLogger()
 	mockConfigYaml := configs.ConfigYamls[configs.LatestVersion]
 	configDir := filepath.Join("config")
 	err := os.MkdirAll(configDir, 0755)
@@ -111,7 +112,7 @@ func TestCreateCommand(t *testing.T) {
 
 	app := &cli.App{
 		Name:     "test",
-		Commands: []*cli.Command{testutils.WithTestConfig(&tmpCmd)},
+		Commands: []*cli.Command{testutils.WithTestConfigAndNoopLogger(&tmpCmd)},
 	}
 
 	// Test cases
@@ -184,7 +185,7 @@ build:
 
 	buildApp := &cli.App{
 		Name:     "test",
-		Commands: []*cli.Command{testutils.WithTestConfig(BuildCommand)},
+		Commands: []*cli.Command{testutils.WithTestConfigAndNoopLogger(BuildCommand)},
 	}
 
 	if err := buildApp.Run([]string{"app", "build"}); err != nil {
@@ -245,7 +246,7 @@ func TestCreateCommand_ContextCancellation(t *testing.T) {
 
 	app := &cli.App{
 		Name:     "test",
-		Commands: []*cli.Command{testutils.WithTestConfig(origCmd)},
+		Commands: []*cli.Command{testutils.WithTestConfigAndNoopLogger(origCmd)},
 	}
 
 	done := make(chan error, 1)

--- a/pkg/commands/devnet_actions.go
+++ b/pkg/commands/devnet_actions.go
@@ -727,7 +727,7 @@ func RegisterOperatorsFromConfigAction(cCtx *cli.Context, logger iface.Logger) e
 }
 
 func FetchZeusAddressesAction(cCtx *cli.Context) error {
-	logger, _ := common.GetLoggerFromCLIContext(cCtx)
+	logger := common.LoggerFromContext(cCtx.Context)
 	contextName := cCtx.String("context")
 
 	// Set path for context yaml
@@ -917,7 +917,7 @@ func registerOperatorAVS(cCtx *cli.Context, logger iface.Logger, operatorAddress
 }
 
 func extractContractOutputs(cCtx *cli.Context, context string, contractsList []DeployContractTransport) error {
-	logger, _ := common.GetLoggerFromCLIContext(cCtx)
+	logger := common.LoggerFromContext(cCtx.Context)
 
 	// Push contract artefacts to ./contracts/outputs
 	outDir := filepath.Join("contracts", "outputs", context)

--- a/pkg/commands/template/info_test.go
+++ b/pkg/commands/template/info_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/Layr-Labs/devkit-cli/pkg/common"
+	"github.com/Layr-Labs/devkit-cli/pkg/testutils"
 	"github.com/urfave/cli/v2"
 )
 
@@ -35,11 +36,12 @@ func TestInfoCommand(t *testing.T) {
 		t.Fatalf("Failed to write config file: %v", err)
 	}
 
-	// Create test context
+	// Create test context with no-op logger
+	infoCmdWithLogger, _ := testutils.WithTestConfigAndNoopLoggerAndAccess(InfoCommand)
 	app := &cli.App{
 		Name: "test-app",
 		Commands: []*cli.Command{
-			InfoCommand,
+			infoCmdWithLogger,
 		},
 	}
 
@@ -58,12 +60,20 @@ func TestInfoCommand(t *testing.T) {
 
 	// Test info command
 	t.Run("Info command", func(t *testing.T) {
-		// Create a flag set and context
+		// Create a flag set and context with no-op logger
 		set := flag.NewFlagSet("test", 0)
 		ctx := cli.NewContext(app, set, nil)
 
+		// Execute the Before hook to set up the logger context
+		if infoCmdWithLogger.Before != nil {
+			err := infoCmdWithLogger.Before(ctx)
+			if err != nil {
+				t.Fatalf("Before hook failed: %v", err)
+			}
+		}
+
 		// Run the info command
-		err := InfoCommand.Action(ctx)
+		err := infoCmdWithLogger.Action(ctx)
 		if err != nil {
 			t.Errorf("InfoCommand action returned error: %v", err)
 		}

--- a/pkg/common/dockerutils.go
+++ b/pkg/common/dockerutils.go
@@ -3,16 +3,17 @@ package common
 import (
 	"context"
 	"fmt"
-	"github.com/docker/docker/client"
-	"github.com/urfave/cli/v2"
 	"os/exec"
 	"runtime"
 	"time"
+
+	"github.com/docker/docker/client"
+	"github.com/urfave/cli/v2"
 )
 
 // EnsureDockerIsRunning checks if Docker is running and attempts to launch Docker Desktop if not.
 func EnsureDockerIsRunning(ctx *cli.Context) error {
-	logger, _ := GetLoggerFromCLIContext(ctx)
+	logger := LoggerFromContext(ctx.Context)
 	dockerPingTimeout := 2 * time.Second
 	if !isDockerInstalled() {
 		return fmt.Errorf("docker is not installed. Please install Docker Desktop from https://www.docker.com/products/docker-desktop")

--- a/pkg/common/logger/noop_logger.go
+++ b/pkg/common/logger/noop_logger.go
@@ -1,0 +1,204 @@
+package logger
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/Layr-Labs/devkit-cli/pkg/common/iface"
+)
+
+// LogEntry represents a single log entry with level and message
+type LogEntry struct {
+	Level   string
+	Message string
+}
+
+// NoopLogger implements the Logger interface but doesn't output anything.
+// Instead, it buffers all log messages for testing assertions.
+// It is safe for concurrent use.
+type NoopLogger struct {
+	mu      sync.RWMutex
+	entries []LogEntry
+}
+
+// NewNoopLogger creates a new no-op logger for testing
+func NewNoopLogger() *NoopLogger {
+	return &NoopLogger{
+		entries: make([]LogEntry, 0),
+	}
+}
+
+// Title implements the Logger interface - buffers title messages
+func (l *NoopLogger) Title(msg string, args ...any) {
+	formatted := fmt.Sprintf("\n"+msg+"\n", args...)
+	l.addEntry("TITLE", formatted)
+}
+
+// Info implements the Logger interface - buffers info messages
+func (l *NoopLogger) Info(msg string, args ...any) {
+	msg = strings.Trim(msg, "\n")
+	if msg == "" {
+		return
+	}
+	formatted := fmt.Sprintf(msg, args...)
+	l.addEntry("INFO", formatted)
+}
+
+// Warn implements the Logger interface - buffers warning messages
+func (l *NoopLogger) Warn(msg string, args ...any) {
+	msg = strings.Trim(msg, "\n")
+	if msg == "" {
+		return
+	}
+	formatted := fmt.Sprintf(msg, args...)
+	l.addEntry("WARN", formatted)
+}
+
+// Error implements the Logger interface - buffers error messages
+func (l *NoopLogger) Error(msg string, args ...any) {
+	msg = strings.Trim(msg, "\n")
+	if msg == "" {
+		return
+	}
+	formatted := fmt.Sprintf(msg, args...)
+	l.addEntry("ERROR", formatted)
+}
+
+// Debug implements the Logger interface - buffers debug messages
+func (l *NoopLogger) Debug(msg string, args ...any) {
+	msg = strings.Trim(msg, "\n")
+	if msg == "" {
+		return
+	}
+	formatted := fmt.Sprintf(msg, args...)
+	l.addEntry("DEBUG", formatted)
+}
+
+// addEntry safely adds a log entry to the buffer
+func (l *NoopLogger) addEntry(level, message string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.entries = append(l.entries, LogEntry{
+		Level:   level,
+		Message: message,
+	})
+}
+
+// GetEntries returns a copy of all buffered log entries
+func (l *NoopLogger) GetEntries() []LogEntry {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+
+	entries := make([]LogEntry, len(l.entries))
+	copy(entries, l.entries)
+	return entries
+}
+
+// GetEntriesByLevel returns all entries for a specific log level
+func (l *NoopLogger) GetEntriesByLevel(level string) []LogEntry {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+
+	var filtered []LogEntry
+	for _, entry := range l.entries {
+		if entry.Level == level {
+			filtered = append(filtered, entry)
+		}
+	}
+	return filtered
+}
+
+// GetMessages returns all buffered messages as strings
+func (l *NoopLogger) GetMessages() []string {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+
+	messages := make([]string, len(l.entries))
+	for i, entry := range l.entries {
+		messages[i] = entry.Message
+	}
+	return messages
+}
+
+// GetMessagesByLevel returns all messages for a specific log level
+func (l *NoopLogger) GetMessagesByLevel(level string) []string {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+
+	var messages []string
+	for _, entry := range l.entries {
+		if entry.Level == level {
+			messages = append(messages, entry.Message)
+		}
+	}
+	return messages
+}
+
+// Clear removes all buffered entries
+func (l *NoopLogger) Clear() {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.entries = l.entries[:0]
+}
+
+// Len returns the number of buffered entries
+func (l *NoopLogger) Len() int {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	return len(l.entries)
+}
+
+// Contains checks if any log entry contains the specified text
+func (l *NoopLogger) Contains(text string) bool {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+
+	for _, entry := range l.entries {
+		if strings.Contains(entry.Message, text) {
+			return true
+		}
+	}
+	return false
+}
+
+// ContainsLevel checks if any log entry with the specified level contains the text
+func (l *NoopLogger) ContainsLevel(level, text string) bool {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+
+	for _, entry := range l.entries {
+		if entry.Level == level && strings.Contains(entry.Message, text) {
+			return true
+		}
+	}
+	return false
+}
+
+// NoopProgressTracker is a progress tracker that does nothing (for testing)
+type NoopProgressTracker struct{}
+
+// NewNoopProgressTracker creates a new no-op progress tracker
+func NewNoopProgressTracker() *NoopProgressTracker {
+	return &NoopProgressTracker{}
+}
+
+// ProgressRows returns an empty slice
+func (n *NoopProgressTracker) ProgressRows() []iface.ProgressRow {
+	return []iface.ProgressRow{}
+}
+
+// Set does nothing
+func (n *NoopProgressTracker) Set(id string, pct int, label string) {
+	// No-op
+}
+
+// Render does nothing
+func (n *NoopProgressTracker) Render() {
+	// No-op
+}
+
+// Clear does nothing
+func (n *NoopProgressTracker) Clear() {
+	// No-op
+}

--- a/pkg/common/logger/noop_logger_test.go
+++ b/pkg/common/logger/noop_logger_test.go
@@ -261,7 +261,7 @@ func TestNoopLogger_MessageFormatting(t *testing.T) {
 	assert.Contains(t, messages[1], "user alice has 5 items")
 }
 
-// Example test demonstrating typical usage in unit tests
+// Example test showing typical usage in unit tests
 func TestNoopLogger_UsageExample(t *testing.T) {
 	// Create logger for test
 	logger := NewNoopLogger()

--- a/pkg/common/logger/noop_logger_test.go
+++ b/pkg/common/logger/noop_logger_test.go
@@ -1,0 +1,299 @@
+package logger
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNoopLogger_Interface(t *testing.T) {
+	// Verify that NoopLogger implements the Logger interface
+	var _ interface {
+		Title(msg string, args ...any)
+		Info(msg string, args ...any)
+		Warn(msg string, args ...any)
+		Error(msg string, args ...any)
+		Debug(msg string, args ...any)
+	} = &NoopLogger{}
+}
+
+func TestNoopLogger_NewNoopLogger(t *testing.T) {
+	logger := NewNoopLogger()
+
+	assert.NotNil(t, logger)
+	assert.Equal(t, 0, logger.Len())
+	assert.Empty(t, logger.GetEntries())
+}
+
+func TestNoopLogger_LoggingMethods(t *testing.T) {
+	logger := NewNoopLogger()
+
+	// Test each logging method
+	logger.Title("Test Title %s", "message")
+	logger.Info("Test Info %s", "message")
+	logger.Warn("Test Warn %s", "message")
+	logger.Error("Test Error %s", "message")
+	logger.Debug("Test Debug %s", "message")
+
+	// Verify entries were captured
+	assert.Equal(t, 5, logger.Len())
+
+	entries := logger.GetEntries()
+	require.Len(t, entries, 5)
+
+	// Check each entry
+	assert.Equal(t, "TITLE", entries[0].Level)
+	assert.Contains(t, entries[0].Message, "Test Title message")
+
+	assert.Equal(t, "INFO", entries[1].Level)
+	assert.Equal(t, "Test Info message", entries[1].Message)
+
+	assert.Equal(t, "WARN", entries[2].Level)
+	assert.Equal(t, "Test Warn message", entries[2].Message)
+
+	assert.Equal(t, "ERROR", entries[3].Level)
+	assert.Equal(t, "Test Error message", entries[3].Message)
+
+	assert.Equal(t, "DEBUG", entries[4].Level)
+	assert.Equal(t, "Test Debug message", entries[4].Message)
+}
+
+func TestNoopLogger_EmptyMessages(t *testing.T) {
+	logger := NewNoopLogger()
+
+	// Test empty messages are ignored for Info, Warn, Error, Debug
+	logger.Info("")
+	logger.Info("\n")
+	logger.Info("\n\n")
+	logger.Warn("")
+	logger.Error("")
+	logger.Debug("")
+
+	// Title should still be captured even if empty
+	logger.Title("")
+
+	assert.Equal(t, 1, logger.Len())
+	entries := logger.GetEntries()
+	assert.Equal(t, "TITLE", entries[0].Level)
+}
+
+func TestNoopLogger_GetEntriesByLevel(t *testing.T) {
+	logger := NewNoopLogger()
+
+	logger.Info("info message 1")
+	logger.Error("error message 1")
+	logger.Info("info message 2")
+	logger.Warn("warn message 1")
+	logger.Error("error message 2")
+
+	// Test filtering by level
+	infoEntries := logger.GetEntriesByLevel("INFO")
+	assert.Len(t, infoEntries, 2)
+	assert.Equal(t, "info message 1", infoEntries[0].Message)
+	assert.Equal(t, "info message 2", infoEntries[1].Message)
+
+	errorEntries := logger.GetEntriesByLevel("ERROR")
+	assert.Len(t, errorEntries, 2)
+	assert.Equal(t, "error message 1", errorEntries[0].Message)
+	assert.Equal(t, "error message 2", errorEntries[1].Message)
+
+	warnEntries := logger.GetEntriesByLevel("WARN")
+	assert.Len(t, warnEntries, 1)
+	assert.Equal(t, "warn message 1", warnEntries[0].Message)
+
+	debugEntries := logger.GetEntriesByLevel("DEBUG")
+	assert.Len(t, debugEntries, 0)
+}
+
+func TestNoopLogger_GetMessages(t *testing.T) {
+	logger := NewNoopLogger()
+
+	logger.Info("first message")
+	logger.Warn("second message")
+	logger.Error("third message")
+
+	messages := logger.GetMessages()
+	expected := []string{"first message", "second message", "third message"}
+	assert.Equal(t, expected, messages)
+}
+
+func TestNoopLogger_GetMessagesByLevel(t *testing.T) {
+	logger := NewNoopLogger()
+
+	logger.Info("info 1")
+	logger.Error("error 1")
+	logger.Info("info 2")
+	logger.Error("error 2")
+
+	infoMessages := logger.GetMessagesByLevel("INFO")
+	assert.Equal(t, []string{"info 1", "info 2"}, infoMessages)
+
+	errorMessages := logger.GetMessagesByLevel("ERROR")
+	assert.Equal(t, []string{"error 1", "error 2"}, errorMessages)
+
+	debugMessages := logger.GetMessagesByLevel("DEBUG")
+	assert.Empty(t, debugMessages)
+}
+
+func TestNoopLogger_Clear(t *testing.T) {
+	logger := NewNoopLogger()
+
+	logger.Info("test message")
+	logger.Error("another message")
+
+	assert.Equal(t, 2, logger.Len())
+
+	logger.Clear()
+
+	assert.Equal(t, 0, logger.Len())
+	assert.Empty(t, logger.GetEntries())
+	assert.Empty(t, logger.GetMessages())
+}
+
+func TestNoopLogger_Contains(t *testing.T) {
+	logger := NewNoopLogger()
+
+	logger.Info("this is a test message")
+	logger.Error("something went wrong")
+	logger.Warn("be careful about this")
+
+	// Test general contains
+	assert.True(t, logger.Contains("test message"))
+	assert.True(t, logger.Contains("went wrong"))
+	assert.True(t, logger.Contains("careful"))
+	assert.False(t, logger.Contains("not found"))
+
+	// Test partial matches
+	assert.True(t, logger.Contains("this is"))
+	assert.True(t, logger.Contains("wrong"))
+}
+
+func TestNoopLogger_ContainsLevel(t *testing.T) {
+	logger := NewNoopLogger()
+
+	logger.Info("info message here")
+	logger.Error("error message here")
+	logger.Warn("warning message here")
+
+	// Test level-specific contains
+	assert.True(t, logger.ContainsLevel("INFO", "info message"))
+	assert.True(t, logger.ContainsLevel("ERROR", "error message"))
+	assert.True(t, logger.ContainsLevel("WARN", "warning message"))
+
+	// Test cross-level (should return false)
+	assert.False(t, logger.ContainsLevel("INFO", "error message"))
+	assert.False(t, logger.ContainsLevel("ERROR", "info message"))
+	assert.False(t, logger.ContainsLevel("DEBUG", "info message"))
+
+	// Test non-existent text
+	assert.False(t, logger.ContainsLevel("INFO", "not found"))
+}
+
+func TestNoopLogger_ConcurrentSafety(t *testing.T) {
+	logger := NewNoopLogger()
+	const numGoroutines = 100
+	const messagesPerGoroutine = 10
+
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines)
+
+	// Start multiple goroutines writing to the logger
+	for i := 0; i < numGoroutines; i++ {
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < messagesPerGoroutine; j++ {
+				logger.Info("goroutine %d message %d", id, j)
+				logger.Error("goroutine %d error %d", id, j)
+			}
+		}(i)
+	}
+
+	// Start a goroutine reading from the logger
+	readDone := make(chan bool)
+	go func() {
+		for i := 0; i < 50; i++ {
+			_ = logger.GetEntries()
+			_ = logger.GetMessages()
+			_ = logger.Len()
+			_ = logger.Contains("goroutine")
+		}
+		readDone <- true
+	}()
+
+	wg.Wait()
+	<-readDone
+
+	// Verify all messages were captured
+	expectedCount := numGoroutines * messagesPerGoroutine * 2 // 2 message types per iteration
+	assert.Equal(t, expectedCount, logger.Len())
+
+	// Test clearing while reading
+	var clearWg sync.WaitGroup
+	clearWg.Add(2)
+
+	go func() {
+		defer clearWg.Done()
+		logger.Clear()
+	}()
+
+	go func() {
+		defer clearWg.Done()
+		_ = logger.GetEntries()
+	}()
+
+	clearWg.Wait()
+
+	// After clear, should have 0 entries
+	assert.Equal(t, 0, logger.Len())
+}
+
+func TestNoopLogger_MessageFormatting(t *testing.T) {
+	logger := NewNoopLogger()
+
+	// Test format strings with various argument types
+	logger.Info("number: %d, string: %s, float: %.2f", 42, "test", 3.14159)
+	logger.Error("user %s has %d items", "alice", 5)
+
+	messages := logger.GetMessages()
+	assert.Contains(t, messages[0], "number: 42, string: test, float: 3.14")
+	assert.Contains(t, messages[1], "user alice has 5 items")
+}
+
+// Example test demonstrating typical usage in unit tests
+func TestNoopLogger_UsageExample(t *testing.T) {
+	// Create logger for test
+	logger := NewNoopLogger()
+
+	// Simulate some function that uses logging
+	simulateFunction := func() {
+		logger.Info("Starting operation")
+		logger.Debug("Processing item %d", 1)
+		logger.Warn("Low memory warning")
+		logger.Info("Operation completed successfully")
+	}
+
+	// Execute the function
+	simulateFunction()
+
+	// Assert expected log messages
+	assert.Equal(t, 4, logger.Len())
+	assert.True(t, logger.ContainsLevel("INFO", "Starting operation"))
+	assert.True(t, logger.ContainsLevel("DEBUG", "Processing item 1"))
+	assert.True(t, logger.ContainsLevel("WARN", "Low memory warning"))
+	assert.True(t, logger.ContainsLevel("INFO", "Operation completed"))
+
+	// Verify message order
+	messages := logger.GetMessages()
+	assert.Equal(t, "Starting operation", messages[0])
+	assert.Equal(t, "Processing item 1", messages[1])
+	assert.Equal(t, "Low memory warning", messages[2])
+	assert.Equal(t, "Operation completed successfully", messages[3])
+
+	// Test specific level filtering
+	infoMessages := logger.GetMessagesByLevel("INFO")
+	assert.Len(t, infoMessages, 2)
+	assert.Contains(t, infoMessages, "Starting operation")
+	assert.Contains(t, infoMessages, "Operation completed successfully")
+}

--- a/pkg/common/telemetry_prompt_test.go
+++ b/pkg/common/telemetry_prompt_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestTelemetryPromptWithOptions(t *testing.T) {
-	logger := logger.NewZapLogger(false)
+	logger := logger.NewNoopLogger()
 
 	t.Run("EnableTelemetry enables telemetry", func(t *testing.T) {
 		opts := TelemetryPromptOptions{
@@ -111,7 +111,7 @@ func TestIsStdinAvailable(t *testing.T) {
 }
 
 func TestHandleFirstRunTelemetryPromptWithOptions(t *testing.T) {
-	logger := logger.NewZapLogger(false)
+	logger := logger.NewNoopLogger()
 
 	t.Run("Non-first run returns existing preference", func(t *testing.T) {
 		// This test would need to set up a mock environment

--- a/pkg/common/user_config_test.go
+++ b/pkg/common/user_config_test.go
@@ -67,13 +67,33 @@ func TestSaveUserIdAndLoadGlobalConfig(t *testing.T) {
 }
 
 func TestGetUserUUIDFromGlobalConfig_Empty(t *testing.T) {
-	// Unset XDG_CONFIG_HOME
-	os.Unsetenv("XDG_CONFIG_HOME")
+	// Save original environment
+	originalXDG := os.Getenv("XDG_CONFIG_HOME")
+	originalHOME := os.Getenv("HOME")
 
-	// Ensure no config and HOME unset
+	// Clean up after test
+	defer func() {
+		if originalXDG != "" {
+			os.Setenv("XDG_CONFIG_HOME", originalXDG)
+		} else {
+			os.Unsetenv("XDG_CONFIG_HOME")
+		}
+		if originalHOME != "" {
+			os.Setenv("HOME", originalHOME)
+		} else {
+			os.Unsetenv("HOME")
+		}
+	}()
+
+	// Unset XDG_CONFIG_HOME and set HOME to a temp directory with no config
+	os.Unsetenv("XDG_CONFIG_HOME")
+	tempHome := t.TempDir()
+	os.Setenv("HOME", tempHome)
+
+	// Now getUserUUIDFromGlobalConfig should return empty string since no config exists
 	uuid := getUserUUIDFromGlobalConfig()
 	if uuid != "" {
-		t.Errorf("expected empty UUID when XDG_CONFIG_HOME unset, got %q", uuid)
+		t.Errorf("expected empty UUID when no config exists, got %q", uuid)
 	}
 }
 

--- a/pkg/template/git_fetcher_test.go
+++ b/pkg/template/git_fetcher_test.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/Layr-Labs/devkit-cli/pkg/common"
 	"github.com/Layr-Labs/devkit-cli/pkg/common/iface"
 	"github.com/Layr-Labs/devkit-cli/pkg/common/logger"
 	"github.com/Layr-Labs/devkit-cli/pkg/common/progress"
@@ -85,7 +84,7 @@ func (s *spyTrackerDedup) ProgressRows() []iface.ProgressRow { return make([]ifa
 // getFetcherWithRunner returns a GitFetcher and its underlying LogProgressTracker.
 func getFetcherWithRunner(r template.Runner) (*template.GitFetcher, *spyTrackerDedup) {
 	client := template.NewGitClientWithRunner(r)
-	log, _ := common.GetLogger(false)
+	log := logger.NewNoopLogger()
 
 	// Inject our spyTracker instead of the real one:
 	spy := newSpyTrackerDedup()
@@ -154,7 +153,7 @@ func TestCloneRealRepo(t *testing.T) {
 
 	// Use real runner
 	client := template.NewGitClient()
-	log, _ := common.GetLogger(false)
+	log := logger.NewNoopLogger()
 	tracker := progress.NewLogProgressTracker(100, log)
 	prog := logger.NewProgressLogger(log, tracker)
 

--- a/pkg/template/git_reporter_test.go
+++ b/pkg/template/git_reporter_test.go
@@ -4,7 +4,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/Layr-Labs/devkit-cli/pkg/common"
 	"github.com/Layr-Labs/devkit-cli/pkg/common/iface"
 	"github.com/Layr-Labs/devkit-cli/pkg/common/logger"
 	"github.com/Layr-Labs/devkit-cli/pkg/template"
@@ -45,7 +44,7 @@ func (f *mockTracker) Clear() {
 func (s *mockTracker) ProgressRows() []iface.ProgressRow { return make([]iface.ProgressRow, 0) }
 
 func TestCloneReporterEndToEnd(t *testing.T) {
-	log, _ := common.GetLogger(false)
+	log := logger.NewNoopLogger()
 	mock := newMockTracker()
 	progLogger := *logger.NewProgressLogger(log, mock)
 
@@ -87,7 +86,7 @@ func TestCloneReporterEndToEnd(t *testing.T) {
 }
 
 func TestCloneReporterSubmoduleDiscoveryGrouping(t *testing.T) {
-	log, _ := common.GetLogger(false)
+	log := logger.NewNoopLogger()
 	mock := newMockTracker()
 	progLogger := *logger.NewProgressLogger(log, mock)
 
@@ -106,7 +105,7 @@ func TestCloneReporterSubmoduleDiscoveryGrouping(t *testing.T) {
 }
 
 func TestCloneReporterFallbackRootProgress(t *testing.T) {
-	log, _ := common.GetLogger(false)
+	log := logger.NewNoopLogger()
 	mock := newMockTracker()
 	progLogger := *logger.NewProgressLogger(log, mock)
 


### PR DESCRIPTION
## Closes #146 

**Motivation:**

Currently, tests are too verbose to debug during development. Its difficult to get the failing test in the terminal

**Modifications:**

Use noop logger that use buffer for assertion wherever required , instead of using stdOut.

**Result:**

<img width="650" alt="Screenshot 2025-06-11 at 4 39 39 PM" src="https://github.com/user-attachments/assets/3991d78f-a42b-4518-9a82-358eac1613d8" />
Cleaner test suite

**Testing:**

- noop_logger_test in logger/ dir for noop logger implementation.
- Modified tests to use noop logger and use buffer assertions, remove stdout usage to assert logging

**Open questions:**
<!--
(optional) Any open questions or feedback on design desired?
-->