### PR TITLE
feat: remove foundry cast as dependency

### DIFF
--- a/pkg/commands/devnet_actions.go
+++ b/pkg/commands/devnet_actions.go
@@ -213,6 +213,32 @@ func StartDevnetAction(cCtx *cli.Context) error {
 		}()
 	}
 
+	// Wait for container to be ready
+	logger.Info("Waiting for devnet to be ready...")
+	maxRetries := 10
+	baseDelay := 2 * time.Second
+	for i := 0; i < maxRetries; i++ {
+		// Check if container is running
+		checkCmd := exec.CommandContext(cCtx.Context, "docker", "ps", "--filter", fmt.Sprintf("name=%s", containerName), "--format", "{{.Status}}")
+		output, err := checkCmd.CombinedOutput()
+		if err == nil && len(output) > 0 {
+			// Container is running, now check if RPC is responding
+			ethClient, err := ethclient.Dial(fmt.Sprintf("http://localhost:%d", port))
+			if err == nil {
+				_, err = ethClient.BlockNumber(cCtx.Context)
+				if err == nil {
+					break
+				}
+			}
+		}
+		if i == maxRetries-1 {
+			return fmt.Errorf("devnet failed to start after %d retries", maxRetries)
+		}
+		delay := baseDelay * time.Duration(1<<uint(i))
+		logger.Info("Devnet not ready yet, retrying in %v...", delay)
+		time.Sleep(delay)
+	}
+
 	// Construct RPC url to pass to scripts
 	rpcUrl := devnet.GetRPCURL(port)
 	logger.Info("Waiting for devnet to be ready...")

--- a/pkg/commands/devnet_actions.go
+++ b/pkg/commands/devnet_actions.go
@@ -213,32 +213,6 @@ func StartDevnetAction(cCtx *cli.Context) error {
 		}()
 	}
 
-	// Wait for container to be ready
-	logger.Info("Waiting for devnet to be ready...")
-	maxRetries := 10
-	baseDelay := 2 * time.Second
-	for i := 0; i < maxRetries; i++ {
-		// Check if container is running
-		checkCmd := exec.CommandContext(cCtx.Context, "docker", "ps", "--filter", fmt.Sprintf("name=%s", containerName), "--format", "{{.Status}}")
-		output, err := checkCmd.CombinedOutput()
-		if err == nil && len(output) > 0 {
-			// Container is running, now check if RPC is responding
-			ethClient, err := ethclient.Dial(fmt.Sprintf("http://localhost:%d", port))
-			if err == nil {
-				_, err = ethClient.BlockNumber(cCtx.Context)
-				if err == nil {
-					break
-				}
-			}
-		}
-		if i == maxRetries-1 {
-			return fmt.Errorf("devnet failed to start after %d retries", maxRetries)
-		}
-		delay := baseDelay * time.Duration(1<<uint(i))
-		logger.Info("Devnet not ready yet, retrying in %v...", delay)
-		time.Sleep(delay)
-	}
-
 	// Construct RPC url to pass to scripts
 	rpcUrl := devnet.GetRPCURL(port)
 	logger.Info("Waiting for devnet to be ready...")

--- a/pkg/common/devnet/constants.go
+++ b/pkg/common/devnet/constants.go
@@ -3,9 +3,10 @@ package devnet
 // Foundry Image Date : 21 April 2025
 const FOUNDRY_IMAGE = "ghcr.io/foundry-rs/foundry:stable"
 const CHAIN_ARGS = "--gas-limit 140000000 --base-fee 9400000"
-const FUND_VALUE = "10000000000000000000"
+const FUND_VALUE = "1000000000000000000"
 const CONTEXT = "devnet"
 const L1 = "l1"
+const ANVIL_1_KEY = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
 
 // These are fallback EigenLayer deployment addresses when not specified in context
 const ALLOCATION_MANAGER_ADDRESS = "0x948a420b8CC1d6BFd0B6087C2E7c344a2CD0bc39"

--- a/pkg/common/devnet/funding.go
+++ b/pkg/common/devnet/funding.go
@@ -1,83 +1,138 @@
 package devnet
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"math/big"
 	"os"
