### PR TITLE
feat: extend release with e2e test for each target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -227,7 +227,7 @@ jobs:
           version: stable
 
       - name: Run devkit avs create
-        run: devkit avs create my-awesome-avs
+        run: devkit avs create --disable-telemetry my-awesome-avs
 
       - name: Source shell profile
         # force a login shell so it actually reads ~/.bashrc / ~/.bash_profile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -250,9 +250,11 @@ jobs:
           ORBSTACK_CLI_SKIP_ANALYTICS: "1"
           ORBSTACK_CLI_SKIP_UPDATES_CHECK: "1"
         run: |
-          orbstack start docker
-          # point Docker CLI at Orbstacks daemon socket
+          # start OrbStacks VM & Docker engine without blocking
+          orbstack start --wait=false
+          # wire Docker CLI to OrbStacks engine
           eval "$(orbstack docker env --shell=posix)"
+          # wait for Docker daemon
           for i in {1..30}; do
             docker info >/dev/null && break
             echo "Waiting for Orbstack Docker... ($i/30)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -199,32 +199,15 @@ jobs:
 
       - name: Install Homebrew on macOS x64
         if: matrix.os == 'macos-latest' && matrix.arch == 'x64'
+        uses: Homebrew/actions/setup-homebrew@master
+        with:
+          arch: ${{ matrix.arch }}
+          
+      - name: Force Intel-brew on macOS x64
+        if: matrix.os == 'macos-latest' && matrix.arch == 'x64'
         run: |
-          # enable Rosetta (needed only on Apple Silicon hosts)
-          sudo softwareupdate --install-rosetta --agree-to-license || true
-
-          # disable Homebrew hints and cleanup
-          export CI=1
-          export HOMEBREW_NO_ENV_HINTS=1
-          export HOMEBREW_NO_INSTALL_CLEANUP=1
-
-          # run installer but drop the "Next steps" section
-          curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh \
-            | sed -e '/^==> Next steps:/,$d' \
-            | arch -x86_64 /bin/bash
-
-          # capture the brew-env exports into GITHUB_ENV
-          arch -x86_64 /usr/local/bin/brew shellenv \
-            | sed 's/^export //g' >> $GITHUB_ENV
-
-          # make sure 'brew' always runs under x86_64
           echo "alias brew='arch -x86_64 brew'" >> $BASH_ENV
-
-          # verify brew is on PATH and running under x86_64
-          which brew
-          file "$(which brew)"
-          brew --version
-
+          
       - name: Set up Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -188,3 +188,65 @@ jobs:
             exit 1
           fi
           echo "✔ version $installed matches expected $ver"
