### PR TITLE
feat: register template submodules following git init

### DIFF
--- a/pkg/commands/create_test.go
+++ b/pkg/commands/create_test.go
@@ -21,6 +21,8 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
+const contractsBasePath = ".devkit/contracts"
+
 func TestCreateCommand(t *testing.T) {
 	tmpDir := t.TempDir()
 	logger := logger.NewNoopLogger()


### PR DESCRIPTION
<!-- 
    🚨 ATTENTION! 🚨 
    
    This PR template is REQUIRED. PRs not following this format will be closed without review.
    
    Requirements:
    - PR title must follow commit conventions: https://www.conventionalcommits.org/en/v1.0.0/
    - Label your PR with the correct type (e.g., 🐛 Bug, ✨ Enhancement, 🧪 Test, etc.)
    - Provide clear and specific details in each section
-->

**Motivation:**
<!--
Explain here the context, and why you're making that change. What is the problem you're trying to solve.
-->
When a user performs a create from a template we currently check everything in to the users new project, but we should be making sure that submodules are carried through and properly associated.

**Modifications:**
<!--
Describe the modifications you've done from a high level. What are the key technical decisions and why were they made?
-->
- Performs a backup of the templates `.git/modules` directory and restores to the fresh `.git` directory

**Result:**
<!--
*After your change, what will change.
-->
- Submodules are properly registered in the fresh repo

**Testing:**
<!--
*List testing procedures taken and useful artifacts.
-->
- Manually tested in create and upgrade flows