-	"os/exec"
 	"strings"
 
 	devkitcommon "github.com/Layr-Labs/devkit-cli/pkg/common"
-
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
 )
 
-// FundWallets sends ETH to a list of addresses using `cast send`
+// FundWallets sends ETH to a list of addresses
 // Only funds wallets with balance < 10 ether.
 func FundWalletsDevnet(cfg *devkitcommon.ConfigWithContextConfig, rpcURL string) error {
-
 	if os.Getenv("SKIP_DEVNET_FUNDING") == "true" {
 		log.Println("🔧 Skipping devnet wallet funding (test mode)")
 		return nil
 	}
 
+	ethClient, err := ethclient.Dial(rpcURL)
+	if err != nil {
+		return fmt.Errorf("failed to connect to ETH client: %w", err)
+	}
+	defer ethClient.Close()
+
 	// All operator keys from [operator]
 	// We only intend to fund for devnet, so hardcoding to `CONTEXT` is fine
 	for _, key := range cfg.Context[CONTEXT].Operators {
-		cleanedKey := strings.TrimPrefix(key.ECDSAKey, "0x")
-		privateKey, err := crypto.HexToECDSA(cleanedKey)
+		pvtKey := strings.TrimPrefix(key.ECDSAKey, "0x")
+		privateKey, err := crypto.HexToECDSA(pvtKey)
 		if err != nil {
 			log.Fatalf("invalid private key %q: %v", key.ECDSAKey, err)
 		}
-		err = fundIfNeeded(crypto.PubkeyToAddress(privateKey.PublicKey), key.ECDSAKey, rpcURL)
+		err = fundIfNeeded(ethClient, crypto.PubkeyToAddress(privateKey.PublicKey), ANVIL_1_KEY)
 		if err != nil {
 			return err
 		}
 	}
+
 	return nil
 }
 