+
+      - name: Add ~/bin to PATH
+        run: echo "$HOME/bin" >> $GITHUB_PATH
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: stable
+
+      - name: Run devkit avs create
+        run: devkit avs create my-awesome-avs
+
+      - name: Verify AVS project created
+        run: |
+          if [ ! -f "./my-awesome-avs/config/config.yaml" ]; then
+            echo "❌ AVS project config/config.yaml not found!"
+            exit 1
+          fi
+          echo "✅ AVS project created successfully at ${GITHUB_WORKSPACE}/my-awesome-avs/"
+
+      - name: Run devkit avs build
+        run: |
+          cd ./my-awesome-avs/
+          devkit avs build
+
+      - name: Start devnet
+        run: |
+          cd ./my-awesome-avs/
+          devkit avs devnet start &
+          # wait until executor and aggregator are available
+          until nc -z localhost 9090 && nc -z localhost 8081; do
+            sleep 1
+          done
+
+      - name: Check devnet RPC is live
+        run: |
+          for i in {1..10}; do
+            bn=$(cast block-number --rpc-url http://localhost:8545 || echo "error")
+            if [ "$bn" != "error" ]; then
+              echo "Current block number: $bn"
+              exit 0
+            fi
+            echo "Waiting for devnet... retrying in 2s"
+            sleep 2
+          done
+          echo "❌ Devnet failed to start"
+          exit 1
+
+      - name: Call AVS
+        run: |
+          cd ./my-awesome-avs/
+          devkit avs call -- signature="(uint256,string)" args='(5,"hello")'
+
+      - name: Stop devnet
+        run: |
+          cd ./my-awesome-avs/
+          devkit avs devnet stop

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -284,7 +284,20 @@ jobs:
           
       - name: Install Docker Buildx (macOS)
         if: matrix.os == 'macos-latest'
-        run: brew install docker-buildx
+        run:  |
+          brew install docker-buildx
+
+          # ensure the CLI-plugins dir exists
+          mkdir -p ~/.docker/cli-plugins
+
+          # symlink the Homebrew buildx into Dockers plugin folder
+          ln -sf "$(brew --prefix)/bin/docker-buildx" ~/.docker/cli-plugins/docker-buildx
+
+          # install it as the default builder
+          docker buildx install
+
+          # verify
+          docker buildx version
 
       - name: Run devkit avs build
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -288,8 +288,8 @@ jobs:
             --disk 50 \
             --activate
 
-          # export the environment variables into GITHUB_ENV
-          colima docker-env | sed 's/^export //g' >> $GITHUB_ENV
+          # instruct docker to use colima socket
+          docker context use colima
           
       - name: Verify Docker daemon
         if: matrix.os == 'macos-latest'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,7 +206,18 @@ jobs:
       - name: Force Intel-brew on macOS x64
         if: matrix.os == 'macos-latest' && matrix.arch == 'x64'
         run: |
-          echo "alias brew='arch -x86_64 brew'" >> $BASH_ENV
+          mkdir -p $HOME/bin
+          printf '%s\n' '#!/usr/bin/env bash' \
+            'exec arch -x86_64 /usr/local/bin/brew "$@"' \
+            > "$HOME/bin/brew"
+          chmod +x "$HOME/bin/brew"
+
+          # make sure our shim comes first
+          echo "$HOME/bin" >> $GITHUB_PATH
+
+          # sanity check
+          which brew
+          brew --version
           
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -254,27 +254,29 @@ jobs:
           fi
           echo "✅ AVS project created successfully at ${GITHUB_WORKSPACE}/my-awesome-avs/"
 
-      - name: Install Colima, Lima & Docker CLI on macOS
+      - name: Install Colima, Lima guestagents & Docker CLI on macOS
         if: matrix.os == 'macos-latest'
         run: |
-          # Install the runtime and CLI
           brew install lima colima docker
-
-          # Lima's "additional guest agents" package provides the missing binaries
+          # this provides the missing guest-agent bits for various arches
           brew install lima-additional-guestagents
 
-      - name: Start Colima with guest agent
+      - name: Start Colima under QEMU
         if: matrix.os == 'macos-latest'
         run: |
-          # spin up the VM under vz (the default on macOS)
-          colima start --cpu 2 --memory 4
-
+          colima start \
+            --driver qemu \
+            --cpu 2 \
+            --memory 4 \
+            --disk 50
+          
       - name: Verify Docker daemon
         if: matrix.os == 'macos-latest'
         run: |
           for i in {1..30}; do
-            command -v docker >/dev/null && docker info >/dev/null 2>&1 && break
-            echo "Waiting for Colima's Docker… ($i/30)"
+            command -v docker >/dev/null \
+              && docker info >/dev/null 2>&1 && break
+            echo "Waiting for Colima/QEMU Docker... ($i/30)"
             sleep 2
           done
           docker info

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -199,13 +199,19 @@ jobs:
 
       - name: Install Homebrew on macOS x64
         if: matrix.os == 'macos-latest' && matrix.arch == 'x64'
-        uses: Homebrew/actions/setup-homebrew@master
-        with:
-          arch: ${{ matrix.arch }}
-          
-      - name: Force Intel-brew on macOS x64
-        if: matrix.os == 'macos-latest' && matrix.arch == 'x64'
         run: |
+          # enable Rosetta (needed only on Apple Silicon hosts)
+          sudo softwareupdate --install-rosetta --agree-to-license || true
+
+          # install Intel Homebrew into /usr/local
+          arch -x86_64 /bin/bash -c \
+            "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+          # capture the brew-env exports into GITHUB_ENV
+          arch -x86_64 /usr/local/bin/brew shellenv \
+            | sed 's/^export //g' >> $GITHUB_ENV
+
+          # alias brew via a shim
           mkdir -p $HOME/bin
           printf '%s\n' '#!/usr/bin/env bash' \
             'exec arch -x86_64 /usr/local/bin/brew "$@"' \
@@ -215,8 +221,9 @@ jobs:
           # make sure our shim comes first
           echo "$HOME/bin" >> $GITHUB_PATH
 
-          # sanity check
+          # verify brew is on PATH and running under x86_64
           which brew
+          file "$(which brew)"
           brew --version
           
       - name: Set up Go

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -239,21 +239,13 @@ jobs:
       - name: Install Orbstack & Docker CLI (macOS)
         if: matrix.os == 'macos-latest'
         run: |
-          brew install --cask orbstack
-          brew install docker
-          # make the orbstack binary visible
-          echo "/Applications/Orbstack.app/Contents/MacOS" >> $GITHUB_PATH
+          brew install docker orbstack
 
       - name: Start OrbStacks Docker engine
         if: matrix.os == 'macos-latest'
-        env:
-          ORBSTACK_CLI_SKIP_ANALYTICS: "1"
-          ORBSTACK_CLI_SKIP_UPDATES_CHECK: "1"
         run: |
-          # start OrbStacks VM & Docker engine without blocking
-          nohup orbstack start docker --wait=false >/dev/null 2>&1 &
-          # source init script
-          source ~/.orbstack/shell/init.bash 2>/dev/null || true
+          orb config set setup.use_admin false
+          orb start
           # wire Docker CLI to OrbStacks engine
           docker context use orbstack
           # wait for Docker daemon

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -285,7 +285,11 @@ jobs:
             --arch x86_64 \
             --cpu 2 \
             --memory 4 \
-            --disk 50
+            --disk 50 \
+            --activate
+
+          # export the environment variables into GITHUB_ENV
+          colima docker-env | sed 's/^/export /' >> $GITHUB_ENV
           
       - name: Verify Docker daemon
         if: matrix.os == 'macos-latest'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -207,18 +207,15 @@ jobs:
           arch -x86_64 /bin/bash -c \
             "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
-          # load /usr/local/bin/brew into PATH
-          eval "$(/usr/local/bin/brew shellenv)"
-
-          # persist the shellenv to login profile
-          echo 'eval "$(/usr/local/bin/brew shellenv)"' >> $GITHUB_ENV
-
-          # alias all future brew invocations to x86_64
-          echo "alias brew='arch -x86_64 brew'" >> $GITHUB_ENV
-
-          # verify
-          brew --version
+          # capture the brew-env exports, strip the leading 'export '
+          arch -x86_64 /usr/local/bin/brew shellenv \
+            | sed 's/^export //g' >> $GITHUB_ENV
           
+          # verify brew is on PATH and running under x86_64
+          which brew
+          file "$(which brew)"
+          brew --version
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -305,6 +305,23 @@ jobs:
           fi
           echo "✅ AVS project created successfully at ${GITHUB_WORKSPACE}/my-awesome-avs/"
 
+      - name: Install Docker Buildx (macOS)
+        if: matrix.os == 'macos-latest'
+        run:  |
+          brew install docker-buildx
+
+          # ensure the CLI-plugins dir exists
+          mkdir -p ~/.docker/cli-plugins
+
+          # symlink the Homebrew buildx into Dockers plugin folder
+          ln -sf "$(brew --prefix)/bin/docker-buildx" ~/.docker/cli-plugins/docker-buildx
+
+          # install it as the default builder
+          docker buildx install
+
+          # verify
+          docker buildx version
+
       - name: Run devkit avs build
         env:
           DOCKER_BUILDKIT: 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -252,6 +252,8 @@ jobs:
         run: |
           # start OrbStacks VM & Docker engine without blocking
           nohup orbstack start docker --wait=false >/dev/null 2>&1 &
+          # source init script
+          source ~/.orbstack/shell/init.bash 2>/dev/null || true
           # wire Docker CLI to OrbStacks engine
           docker context use orbstack
           # wait for Docker daemon

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -277,6 +277,9 @@ jobs:
           # switch your CLI to that context
           docker context use colima
 
+          # put env into GITHUB_ENV
+          colima docker-env --shell bash >> $GITHUB_ENV
+
       - name: Verify Docker daemon
         if: matrix.os == 'macos-latest'
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -239,14 +239,25 @@ jobs:
       - name: Install Colima, Lima guestagents & Docker CLI on macOS
         if: matrix.os == 'macos-latest'
         run: |
-          brew install lima colima docker
+          # use the ARM-native Homebrew for host tools
+          BREW_ARM=/opt/homebrew/bin/brew
 
-          # this provides the missing guest-agent bits for various arches
-          brew install lima-additional-guestagents
+          echo "Using ARM Homebrew at $BREW_ARM"
 
-          # ensure Homebrews bin is on PATH for all later steps
-          echo "/usr/local/bin" >> $GITHUB_PATH
-          
+          # install Lima, Colima and Docker CLI natively
+          $BREW_ARM install lima colima docker
+          $BREW_ARM install lima-additional-guestagents
+
+          # ensure ARM brews bin is on PATH for all later steps
+          echo "/opt/homebrew/bin" >> $GITHUB_PATH
+
+          # sanity-check
+          which colima
+          file "$(which colima)"
+          colima version
+          which docker
+          docker --version
+                
       - name: Run devkit avs create
         run: devkit avs create --disable-telemetry my-awesome-avs
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -242,7 +242,7 @@ jobs:
           brew install --cask orbstack
           brew install docker
           # make the orbstack binary visible
-          echo "/opt/homebrew/bin/" >> $GITHUB_PATH
+          echo "/Applications/Orbstack.app/Contents/MacOS" >> $GITHUB_PATH
 
       - name: Start OrbStacks Docker engine
         if: matrix.os == 'macos-latest'
@@ -251,7 +251,7 @@ jobs:
           ORBSTACK_CLI_SKIP_UPDATES_CHECK: "1"
         run: |
           # start OrbStacks VM & Docker engine without blocking
-          orb start docker &
+          nohup orbstack start docker --wait=false >/dev/null 2>&1 &
           # wire Docker CLI to OrbStacks engine
           docker context use orbstack
           # wait for Docker daemon

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -335,9 +335,25 @@ jobs:
       - name: Start devnet (macOS)
         if: matrix.os == 'macos-latest'
         run: |
+          set -euxo pipefail
           docker context use colima
           cd ./my-awesome-avs/
-          devkit avs devnet start &
+
+          # show resolved compose file
+          docker compose config
+
+          # redirect stdout/stderr to a file for later inspection
+          devkit avs devnet start >devnet.log 2>&1 &
+          pid=$!
+
+          # give it a second to crash if its going to
+          sleep 3
+          if ! kill -0 $pid 2>/dev/null; then
+            cat devnet.log
+            docker compose logs --no-color
+            exit 1
+          fi
+
           until nc -z localhost 9090 && nc -z localhost 8081; do sleep 1; done
 
       - name: Start devnet (Linux)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -334,9 +334,8 @@ jobs:
 
       - name: Start devnet (macOS)
         if: matrix.os == 'macos-latest'
-        env:
-          DOCKER_HOST: unix://${HOME}/.colima/default/docker.sock
         run: |
+          export DOCKER_HOST=unix://$HOME/.colima/default/docker.sock
           docker context use colima
           cd ./my-awesome-avs/
           devkit avs devnet start &

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -211,6 +211,9 @@ jobs:
           arch -x86_64 /usr/local/bin/brew shellenv \
             | sed 's/^export //g' >> $GITHUB_ENV
           
+          # make sure 'brew' always runs under x86_64
+          echo "alias brew='arch -x86_64 brew'" >> $BASH_ENV
+
           # verify brew is on PATH and running under x86_64
           which brew
           file "$(which brew)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -251,7 +251,7 @@ jobs:
           ORBSTACK_CLI_SKIP_UPDATES_CHECK: "1"
         run: |
           # start OrbStacks VM & Docker engine without blocking
-          orbstack start --wait=false
+          orbstack start docker --wait=false
           # wire Docker CLI to OrbStacks engine
           eval "$(orbstack docker env --shell=posix)"
           # wait for Docker daemon

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -265,7 +265,8 @@ jobs:
         if: matrix.os == 'macos-latest'
         run: |
           colima start \
-            --driver qemu \
+            --vm-type qemu \
+            --arch x86_64 \
             --cpu 2 \
             --memory 4 \
             --disk 50

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -282,7 +282,13 @@ jobs:
           done
           docker info
           
+      - name: Install Docker Buildx (macOS)
+        if: matrix.os == 'macos-latest'
+        run: brew install docker-buildx
+
       - name: Run devkit avs build
+        env:
+          DOCKER_BUILDKIT: 1
         run: |
           cd ./my-awesome-avs/
           devkit avs build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -207,10 +207,11 @@ jobs:
           export CI=1
           export HOMEBREW_NO_ENV_HINTS=1
           export HOMEBREW_NO_INSTALL_CLEANUP=1
-          
-          # install Intel Homebrew into /usr/local
-          arch -x86_64 /bin/bash -c \
-            "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+          # run installer but drop the "Next steps" section
+          curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh \
+            | sed '/^==> Next steps:/Q' \
+            | arch -x86_64 /bin/bash
 
           # capture the brew-env exports into GITHUB_ENV
           arch -x86_64 /usr/local/bin/brew shellenv \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,14 +203,19 @@ jobs:
           # enable Rosetta (needed only on Apple Silicon hosts)
           sudo softwareupdate --install-rosetta --agree-to-license || true
 
+          # disable Homebrew hints and cleanup
+          export CI=1
+          export HOMEBREW_NO_ENV_HINTS=1
+          export HOMEBREW_NO_INSTALL_CLEANUP=1
+          
           # install Intel Homebrew into /usr/local
           arch -x86_64 /bin/bash -c \
             "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
-          # capture the brew-env exports, strip the leading 'export '
+          # capture the brew-env exports into GITHUB_ENV
           arch -x86_64 /usr/local/bin/brew shellenv \
             | sed 's/^export //g' >> $GITHUB_ENV
-          
+
           # make sure 'brew' always runs under x86_64
           echo "alias brew='arch -x86_64 brew'" >> $BASH_ENV
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -271,14 +271,12 @@ jobs:
             --disk 50 \
             --activate
 
-          # ensure the 'colima' Docker context is registered (idempotent)
-          colima docker context create colima || true
-
           # switch your CLI to that context
           docker context use colima
 
-          # put env into GITHUB_ENV
-          colima docker-env --shell bash >> $GITHUB_ENV
+      - name: Link Docker socket for Docker CLI
+        if: matrix.os == 'macos-latest'
+        run: sudo ln -sf $HOME/.colima/default/docker.sock /var/run/docker.sock
 
       - name: Verify Docker daemon
         if: matrix.os == 'macos-latest'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -261,14 +261,27 @@ jobs:
 
       - name: Install Docker Compose plugin (macOS)
         if: matrix.os == 'macos-latest'
+        env:
+          GHA_ARCH: ${{ matrix.arch }}
         run: |
-          # install the official Compose V2 plugin
-          brew tap docker/compose
-          brew install docker-compose-plugin
-
-          # ensure its picked up by the Docker CLI
+          # create plugin dir
           mkdir -p ~/.docker/cli-plugins
-          ln -sf "$(brew --prefix)/bin/docker-compose" ~/.docker/cli-plugins/docker-compose
+
+          # select binary according to arch
+          case "$GHA_ARCH" in
+            arm64) FILE=docker-compose-darwin-aarch64 ;;
+            x64)   FILE=docker-compose-darwin-x86_64 ;;
+            *)
+              echo "Unsupported arch: $GHA_ARCH"
+              exit 1
+              ;;
+          esac
+
+          # download the Compose V2 binary
+          curl -SL \
+            "https://github.com/docker/compose/releases/download/v2.36.2/${FILE}" \
+            -o ~/.docker/cli-plugins/docker-compose
+          chmod +x ~/.docker/cli-plugins/docker-compose
 
           # verify
           docker compose version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -239,21 +239,19 @@ jobs:
       - name: Install Colima & Docker CLI (macOS)
         if: matrix.os == 'macos-latest'
         run: |
-          brew install docker colima lima
-          brew install lima-additional-guestagents
+          brew install docker colima
 
       - name: Start Colima Docker engine
         if: matrix.os == 'macos-latest'
         run: |
           # start Colima headlessly under QEMU
-          limactl start --name colima --cpus 2 --memory 4 --disk 50 --agent 0.0.0
-          colima start --vm-type lima --cpu 2 --memory 4 --disk 50 --mount-type virtiofs
+          colima start --cpu 2 --memory 4 --disk 50
           # wire Docker CLI to Colima engine
           docker context use colima
           # wait for Docker daemon
           for i in {1..30}; do
             docker info >/dev/null && break
-            echo "Waiting for Orbstack Docker... ($i/30)"
+            echo "Waiting for Colima Docker... ($i/30)"
             sleep 2
           done
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -366,9 +366,6 @@ jobs:
           docker context use colima
           cd ./my-awesome-avs/
 
-          # show resolved compose file
-          docker compose config
-
           # redirect stdout/stderr to a file for later inspection
           devkit avs devnet start >devnet.log 2>&1 &
           pid=$!

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -210,7 +210,7 @@ jobs:
 
           # run installer but drop the "Next steps" section
           curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh \
-            | sed '/^==> Next steps:/Q' \
+            | sed -e '/^==> Next steps:/,$d' \
             | arch -x86_64 /bin/bash
 
           # capture the brew-env exports into GITHUB_ENV

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -254,22 +254,31 @@ jobs:
           fi
           echo "✅ AVS project created successfully at ${GITHUB_WORKSPACE}/my-awesome-avs/"
 