-func fundIfNeeded(to common.Address, fromKey string, rpcURL string) error {
-	balanceCmd := exec.Command("cast", "balance", to.String(), "--rpc-url", rpcURL)
-	balanceCmd.Env = append(os.Environ(), "FOUNDRY_DISABLE_NIGHTLY_WARNING=1")
-	output, err := balanceCmd.CombinedOutput()
+func fundIfNeeded(ethClient *ethclient.Client, to common.Address, fromKey string) error {
+	balance, err := ethClient.BalanceAt(context.Background(), to, nil)
 	if err != nil {
-		if strings.Contains(string(output), "Error: error sending request for url") {
-			log.Printf(" Please check if your mainnet fork rpc url is up")
-		}
-		return fmt.Errorf("failed to get balance for account %s", to.String())
+		return fmt.Errorf("failed to get balance for account %s %v", to.String(), err)
 	}
 	threshold := new(big.Int)
-	threshold.SetString(FUND_VALUE, 10)
+	threshold.SetString("300000000000000000", 10) // 0.3 ETH in wei
 
-	balanceStr := strings.TrimSpace(string(output))
-	balance := new(big.Int)
-	if _, ok := balance.SetString(balanceStr, 10); !ok {
-		return fmt.Errorf("failed to parse balance from cast output: %s", balanceStr)
-	}
-	balance.SetString(string(output), 10)
 	if balance.Cmp(threshold) >= 0 {
 		log.Printf("✅ %s already has sufficient balance (%s wei)", to, balance.String())
 		return nil
 	}
 
-	log.Printf("💸 Funding %s with %s from %s", to, FUND_VALUE, fromKey)
-	cmd := exec.Command("cast", "send",
-		to.String(),
-		"--value", FUND_VALUE,
-		"--rpc-url", rpcURL,
-		"--private-key", fromKey,
+	value, _ := new(big.Int).SetString(FUND_VALUE, 10) // 1 ETH in wei
+	gasPrice, err := ethClient.SuggestGasPrice(context.Background())
+	if err != nil {
+		return fmt.Errorf("failed to get gas price: %w", err)
+	}
+
+	// Get the nonce for the sender
+	fromKey = strings.TrimPrefix(fromKey, "0x")
+	privateKey, err := crypto.HexToECDSA(fromKey)
+	if err != nil {
+		return fmt.Errorf("failed to parse private key: %w", err)
+	}
+	fromAddress := crypto.PubkeyToAddress(privateKey.PublicKey)
+
+	// Check sender's balance
+	senderBalance, err := ethClient.BalanceAt(context.Background(), fromAddress, nil)
+	if err != nil {
+		return fmt.Errorf("failed to get sender balance: %w", err)
+	}
+
+	// Calculate total cost (value + gas)
+	gasLimit := uint64(21000)
+	totalCost := new(big.Int).Mul(gasPrice, big.NewInt(int64(gasLimit)))
+	totalCost.Add(totalCost, value)
+
+	if senderBalance.Cmp(totalCost) < 0 {
+		return fmt.Errorf("funder has insufficient balance: has %s wei, needs %s wei", senderBalance.String(), totalCost.String())
+	}
+
+	nonce, err := ethClient.PendingNonceAt(context.Background(), fromAddress)
+	if err != nil {
+		return fmt.Errorf("failed to get nonce: %w", err)
+	}
+
+	tx := types.NewTransaction(
+		nonce,
+		to,
+		value,
+		gasLimit,
+		gasPrice,
+		nil, // data
 	)
 
-	_, err = cmd.CombinedOutput()
-
+	// Get chain ID
+	chainID, err := ethClient.ChainID(context.Background())
 	if err != nil {
-		log.Printf("❌ Failed to fund %s: %v", to, err)
-		return err
-	} else {
-		log.Printf("✅ Funded %s", to)
+		return fmt.Errorf("failed to get chain ID: %w", err)
 	}
+
+	// Sign the transaction with the latest signer
+	signedTx, err := types.SignTx(tx, types.LatestSignerForChainID(chainID), privateKey)
+	if err != nil {
+		return fmt.Errorf("failed to sign transaction: %w", err)
+	}
+
+	err = ethClient.SendTransaction(context.Background(), signedTx)
+	if err != nil {
+		log.Printf("Failed to send eth funding transaction: %v", err)
+		return fmt.Errorf("failed to send transaction: %w", err)
+	}
+
+	log.Printf("Transaction sent, waiting for confirmation...")
+
+	// Wait for transaction to be mined using bind.WaitMined
+	receipt, err := bind.WaitMined(context.Background(), ethClient, signedTx)
+	if err != nil {
+		return fmt.Errorf("failed to wait for transaction: %w", err)
+	}
+
+	if receipt.Status == 0 {
+		return fmt.Errorf("transaction failed")
+	}
+
+	log.Printf("✅ Funded %s (tx: %s)", to, signedTx.Hash().Hex())
 	return nil
 }

--- a/pkg/common/devnet/funding.go
+++ b/pkg/common/devnet/funding.go
@@ -50,6 +50,7 @@ func FundWalletsDevnet(cfg *devkitcommon.ConfigWithContextConfig, rpcURL string)
 func fundIfNeeded(ethClient *ethclient.Client, to common.Address, fromKey string) error {
 	balance, err := ethClient.BalanceAt(context.Background(), to, nil)
 	if err != nil {
+		log.Printf(" Please check if your mainnet fork rpc url is up")
 		return fmt.Errorf("failed to get balance for account %s %v", to.String(), err)
 	}
 	threshold := new(big.Int)

--- a/pkg/common/devnet/funding.go
+++ b/pkg/common/devnet/funding.go
@@ -17,7 +17,7 @@ import (
 )
 
 // FundWallets sends ETH to a list of addresses
-// Only funds wallets with balance < 10 ether.
+// Only funds wallets with balance < 0.3 ether.
 func FundWalletsDevnet(cfg *devkitcommon.ConfigWithContextConfig, rpcURL string) error {
 	if os.Getenv("SKIP_DEVNET_FUNDING") == "true" {
 		log.Println("🔧 Skipping devnet wallet funding (test mode)")


### PR DESCRIPTION
## closes #130 

**Motivation:**

We don't want  foundry's `cast` as requirement for users to be able to run devkit .

**Modifications:**

Use ethclient for funding from go-ethereum , instead of using cast.

**Result:**

Cast is no longer needed for devkit users

**Testing:**
<!--
*List testing procedures taken and useful artifacts.
-->
**Open questions:**
<!--
(optional) Any open questions or feedback on design desired?
-->