-      - name: Install & Start Docker Desktop on macOS
+      - name: Install Colima, Lima & Docker CLI on macOS
         if: matrix.os == 'macos-latest'
         run: |
-          # launch Docker.app without stealing focus
-          open -g /Applications/Docker.app
+          # Install the runtime and CLI
+          brew install lima colima docker
 
-          # wait up to 60s for the daemon to be responsive
+          # Lima's "additional guest agents" package provides the missing binaries
+          brew install lima-additional-guestagents
+
+      - name: Start Colima with guest agent
+        if: matrix.os == 'macos-latest'
+        run: |
+          # spin up the VM under vz (the default on macOS)
+          colima start --cpu 2 --memory 4
+
+      - name: Verify Docker daemon
+        if: matrix.os == 'macos-latest'
+        run: |
           for i in {1..30}; do
-            docker info >/dev/null 2>&1 && break
-            echo "Waiting for Docker daemon… ($i/30)"
+            command -v docker >/dev/null && docker info >/dev/null 2>&1 && break
+            echo "Waiting for Colima's Docker… ($i/30)"
             sleep 2
           done
-
-          # fail if it never started
-          docker info || (echo "Docker daemon failed to start" && exit 1)
-
+          docker info
+          
       - name: Run devkit avs build
         run: |
           cd ./my-awesome-avs/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -286,6 +286,23 @@ jobs:
           # verify
           docker compose version
 
+      - name: Install Docker Buildx (macOS)
+        if: matrix.os == 'macos-latest'
+        run:  |
+          brew install docker-buildx
+
+          # ensure the CLI-plugins dir exists
+          mkdir -p ~/.docker/cli-plugins
+
+          # symlink the Homebrew buildx into Dockers plugin folder
+          ln -sf "$(brew --prefix)/bin/docker-buildx" ~/.docker/cli-plugins/docker-buildx
+
+          # install it as the default builder
+          docker buildx install
+
+          # verify
+          docker buildx version
+
       - name: Start Colima under QEMU (macOS)
         if: matrix.os == 'macos-latest'
         run: |
@@ -320,13 +337,6 @@ jobs:
       - name: Run devkit avs create
         run: devkit avs create --disable-telemetry my-awesome-avs
 
-      - name: Source shell profile
-        # force a login shell so it actually reads ~/.bashrc / ~/.bash_profile
-        shell: bash -l {0}
-        run: |
-          source ~/.bashrc       2>/dev/null || true
-          source ~/.bash_profile 2>/dev/null || true
-
       - name: Verify AVS project created
         run: |
           if [ ! -f "./my-awesome-avs/config/config.yaml" ]; then
@@ -335,23 +345,6 @@ jobs:
           fi
           echo "✅ AVS project created successfully at ${GITHUB_WORKSPACE}/my-awesome-avs/"
 
-      - name: Install Docker Buildx (macOS)
-        if: matrix.os == 'macos-latest'
-        run:  |
-          brew install docker-buildx
-
-          # ensure the CLI-plugins dir exists
-          mkdir -p ~/.docker/cli-plugins
-
-          # symlink the Homebrew buildx into Dockers plugin folder
-          ln -sf "$(brew --prefix)/bin/docker-buildx" ~/.docker/cli-plugins/docker-buildx
-
-          # install it as the default builder
-          docker buildx install
-
-          # verify
-          docker buildx version
-
       - name: Run devkit avs build
         env:
           DOCKER_BUILDKIT: 1
@@ -359,29 +352,7 @@ jobs:
           cd ./my-awesome-avs/
           devkit avs build
 
-      - name: Start devnet (macOS)
-        if: matrix.os == 'macos-latest'
-        run: |
-          set -euxo pipefail
-          docker context use colima
-          cd ./my-awesome-avs/
-
-          # redirect stdout/stderr to a file for later inspection
-          devkit avs devnet start >devnet.log 2>&1 &
-          pid=$!
-
-          # give it a second to crash if its going to
-          sleep 3
-          if ! kill -0 $pid 2>/dev/null; then
-            cat devnet.log
-            docker compose logs --no-color
-            exit 1
-          fi
-
-          until nc -z localhost 9090 && nc -z localhost 8081; do sleep 1; done
-
-      - name: Start devnet (Linux)
-        if: matrix.os != 'macos-latest'
+      - name: Start devnet
         run: |
           cd ./my-awesome-avs/
           devkit avs devnet start &

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,41 +197,27 @@ jobs:
       - name: Add ~/bin to PATH
         run: echo "$HOME/bin" >> $GITHUB_PATH
 
-      - name: Install Homebrew on macOS ARM64
-        if: matrix.os == 'macos-latest' && matrix.arch == 'arm64'
-        run: |
-          # enable Rosetta  
-          sudo softwareupdate --install-rosetta --agree-to-license || true
-
-          # install ARM Homebrew into /opt/homebrew  
-          arch -arm64 /bin/bash -c \
-            "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-
-          # load /opt/homebrew/bin/brew into your PATH
-          echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> ~/.zprofile
-          eval "$(/opt/homebrew/bin/brew shellenv)"
-
-          # force all brew calls under arm64  
-          echo "alias brew='arch -arm64 brew'" >> ~/.bashrc
-          source ~/.bashrc
-
-      - name: Install Homebrew on macOS AMD64
+      - name: Install Homebrew on macOS x64
         if: matrix.os == 'macos-latest' && matrix.arch == 'x64'
         run: |
-          # enable Rosetta (so you can run x86_64 processes on Apple Silicon hosts)
+          # enable Rosetta (needed only on Apple Silicon hosts)
           sudo softwareupdate --install-rosetta --agree-to-license || true
 
           # install Intel Homebrew into /usr/local
           arch -x86_64 /bin/bash -c \
             "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
-          # load /usr/local/bin/brew into your PATH
-          echo 'eval "$(/usr/local/bin/brew shellenv)"' >> ~/.bash_profile
+          # load /usr/local/bin/brew into PATH
           eval "$(/usr/local/bin/brew shellenv)"
 
-          # force all future brew invocations under x86_64
-          echo "alias brew='arch -x86_64 brew'" >> ~/.bashrc
-          source ~/.bashrc
+          # persist the shellenv to login profile
+          echo 'eval "$(/usr/local/bin/brew shellenv)"' >> $GITHUB_ENV
+
+          # alias all future brew invocations to x86_64
+          echo "alias brew='arch -x86_64 brew'" >> $GITHUB_ENV
+
+          # verify
+          brew --version
           
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -242,7 +242,7 @@ jobs:
           brew install --cask orbstack
           brew install docker
           # make the orbstack binary visible
-          echo "/Applications/Orbstack.app/Contents/MacOS" >> $GITHUB_PATH
+          echo "/opt/homebrew/bin/" >> $GITHUB_PATH
 
       - name: Start OrbStacks Docker engine
         if: matrix.os == 'macos-latest'
@@ -251,9 +251,9 @@ jobs:
           ORBSTACK_CLI_SKIP_UPDATES_CHECK: "1"
         run: |
           # start OrbStacks VM & Docker engine without blocking
-          orbstack start docker --wait=false
+          orb start docker &
           # wire Docker CLI to OrbStacks engine
-          eval "$(orbstack docker env --shell=posix)"
+          docker context use orbstack
           # wait for Docker daemon
           for i in {1..30}; do
             docker info >/dev/null && break

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -225,7 +225,7 @@ jobs:
           which brew
           file "$(which brew)"
           brew --version
-          
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
@@ -344,6 +344,12 @@ jobs:
             exit 1
           fi
           echo "✅ AVS project created successfully at ${GITHUB_WORKSPACE}/my-awesome-avs/"
+
+      - name: Link gomplate (macOS)
+        if: matrix.os == 'macos-latest'
+        run: |
+          mkdir -p "${GOPATH:-$HOME/go}/bin"
+          ln -sf "$(brew --prefix)/bin/gomplate" "${GOPATH:-$HOME/go}/bin/gomplate"
 
       - name: Run devkit avs build
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -236,30 +236,32 @@ jobs:
         with:
           version: stable
 
-      - name: Install Orbstack (macOS)
+      - name: Install Orbstack & Docker CLI (macOS)
         if: matrix.os == 'macos-latest'
         run: |
           brew install --cask orbstack
-          # ensure CLI is on PATH
-          echo "/Applications/Orbstack.app/Contents/Resources/cli" >> $GITHUB_PATH
+          brew install docker
+          export PATH="/Applications/Orbstack.app/Contents/MacOS:$PATH"
 
-      - name: Start Orbstacks Docker service
+      - name: Start OrbStacks Docker engine
         if: matrix.os == 'macos-latest'
+        env:
+          ORBSTACK_CLI_SKIP_ANALYTICS: "1"
+          ORBSTACK_CLI_SKIP_UPDATES_CHECK: "1"
         run: |
           orbstack start docker
-          # wait until Docker daemon is ready
+          # point Docker CLI at Orbstacks daemon socket
+          eval "$(orbstack docker env --shell=posix)"
           for i in {1..30}; do
-            command -v docker >/dev/null \
-              && docker info >/dev/null 2>&1 && break
+            docker info >/dev/null && break
             echo "Waiting for Orbstack Docker... ($i/30)"
             sleep 2
           done
 
       - name: Verify Docker daemon
         if: matrix.os == 'macos-latest'
-        run: |
-          docker info
-                
+        run: docker info
+
       - name: Run devkit avs create
         run: devkit avs create --disable-telemetry my-awesome-avs
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -236,29 +236,56 @@ jobs:
         with:
           version: stable
 
-      - name: Install Colima & Docker CLI (macOS)
+      - name: Install Colima, Lima guestagents & Docker CLI on macOS
         if: matrix.os == 'macos-latest'
         run: |
-          brew install docker colima
-          brew install lima-additional-guestagents
+          # use the ARM-native Homebrew for host tools
+          BREW_ARM=/opt/homebrew/bin/brew
 
-      - name: Start Colima Docker engine
+          echo "Using ARM Homebrew at $BREW_ARM"
+
+          # install Lima, Colima and Docker CLI natively
+          $BREW_ARM install lima colima docker
+          $BREW_ARM install lima-additional-guestagents
+
+          # ensure ARM brews bin is on PATH for all later steps
+          echo "/opt/homebrew/bin" >> $GITHUB_PATH
+          echo "$HOME/bin" >> $GITHUB_PATH
+
+          # sanity-check
+          which colima
+          file "$(which colima)"
+          colima version
+          which docker
+          docker --version
+
+      - name: Start Colima under QEMU
         if: matrix.os == 'macos-latest'
         run: |
-          # start Colima headlessly under QEMU
-          colima start --vm-type qemu --cpu 2 --memory 4 --disk 50
-          # wire Docker CLI to Colima engine
+          # boot the VM + Docker
+          colima start \
+            --vm-type qemu \
+            --arch x86_64 \
+            --cpu 2 \
+            --memory 4 \
+            --disk 50 \
+            --activate
+
+          # ensure the 'colima' Docker context is registered (idempotent)
+          colima docker context create colima || true
+
+          # switch your CLI to that context
           docker context use colima
-          # wait for Docker daemon
-          for i in {1..30}; do
-            docker info >/dev/null && break
-            echo "Waiting for Colima Docker... ($i/30)"
-            sleep 2
-          done
 
       - name: Verify Docker daemon
         if: matrix.os == 'macos-latest'
-        run: docker info
+        run: |
+          for i in {1..30}; do
+            docker info &>/dev/null && break
+            echo "Waiting for Colima Docker context... ($i/30)"
+            sleep 2
+          done
+          docker info
 
       - name: Run devkit avs create
         run: devkit avs create --disable-telemetry my-awesome-avs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -240,9 +240,13 @@ jobs:
         if: matrix.os == 'macos-latest'
         run: |
           brew install lima colima docker
+
           # this provides the missing guest-agent bits for various arches
           brew install lima-additional-guestagents
 
+          # ensure Homebrews bin is on PATH for all later steps
+          echo "/usr/local/bin" >> $GITHUB_PATH
+          
       - name: Run devkit avs create
         run: devkit avs create --disable-telemetry my-awesome-avs
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -259,6 +259,20 @@ jobs:
           which docker
           docker --version
 
+      - name: Install Docker Compose plugin (macOS)
+        if: matrix.os == 'macos-latest'
+        run: |
+          # install the official Compose V2 plugin
+          brew tap docker/compose
+          brew install docker-compose-plugin
+
+          # ensure its picked up by the Docker CLI
+          mkdir -p ~/.docker/cli-plugins
+          ln -sf "$(brew --prefix)/bin/docker-compose" ~/.docker/cli-plugins/docker-compose
+
+          # verify
+          docker compose version
+
       - name: Start Colima under QEMU (macOS)
         if: matrix.os == 'macos-latest'
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,6 +206,24 @@ jobs:
           # force all brew calls under arm64  
           echo "alias brew='arch -arm64 brew'" >> ~/.bashrc
           source ~/.bashrc
+
+      - name: Install Homebrew on macOS AMD64
+        if: matrix.os == 'macos-latest' && matrix.arch == 'x64'
+        run: |
+          # enable Rosetta (so you can run x86_64 processes on Apple Silicon hosts)
+          sudo softwareupdate --install-rosetta --agree-to-license || true
+
+          # install Intel Homebrew into /usr/local
+          arch -x86_64 /bin/bash -c \
+            "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+          # load /usr/local/bin/brew into your PATH
+          echo 'eval "$(/usr/local/bin/brew shellenv)"' >> ~/.bash_profile
+          eval "$(/usr/local/bin/brew shellenv)"
+
+          # force all future brew invocations under x86_64
+          echo "alias brew='arch -x86_64 brew'" >> ~/.bashrc
+          source ~/.bashrc
           
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -236,18 +236,20 @@ jobs:
         with:
           version: stable
 
-      - name: Install Orbstack & Docker CLI (macOS)
+      - name: Install Colima & Docker CLI (macOS)
         if: matrix.os == 'macos-latest'
         run: |
-          brew install docker orbstack
+          brew install docker colima lima
+          brew install lima-additional-guestagents
 
-      - name: Start OrbStacks Docker engine
+      - name: Start Colima Docker engine
         if: matrix.os == 'macos-latest'
         run: |
-          orb config set setup.use_admin false
-          orb start
-          # wire Docker CLI to OrbStacks engine
-          docker context use orbstack
+          # start Colima headlessly under QEMU
+          limactl start --name colima --cpus 2 --memory 4 --disk 50 --agent 0.0.0
+          colima start --vm-type lima --cpu 2 --memory 4 --disk 50 --mount-type virtiofs
+          # wire Docker CLI to Colima engine
+          docker context use colima
           # wait for Docker daemon
           for i in {1..30}; do
             docker info >/dev/null && break

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,6 +192,21 @@ jobs:
       - name: Add ~/bin to PATH
         run: echo "$HOME/bin" >> $GITHUB_PATH
 
+      - name: Install Homebrew on macOS ARM64
+        if: matrix.os == 'macos-latest' && matrix.arch == 'arm64'
+        run: |
+          # enable Rosetta  
+          sudo softwareupdate --install-rosetta --agree-to-license || true
+          # install ARM Homebrew into /opt/homebrew  
+          arch -arm64 /bin/bash -c \
+            "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+          # load it into PATH  
+          echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> ~/.zprofile
+          eval "$(/opt/homebrew/bin/brew shellenv)"
+          # force all brew calls under arm64  
+          echo "alias brew='arch -arm64 brew'" >> ~/.bashrc
+          source ~/.bashrc
+          
       - name: Set up Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,7 +197,7 @@ jobs:
       - name: Add ~/bin to PATH
         run: echo "$HOME/bin" >> $GITHUB_PATH
 
-      - name: Install Homebrew on macOS x64
+      - name: Install Homebrew (macOS -x64)
         if: matrix.os == 'macos-latest' && matrix.arch == 'x64'
         run: |
           # enable Rosetta (needed only on Apple Silicon hosts)
@@ -236,7 +236,7 @@ jobs:
         with:
           version: stable
 
-      - name: Install Colima, Lima guestagents & Docker CLI on macOS
+      - name: Install Colima, Lima guestagents & Docker CLI (macOS)
         if: matrix.os == 'macos-latest'
         run: |
           # use the ARM-native Homebrew for host tools
@@ -259,26 +259,28 @@ jobs:
           which docker
           docker --version
 
-      - name: Start Colima under QEMU
+      - name: Start Colima under QEMU (macOS)
         if: matrix.os == 'macos-latest'
         run: |
           # boot the VM + Docker
           colima start \
             --vm-type qemu \
+            --runtime docker \
             --arch x86_64 \
             --cpu 2 \
             --memory 4 \
             --disk 50 \
             --activate
 
-          # switch your CLI to that context
-          docker context use colima
+      - name: Switch Docker context (macOS)
+        if: matrix.os == 'macos-latest'
+        run: docker context use colima
 
-      - name: Link Docker socket for Docker CLI
+      - name: Link Docker socket for Docker CLI (macOS)
         if: matrix.os == 'macos-latest'
         run: sudo ln -sf $HOME/.colima/default/docker.sock /var/run/docker.sock
 
-      - name: Verify Docker daemon
+      - name: Verify Docker daemon (macOS)
         if: matrix.os == 'macos-latest'
         run: |
           for i in {1..30}; do
@@ -330,14 +332,22 @@ jobs:
           cd ./my-awesome-avs/
           devkit avs build
 
-      - name: Start devnet
+      - name: Start devnet (macOS)
+        if: matrix.os == 'macos-latest'
+        env:
+          DOCKER_HOST: unix://${HOME}/.colima/default/docker.sock
+        run: |
+          docker context use colima
+          cd ./my-awesome-avs/
+          devkit avs devnet start &
+          until nc -z localhost 9090 && nc -z localhost 8081; do sleep 1; done
+
+      - name: Start devnet (Linux)
+        if: matrix.os != 'macos-latest'
         run: |
           cd ./my-awesome-avs/
           devkit avs devnet start &
-          # wait until executor and aggregator are available
-          until nc -z localhost 9090 && nc -z localhost 8081; do
-            sleep 1
-          done
+          until nc -z localhost 9090 && nc -z localhost 8081; do sleep 1; done
 
       - name: Check devnet RPC is live
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -240,12 +240,13 @@ jobs:
         if: matrix.os == 'macos-latest'
         run: |
           brew install docker colima
+          brew install lima-additional-guestagents
 
       - name: Start Colima Docker engine
         if: matrix.os == 'macos-latest'
         run: |
           # start Colima headlessly under QEMU
-          colima start --cpu 2 --memory 4 --disk 50
+          colima start --vm-type qemu --cpu 2 --memory 4 --disk 50
           # wire Docker CLI to Colima engine
           docker context use colima
           # wait for Docker daemon

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -236,28 +236,29 @@ jobs:
         with:
           version: stable
 
-      - name: Install Colima, Lima guestagents & Docker CLI on macOS
+      - name: Install Orbstack (macOS)
         if: matrix.os == 'macos-latest'
         run: |
-          # use the ARM-native Homebrew for host tools
-          BREW_ARM=/opt/homebrew/bin/brew
+          brew install --cask orbstack
+          # ensure CLI is on PATH
+          echo "/Applications/Orbstack.app/Contents/Resources/cli" >> $GITHUB_PATH
 
-          echo "Using ARM Homebrew at $BREW_ARM"
+      - name: Start Orbstacks Docker service
+        if: matrix.os == 'macos-latest'
+        run: |
+          orbstack start docker
+          # wait until Docker daemon is ready
+          for i in {1..30}; do
+            command -v docker >/dev/null \
+              && docker info >/dev/null 2>&1 && break
+            echo "Waiting for Orbstack Docker... ($i/30)"
+            sleep 2
+          done
 
-          # install Lima, Colima and Docker CLI natively
-          $BREW_ARM install lima colima docker
-          $BREW_ARM install lima-additional-guestagents
-
-          # ensure ARM brews bin is on PATH for all later steps
-          echo "/opt/homebrew/bin" >> $GITHUB_PATH
-          echo "$HOME/bin" >> $GITHUB_PATH
-
-          # sanity-check
-          which colima
-          file "$(which colima)"
-          colima version
-          which docker
-          docker --version
+      - name: Verify Docker daemon
+        if: matrix.os == 'macos-latest'
+        run: |
+          docker info
                 
       - name: Run devkit avs create
         run: devkit avs create --disable-telemetry my-awesome-avs
@@ -276,48 +277,6 @@ jobs:
             exit 1
           fi
           echo "✅ AVS project created successfully at ${GITHUB_WORKSPACE}/my-awesome-avs/"
-
-      - name: Start Colima under QEMU
-        if: matrix.os == 'macos-latest'
-        run: |
-          colima start \
-            --vm-type qemu \
-            --arch x86_64 \
-            --cpu 2 \
-            --memory 4 \
-            --disk 50 \
-            --activate
-
-          # instruct docker to use colima socket
-          docker context use colima
-          
-      - name: Verify Docker daemon
-        if: matrix.os == 'macos-latest'
-        run: |
-          for i in {1..30}; do
-            command -v docker >/dev/null \
-              && docker info >/dev/null 2>&1 && break
-            echo "Waiting for Colima/QEMU Docker... ($i/30)"
-            sleep 2
-          done
-          docker info
-          
-      - name: Install Docker Buildx (macOS)
-        if: matrix.os == 'macos-latest'
-        run:  |
-          brew install docker-buildx
-
-          # ensure the CLI-plugins dir exists
-          mkdir -p ~/.docker/cli-plugins
-
-          # symlink the Homebrew buildx into Dockers plugin folder
-          ln -sf "$(brew --prefix)/bin/docker-buildx" ~/.docker/cli-plugins/docker-buildx
-
-          # install it as the default builder
-          docker buildx install
-
-          # verify
-          docker buildx version
 
       - name: Run devkit avs build
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -335,7 +335,6 @@ jobs:
       - name: Start devnet (macOS)
         if: matrix.os == 'macos-latest'
         run: |
-          export DOCKER_HOST=unix://$HOME/.colima/default/docker.sock
           docker context use colima
           cd ./my-awesome-avs/
           devkit avs devnet start &

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,11 @@ on:
     tags:
       - "*"
 
+env:
+  FOUNDRY_PROFILE: ci
+  L1_FORK_URL: ${{ secrets.L1_FORK_URL }}
+  L2_FORK_URL: ${{ secrets.L2_FORK_URL }}
+
 jobs:
   lint:
     name: lint
@@ -197,12 +202,15 @@ jobs:
         run: |
           # enable Rosetta  
           sudo softwareupdate --install-rosetta --agree-to-license || true
+
           # install ARM Homebrew into /opt/homebrew  
           arch -arm64 /bin/bash -c \
             "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-          # load it into PATH  
+
+          # load /opt/homebrew/bin/brew into your PATH
           echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> ~/.zprofile
           eval "$(/opt/homebrew/bin/brew shellenv)"
+
           # force all brew calls under arm64  
           echo "alias brew='arch -arm64 brew'" >> ~/.bashrc
           source ~/.bashrc
@@ -237,6 +245,11 @@ jobs:
 
       - name: Run devkit avs create
         run: devkit avs create my-awesome-avs
+
+      - name: Source shell profile
+        # force a login shell so it actually reads ~/.bashrc / ~/.bash_profile
+        shell: bash --login
+        run: source ~/.bashrc 2>/dev/null || true
 
       - name: Verify AVS project created
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -250,6 +250,7 @@ jobs:
 
           # ensure ARM brews bin is on PATH for all later steps
           echo "/opt/homebrew/bin" >> $GITHUB_PATH
+          echo "$HOME/bin" >> $GITHUB_PATH
 
           # sanity-check
           which colima

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -236,6 +236,13 @@ jobs:
         with:
           version: stable
 
+      - name: Install Colima, Lima guestagents & Docker CLI on macOS
+        if: matrix.os == 'macos-latest'
+        run: |
+          brew install lima colima docker
+          # this provides the missing guest-agent bits for various arches
+          brew install lima-additional-guestagents
+
       - name: Run devkit avs create
         run: devkit avs create --disable-telemetry my-awesome-avs
 
@@ -253,13 +260,6 @@ jobs:
             exit 1
           fi
           echo "✅ AVS project created successfully at ${GITHUB_WORKSPACE}/my-awesome-avs/"
-
-      - name: Install Colima, Lima guestagents & Docker CLI on macOS
-        if: matrix.os == 'macos-latest'
-        run: |
-          brew install lima colima docker
-          # this provides the missing guest-agent bits for various arches
-          brew install lima-additional-guestagents
 
       - name: Start Colima under QEMU
         if: matrix.os == 'macos-latest'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -248,8 +248,10 @@ jobs:
 
       - name: Source shell profile
         # force a login shell so it actually reads ~/.bashrc / ~/.bash_profile
-        shell: bash --login
-        run: source ~/.bashrc 2>/dev/null || true
+        shell: bash -l {0}
+        run: |
+          source ~/.bashrc       2>/dev/null || true
+          source ~/.bash_profile 2>/dev/null || true
 
       - name: Verify AVS project created
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -289,7 +289,7 @@ jobs:
             --activate
 
           # export the environment variables into GITHUB_ENV
-          colima docker-env | sed 's/^/export /' >> $GITHUB_ENV
+          colima docker-env | sed 's/^export //g' >> $GITHUB_ENV
           
       - name: Verify Docker daemon
         if: matrix.os == 'macos-latest'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -244,6 +244,22 @@ jobs:
           fi
           echo "✅ AVS project created successfully at ${GITHUB_WORKSPACE}/my-awesome-avs/"
 
+      - name: Install & Start Docker Desktop on macOS
+        if: matrix.os == 'macos-latest'
+        run: |
+          # launch Docker.app without stealing focus
+          open -g /Applications/Docker.app
+
+          # wait up to 60s for the daemon to be responsive
+          for i in {1..30}; do
+            docker info >/dev/null 2>&1 && break
+            echo "Waiting for Docker daemon… ($i/30)"
+            sleep 2
+          done
+
+          # fail if it never started
+          docker info || (echo "Docker daemon failed to start" && exit 1)
+
       - name: Run devkit avs build
         run: |
           cd ./my-awesome-avs/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -241,7 +241,8 @@ jobs:
         run: |
           brew install --cask orbstack
           brew install docker
-          export PATH="/Applications/Orbstack.app/Contents/MacOS:$PATH"
+          # make the orbstack binary visible
+          echo "/Applications/Orbstack.app/Contents/MacOS" >> $GITHUB_PATH
 
       - name: Start OrbStacks Docker engine
         if: matrix.os == 'macos-latest'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -311,8 +311,8 @@ jobs:
             --vm-type qemu \
             --runtime docker \
             --arch x86_64 \
-            --cpu 2 \
-            --memory 4 \
+            --cpu 4 \
+            --memory 8 \
             --disk 50 \
             --activate
 

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-v0.0.8
+v0.0.8-release-test-e2e

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-v0.0.8-release-test-e2e
+v0.0.8


### PR DESCRIPTION
<!-- 
    🚨 ATTENTION! 🚨 
    
    This PR template is REQUIRED. PRs not following this format will be closed without review.
    
    Requirements:
    - PR title must follow commit conventions: https://www.conventionalcommits.org/en/v1.0.0/
    - Label your PR with the correct type (e.g., 🐛 Bug, ✨ Enhancement, 🧪 Test, etc.)
    - Provide clear and specific details in each section
-->

**Motivation:**
<!--
Explain here the context, and why you're making that change. What is the problem you're trying to solve.
-->
Currently, our release process verifies that the installed version on the binary matches expectation. We should extend this to run the full e2e process to validate the binary works as expected.

**Modifications:**
<!--
Describe the modifications you've done from a high level. What are the key technical decisions and why were they made?
-->
- Adds full e2e process after installing the binary
- Adds additional handling for macos:
  a. Installs `Homebrew` (for `x64`) and aliases `arch` into `brew` command (`arch -<arch> brew ...`)
  b. Installs `Colima`, `Lima guestagents` & `Docker CLI`
  c. Installs `Docker Compose` plugin
  d. Installs `Docker Buildx`
  e. Starts `Colima` under `QEMU`
  f. Switches `Docker` context to `Colima`
  g. Links `Docker socket` for Docker CLI
  h. Verifies `Docker daemon`
  i.  Links `gomplate`
  
Steps **a** (homebrew), **c** (Docker Compose), **d** (Docker Buildx) and **i** (link gomplate) shouldn't require CI workarounds, they belong in the init script, along with proper installs for `go` and `foundry`. 

To avoid these CI hacks, the init script should be updated to:

- Install `Homebrew` for the correct architecture and prefix every command with `arch -<arch> brew...` (macOS runners default to `arm64` in GHA)
- Install `Go` via `brew install go@1.23`
- Install `Foundry` and verify the installer (e2e tests will fail if it's missing)
- `gomplate` should be installed **after** `go` so that it can be linked in the `$GOPATH`
- Install `Docker Compose` plugin and `Docker Buildx` (these are correctly installed in linux with the current handling)

Once these are fixed in the init script we can drop the additional hand holding from this workflow.

cc. @seanmcgary @0xrajath 

**Result:**
<!--
*After your change, what will change.
-->
- Each release target will be tested e2e
