### PR TITLE
feat: add tests to verify transporter works as expected

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -82,6 +82,11 @@ jobs:
           cd ./my-awesome-avs/
           devkit avs call -- signature="(uint256,string)" args='(5,"hello")'
 
+      - name: Verify stake table roots
+        run: |
+          cd ./my-awesome-avs/
+          devkit avs transport verify
+
       - name: Stop devnet
         run: |
           cd ./my-awesome-avs/

--- a/config/contexts/migrations/v0.0.5-v0.0.6.go
+++ b/config/contexts/migrations/v0.0.5-v0.0.6.go
@@ -205,6 +205,8 @@ func Migration_0_0_5_to_0_0_6(user, old, new *yaml.Node) (*yaml.Node, error) {
 				{Kind: yaml.ScalarNode, Tag: "!!str", Value: "0x2ba58f64c57faa1073d63add89799f2a0101855a8b289b1330cb500758d5d1ee"},
 				{Kind: yaml.ScalarNode, Tag: "!!str", Value: "bls_private_key"},
 				{Kind: yaml.ScalarNode, Tag: "!!str", Value: "0x2ba58f64c57faa1073d63add89799f2a0101855a8b289b1330cb500758d5d1ee"},
+				{Kind: yaml.ScalarNode, Tag: "!!str", Value: "active_stake_roots"},
+				{Kind: yaml.SequenceNode, Tag: "!!seq"},
 			},
 		}
 

--- a/config/contexts/v0.0.6.yaml
+++ b/config/contexts/v0.0.6.yaml
@@ -24,6 +24,7 @@ context:
     schedule: "0 */2 * * *"
     private_key: "0x2ba58f64c57faa1073d63add89799f2a0101855a8b289b1330cb500758d5d1ee"
     bls_private_key: "0x2ba58f64c57faa1073d63add89799f2a0101855a8b289b1330cb500758d5d1ee"
+    active_stake_roots: []
   # All key material (BLS and ECDSA) within this file should be used for local testing ONLY
   # ECDSA keys used are from Anvil's private key set
   # BLS keystores are deterministically pre-generated and embedded. These are NOT derived from a secure seed

--- a/pkg/commands/call.go
+++ b/pkg/commands/call.go
@@ -3,7 +3,6 @@ package commands
 import (
 	"encoding/json"
 	"fmt"
-	"path"
 	"path/filepath"
 	"strings"
 
@@ -24,9 +23,7 @@ var CallCommand = &cli.Command{
 		logger.Debug("Testing AVS tasks...")
 
 		// Set path for context yaml
-		contextDir := filepath.Join("config", "contexts")
-		yamlPath := path.Join(contextDir, "devnet.yaml") // @TODO: use selected context name
-		contextJSON, err := common.LoadRawContext(yamlPath)
+		contextJSON, err := common.LoadRawContext("devnet") // @TODO: use selected context name
 		if err != nil {
 			return fmt.Errorf("failed to load context %w", err)
 		}

--- a/pkg/commands/devnet_actions.go
+++ b/pkg/commands/devnet_actions.go
@@ -13,7 +13,6 @@ import (
 	"math/big"
 	"os"
 	"os/exec"
-	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -93,27 +92,10 @@ func StartDevnetAction(cCtx *cli.Context) error {
 		return err
 	}
 
-	// Set path for context yamls
-	contextDir := filepath.Join("config", "contexts")
-	yamlPath := path.Join(contextDir, "devnet.yaml")
-
-	// Load YAML as *yaml.Node
-	rootNode, err := common.LoadYAML(yamlPath)
-	if err != nil {
-		return err
-	}
-
-	// YAML is parsed into a DocumentNode:
-	//   - rootNode.Content[0] is the top-level MappingNode
-	//   - It contains the 'context' mapping we're interested in
-	if len(rootNode.Content) == 0 {
-		return fmt.Errorf("empty YAML root node")
-	}
-
 	// Check for context
-	contextNode := common.GetChildByKey(rootNode.Content[0], "context")
-	if contextNode == nil {
-		return fmt.Errorf("missing 'context' key in ./config/contexts/devnet.yaml")
+	yamlPath, rootNode, contextNode, err := common.LoadContext("devnet") // @TODO: use selected context name
+	if err != nil {
+		return fmt.Errorf("context loading failed: %w", err)
 	}
 
 	// Fetch EigenLayer addresses using Zeus if requested
@@ -395,16 +377,6 @@ func DeployContractsAction(cCtx *cli.Context) error {
 	// Set path for .devkit scripts
 	scriptsDir := filepath.Join(".devkit", "scripts")
 
-	// Set path for context yaml
-	contextDir := filepath.Join("config", "contexts")
-	yamlPath := path.Join(contextDir, fmt.Sprintf("%s.%s", context, "yaml"))
-
-	// Load YAML as *yaml.Node
-	rootNode, err := common.LoadYAML(yamlPath)
-	if err != nil {
-		return err
-	}
-
 	// List of scripts we want to call and curry context through
 	scriptNames := []string{
 		"deployContracts",
@@ -412,17 +384,10 @@ func DeployContractsAction(cCtx *cli.Context) error {
 		"getOperatorRegistrationMetadata",
 	}
 
-	// YAML is parsed into a DocumentNode:
-	//   - rootNode.Content[0] is the top-level MappingNode
-	//   - It contains the 'context' mapping we're interested in
-	if len(rootNode.Content) == 0 {
-		return fmt.Errorf("empty YAML root node")
-	}
-
 	// Check for context
-	contextNode := common.GetChildByKey(rootNode.Content[0], "context")
-	if contextNode == nil {
-		return fmt.Errorf("missing 'context' key in ./config/contexts/%s.yaml", context)
+	yamlPath, rootNode, contextNode, err := common.LoadContext("devnet") // @TODO: use selected context name
+	if err != nil {
+		return fmt.Errorf("context loading failed: %w", err)
 	}
 
 	// Loop scripts with cloned context
@@ -885,19 +850,10 @@ func FetchZeusAddressesAction(cCtx *cli.Context) error {
 	logger := common.LoggerFromContext(cCtx.Context)
 	contextName := cCtx.String("context")
 
-	// Set path for context yaml
-	contextDir := filepath.Join("config", "contexts")
-	yamlPath := path.Join(contextDir, fmt.Sprintf("%s.%s", contextName, "yaml"))
-
-	// Load YAML as *yaml.Node
-	rootNode, err := common.LoadYAML(yamlPath)
-	if err != nil {
-		return err
-	}
 	// Check for context
-	contextNode := common.GetChildByKey(rootNode.Content[0], "context")
-	if contextNode == nil {
-		return fmt.Errorf("missing 'context' key in ./config/contexts/%s.yaml", contextName)
+	yamlPath, rootNode, contextNode, err := common.LoadContext("devnet") // @TODO: use selected context name
+	if err != nil {
+		return fmt.Errorf("context loading failed: %w", err)
 	}
 
 	// Fetch addresses from Zeus

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"fmt"
-	"path"
 	"path/filepath"
 
 	"github.com/Layr-Labs/devkit-cli/pkg/common"
@@ -36,9 +35,7 @@ func AVSRun(cCtx *cli.Context) error {
 	scriptPath := filepath.Join(".devkit", "scripts", "run")
 
 	// Set path for context yaml
-	contextDir := filepath.Join("config", "contexts")
-	yamlPath := path.Join(contextDir, "devnet.yaml") // @TODO: use selected context name
-	contextJSON, err := common.LoadRawContext(yamlPath)
+	contextJSON, err := common.LoadRawContext("devnet") // @TODO: use selected context name
 	if err != nil {
 		return fmt.Errorf("failed to load context: %w", err)
 	}

--- a/pkg/commands/transporter.go
+++ b/pkg/commands/transporter.go
@@ -371,9 +371,15 @@ func GetOnchainStakeTableRoots(cCtx *cli.Context) (map[uint64][32]byte, error) {
 		return nil, fmt.Errorf("Failed to add chain: %v", err)
 	}
 	holeskyClient, err := cm.GetChainForId(holeskyConfig.ChainID)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get chain for ID %d: %v", holeskyConfig.ChainID, err)
+	}
 
 	// Construct registry caller
 	ccRegistryCaller, err := ICrossChainRegistry.NewICrossChainRegistryCaller(crossChainRegistryAddress, holeskyClient.RPCClient)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get CrossChainRegistryCaller for %s: %v", crossChainRegistryAddress, err)
+	}
 
 	// Get chains from contract
 	chainIds, addresses, err := ccRegistryCaller.GetSupportedChains(&bind.CallOpts{})
@@ -401,6 +407,9 @@ func GetOnchainStakeTableRoots(cCtx *cli.Context) (map[uint64][32]byte, error) {
 
 		// Collect the current root from provided chainId
 		root, err := transactor.GetCurrentGlobalTableRoot(&bind.CallOpts{})
+		if err != nil {
+			return nil, fmt.Errorf("failed to get stake root: %w", err)
+		}
 
 		// Collect the provided root
 		roots[chainId.Uint64()] = root

--- a/pkg/commands/transporter.go
+++ b/pkg/commands/transporter.go
@@ -4,12 +4,16 @@ import (
 	"fmt"
 	"log"
 	"math/big"
+	"strconv"
 	"time"
 
 	"github.com/Layr-Labs/crypto-libs/pkg/bn254"
 	"github.com/Layr-Labs/devkit-cli/pkg/common"
 	"github.com/Layr-Labs/devkit-cli/pkg/common/devnet"
+	"github.com/Layr-Labs/eigenlayer-contracts/pkg/bindings/ICrossChainRegistry"
+	"github.com/Layr-Labs/eigenlayer-contracts/pkg/bindings/IOperatorTableUpdater"
 	"github.com/urfave/cli/v2"
+	"gopkg.in/yaml.v3"
 
 	"github.com/Layr-Labs/multichain-go/pkg/blsSigner"
 	"github.com/Layr-Labs/multichain-go/pkg/chainManager"
@@ -18,7 +22,9 @@ import (
 	"github.com/Layr-Labs/multichain-go/pkg/transport"
 	"github.com/Layr-Labs/multichain-go/pkg/txSigner"
 
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/rpc"
 
 	"github.com/robfig/cron/v3"
@@ -29,13 +35,16 @@ var TransportCommand = &cli.Command{
 	Usage: "Transport Stake Root to L1",
 	Subcommands: []*cli.Command{
 		{
-			Name:  "run",
-			Usage: "Immediately transport stake root to L1",
-			Flags: append([]cli.Flag{}, common.GlobalFlags...),
-			Action: func(cCtx *cli.Context) error {
-				// Invoke and return Transport
-				return Transport(cCtx)
-			},
+			Name:   "run",
+			Usage:  "Immediately transport stake root to L1",
+			Flags:  append([]cli.Flag{}, common.GlobalFlags...),
+			Action: Transport,
+		},
+		{
+			Name:   "verify",
+			Usage:  "Verify that the context active_stake_roots match onchain state",
+			Flags:  append([]cli.Flag{}, common.GlobalFlags...),
+			Action: VerifyActiveStakeTableRoots,
 		},
 		{
 			Name:  "schedule",
@@ -86,6 +95,9 @@ func Transport(cCtx *cli.Context) error {
 
 	// Get logger
 	logger := common.LoggerFromContext(cCtx.Context)
+
+	// Construct and collate all roots
+	roots := make(map[uint64][32]byte)
 
 	// Extract context
 	cfg, err := common.LoadConfigWithContextConfig(devnet.DEVNET_CONTEXT)
@@ -183,9 +195,21 @@ func Transport(cCtx *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("Failed to sign and transport global table root: %v", err)
 	}
+
+	// Collect the provided roots
+	roots[holeskyConfig.ChainID] = root
+
+	// Write the roots to context (each time we process one)
+	err = WriteStakeTableRootsToContext(roots)
+	if err != nil {
+		return fmt.Errorf("failed to write active_stake_roots: %w", err)
+	}
+
+	// Sleep before transporting AVSStakeTable
 	logger.Info("Successfully signed and transported global table root, sleeping for 25 seconds")
 	time.Sleep(25 * time.Second)
 
+	// Fetch OperatorSets for AVSStakeTable transport
 	opsets := dist.GetOperatorSets()
 	if len(opsets) == 0 {
 		return fmt.Errorf("No operator sets found, skipping AVS stake table transport")
@@ -211,6 +235,265 @@ func Transport(cCtx *cli.Context) error {
 	return nil
 }
 
+// Record StakeTableRoots in the context for later retrieval
+func WriteStakeTableRootsToContext(roots map[uint64][32]byte) error {
+	// Load and navigate context to arrive at context.transporter.active_stake_roots
+	yamlPath, rootNode, contextNode, err := common.LoadContext("devnet") // @TODO: use selected context name
+	if err != nil {
+		return err
+	}
+	transporterNode := common.GetChildByKey(contextNode, "transporter")
+	if transporterNode == nil {
+		return fmt.Errorf("'transporter' section missing in context")
+	}
+	activeRootsNode := common.GetChildByKey(transporterNode, "active_stake_roots")
+	if activeRootsNode == nil {
+		activeRootsNode = &yaml.Node{
+			Kind:    yaml.SequenceNode,
+			Tag:     "!!seq",
+			Content: []*yaml.Node{},
+		}
+		// insert key-value into transporter
+		transporterNode.Content = append(transporterNode.Content,
+			&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "active_stake_roots"},
+			activeRootsNode,
+		)
+	} else if activeRootsNode.Kind != yaml.SequenceNode {
+		return fmt.Errorf("'active_stake_roots' exists but is not a list")
+	}
+
+	// Force block style on activeRootsNode to prevent collapse
+	activeRootsNode.Style = 0
+
+	// Construct index of the context stored roots
+	indexByChainID := make(map[uint64]int)
+	for idx, node := range activeRootsNode.Content {
+		if node.Kind != yaml.MappingNode {
+			continue
+		}
+		for i := 0; i < len(node.Content)-1; i += 2 {
+			if node.Content[i].Value == "chain_id" {
+				cid, err := strconv.ParseUint(node.Content[i+1].Value, 10, 64)
+				if err == nil {
+					indexByChainID[cid] = idx
+				}
+			}
+		}
+	}
+
+	// Append roots to the context
+	for chainID, root := range roots {
+		hexRoot := fmt.Sprintf("0x%x", root)
+
+		// Check for entry for this chainId
+		if idx, ok := indexByChainID[chainID]; ok {
+			// Update stake_root field in existing node
+			entry := activeRootsNode.Content[idx]
+			found := false
+			for i := 0; i < len(entry.Content)-1; i += 2 {
+				if entry.Content[i].Value == "stake_root" {
+					entry.Content[i+1].Value = hexRoot
+					found = true
+					break
+				}
+			}
+			// If stake_root missing, insert it
+			if !found {
+				entry.Content = append(entry.Content,
+					&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "stake_root"},
+					&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: hexRoot},
+				)
+			}
+		} else {
+			// Append new entry
+			entryNode := &yaml.Node{
+				Kind:  yaml.MappingNode,
+				Tag:   "!!map",
+				Style: 0,
+				Content: []*yaml.Node{
+					{Kind: yaml.ScalarNode, Tag: "!!str", Value: "chain_id", Style: 0},
+					{Kind: yaml.ScalarNode, Tag: "!!int", Value: strconv.FormatUint(chainID, 10), Style: 0},
+					{Kind: yaml.ScalarNode, Tag: "!!str", Value: "stake_root", Style: 0},
+					{Kind: yaml.ScalarNode, Tag: "!!str", Value: hexRoot, Style: 0},
+				},
+			}
+			activeRootsNode.Content = append(activeRootsNode.Content, entryNode)
+		}
+	}
+
+	// Write the context back to disk
+	err = common.WriteYAML(yamlPath, rootNode)
+	if err != nil {
+		return fmt.Errorf("failed to write updated context to disk: %w", err)
+	}
+
+	return nil
+}
+
+// Get all stake table roots from appropriate OperatorTableUpdaters
+func GetOnchainStakeTableRoots(cCtx *cli.Context) (map[uint64][32]byte, error) {
+	// Get logger
+	logger := common.LoggerFromContext(cCtx.Context)
+
+	// Discover and collate all roots
+	roots := make(map[uint64][32]byte)
+
+	// Extract context
+	cfg, err := common.LoadConfigWithContextConfig(devnet.DEVNET_CONTEXT)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load configurations for whitelist chain id in cross registry: %w", err)
+	}
+	envCtx, ok := cfg.Context[devnet.DEVNET_CONTEXT]
+	if !ok {
+		return nil, fmt.Errorf("context '%s' not found in configuration", devnet.DEVNET_CONTEXT)
+	}
+
+	// Get the values from env/config
+	crossChainRegistryAddress := ethcommon.HexToAddress(envCtx.EigenLayer.L1.CrossChainRegistry)
+	rpcUrl, err := devnet.GetDevnetRPCUrlDefault(cfg, devnet.L1)
+	if err != nil {
+		rpcUrl = "http://localhost:8545"
+	}
+	chainId, err := devnet.GetDevnetChainIdOrDefault(cfg, devnet.L1, logger)
+	if err != nil {
+		chainId = common.DefaultAnvilChainId
+	}
+
+	// Get a new chainManager
+	cm := chainManager.NewChainManager()
+
+	// Configure L1 chain
+	holeskyConfig := &chainManager.ChainConfig{
+		ChainID: uint64(chainId),
+		RPCUrl:  rpcUrl,
+	}
+	if err := cm.AddChain(holeskyConfig); err != nil {
+		return nil, fmt.Errorf("Failed to add chain: %v", err)
+	}
+	holeskyClient, err := cm.GetChainForId(holeskyConfig.ChainID)
+
+	// Construct registry caller
+	ccRegistryCaller, err := ICrossChainRegistry.NewICrossChainRegistryCaller(crossChainRegistryAddress, holeskyClient.RPCClient)
+
+	// Get chains from contract
+	chainIds, addresses, err := ccRegistryCaller.GetSupportedChains(&bind.CallOpts{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get supported chains: %w", err)
+	}
+	if len(chainIds) == 0 {
+		return nil, fmt.Errorf("no supported chains found in cross-chain registry")
+	}
+
+	// Iterate and collect all roots for all chainIds
+	for i, chainId := range chainIds {
+		// Use provided OperatorTableUpdaterTransactor address
+		addr := addresses[i]
+		chain, err := cm.GetChainForId(chainId.Uint64())
+		if err != nil {
+			return nil, fmt.Errorf("failed to get chain for ID %d: %w", chainId, err)
+		}
+
+		// Get the OperatorTableUpdaterTransactor at the provided chains address
+		transactor, err := IOperatorTableUpdater.NewIOperatorTableUpdater(addr, chain.RPCClient)
+		if err != nil {
+			return nil, fmt.Errorf("failed to bind NewIOperatorTableUpdaterTransactor: %w", err)
+		}
+
+		// Collect the current root from provided chainId
+		root, err := transactor.GetCurrentGlobalTableRoot(&bind.CallOpts{})
+
+		// Collect the provided root
+		roots[chainId.Uint64()] = root
+	}
+
+	return roots, nil
+}
+
+// Verify the context stored ActiveStakeRoots match onchain state
+func VerifyActiveStakeTableRoots(cCtx *cli.Context) error {
+	// Get logger
+	logger := common.LoggerFromContext(cCtx.Context)
+
+	// Read expected roots from context
+	_, _, contextNode, err := common.LoadContext("devnet") // @TODO: make dynamic
+	if err != nil {
+		return fmt.Errorf("failed to load context YAML: %w", err)
+	}
+
+	transporterNode := common.GetChildByKey(contextNode, "transporter")
+	if transporterNode == nil {
+		return fmt.Errorf("missing 'transporter' section in context")
+	}
+
+	activeRootsNode := common.GetChildByKey(transporterNode, "active_stake_roots")
+	if activeRootsNode == nil || activeRootsNode.Kind != yaml.SequenceNode {
+		return fmt.Errorf("'active_stake_roots' is missing or not a list")
+	}
+
+	expectedMap := make(map[uint64][32]byte)
+	for _, entry := range activeRootsNode.Content {
+		if entry.Kind != yaml.MappingNode {
+			return fmt.Errorf("malformed entry in 'active_stake_roots'; expected map")
+		}
+
+		var chainID uint64
+		var rootBytes [32]byte
+		var foundCID, foundRoot bool
+
+		for i := 0; i < len(entry.Content); i += 2 {
+			key := entry.Content[i].Value
+			val := entry.Content[i+1].Value
+
+			switch key {
+			case "chain_id":
+				cid, err := strconv.ParseUint(val, 10, 64)
+				if err != nil {
+					return fmt.Errorf("invalid chain_id: %w", err)
+				}
+				chainID = cid
+				foundCID = true
+			case "stake_root":
+				b, err := hexutil.Decode(val)
+				if err != nil {
+					return fmt.Errorf("invalid stake_root hex: %w", err)
+				}
+				if len(b) != 32 {
+					return fmt.Errorf("stake_root must be 32 bytes, got %d", len(b))
+				}
+				copy(rootBytes[:], b)
+				foundRoot = true
+			}
+		}
+
+		if !foundCID || !foundRoot {
+			return fmt.Errorf("entry missing required fields 'chain_id' or 'stake_root'")
+		}
+
+		expectedMap[chainID] = rootBytes
+	}
+
+	// Fetch actual roots
+	actualMap, err := GetOnchainStakeTableRoots(cCtx)
+	if err != nil {
+		return fmt.Errorf("failed to get onchain roots: %w", err)
+	}
+
+	// Compare expectations to actual (use actual as map source to allow user to move chainId if req)
+	for id, actual := range actualMap {
+		expected, ok := expectedMap[id]
+		if !ok {
+			return fmt.Errorf("missing onchain root for chainId %d", id)
+		}
+		if expected != actual {
+			return fmt.Errorf("root mismatch for chainId %d:\nexpected: %x\ngot:      %x", id, expected, actual)
+		}
+	}
+
+	logger.Info("Root matches onchain state.")
+	return nil
+}
+
+// Schedule transport using the default parser and transportFunc
 func ScheduleTransport(cCtx *cli.Context, cronExpr string) error {
 	// Validate cron expression
 	parser := cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
@@ -223,6 +506,7 @@ func ScheduleTransport(cCtx *cli.Context, cronExpr string) error {
 	})
 }
 
+// Schedule transport using custom parser and transportFunc
 func ScheduleTransportWithParserAndFunc(cCtx *cli.Context, cronExpr string, parser cron.Parser, transportFunc func()) error {
 	// Validate cron expression
 	c := cron.New(cron.WithParser(parser))

--- a/pkg/commands/transporter.go
+++ b/pkg/commands/transporter.go
@@ -214,18 +214,25 @@ func Transport(cCtx *cli.Context) error {
 func ScheduleTransport(cCtx *cli.Context, cronExpr string) error {
 	// Validate cron expression
 	parser := cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
+
+	// Run the scheduler with transport func
+	return ScheduleTransportWithParserAndFunc(cCtx, cronExpr, parser, func() {
+		if err := Transport(cCtx); err != nil {
+			log.Printf("Scheduled transport failed: %v", err)
+		}
+	})
+}
+
+func ScheduleTransportWithParserAndFunc(cCtx *cli.Context, cronExpr string, parser cron.Parser, transportFunc func()) error {
+	// Validate cron expression
+	c := cron.New(cron.WithParser(parser))
 	_, err := parser.Parse(cronExpr)
 	if err != nil {
 		return fmt.Errorf("invalid cron expression: %w", err)
 	}
 
 	// Call Transport() against cronExpr
-	c := cron.New()
-	_, err = c.AddFunc(cronExpr, func() {
-		if err := Transport(cCtx); err != nil {
-			log.Printf("Scheduled transport failed: %v", err)
-		}
-	})
+	_, err = c.AddFunc(cronExpr, transportFunc)
 	if err != nil {
 		return fmt.Errorf("failed to add transport function to scheduler: %w", err)
 	}

--- a/pkg/commands/transporter_test.go
+++ b/pkg/commands/transporter_test.go
@@ -1,0 +1,82 @@
+package commands
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/robfig/cron/v3"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
+)
+
+func TestScheduleTransport_InvalidCron(t *testing.T) {
+	app := cli.NewApp()
+	cCtx := cli.NewContext(app, nil, nil)
+	cCtx.Context = context.Background()
+
+	// attempt to schedule with invalid cron expression
+	err := ScheduleTransport(cCtx, "invalid-cron")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid cron expression")
+}
+
+func TestScheduleTransportWithParserAndFunc_Executes(t *testing.T) {
+	executed := make(chan struct{}, 1)
+	mockFunc := func() {
+		executed <- struct{}{}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	app := cli.NewApp()
+	cCtx := cli.NewContext(app, nil, nil)
+	cCtx.Context = ctx
+
+	// pass in second aware parser
+	cronExpr := "*/1 * * * * *"
+	parser := cron.NewParser(cron.Second | cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
+	go func() {
+		err := ScheduleTransportWithParserAndFunc(cCtx, cronExpr, parser, mockFunc)
+		require.NoError(t, err)
+	}()
+
+	select {
+	case <-executed:
+		// success
+	case <-time.After(2 * time.Second):
+		t.Fatal("transportFunc did not execute as expected")
+	}
+}
+
+func TestScheduleTransportWithParserAndFunc_ContextCancellationStopsScheduler(t *testing.T) {
+	executed := make(chan struct{}, 1)
+	mockFunc := func() {
+		executed <- struct{}{}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	app := cli.NewApp()
+	cCtx := cli.NewContext(app, nil, nil)
+	cCtx.Context = ctx
+
+	// pass in minute aware parser
+	cronExpr := "*/1 * * * *"
+	parser := cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
+	go func() {
+		_ = ScheduleTransportWithParserAndFunc(cCtx, cronExpr, parser, mockFunc)
+	}()
+
+	// cancel early to test shutdown
+	time.Sleep(500 * time.Millisecond)
+	cancel()
+
+	// wait and confirm function was not called
+	select {
+	case <-executed:
+		t.Fatal("transportFunc should not have executed after early cancel")
+	case <-time.After(2 * time.Second):
+		// success
+	}
+}


### PR DESCRIPTION
<!-- 
    🚨 ATTENTION! 🚨 
    
    This PR template is REQUIRED. PRs not following this format will be closed without review.
    
    Requirements:
    - PR title must follow commit conventions: https://www.conventionalcommits.org/en/v1.0.0/
    - Label your PR with the correct type (e.g., 🐛 Bug, ✨ Enhancement, 🧪 Test, etc.)
    - Provide clear and specific details in each section
-->

**Motivation:**
<!--
Explain here the context, and why you're making that change. What is the problem you're trying to solve.
-->
As an AVS developer, I want automated tests verifying that the transporter correctly and periodically posts stake table roots to the L1 Devnet, so that the system continuously maintains alignment between off-chain state and on-chain stake data.

**Modifications:**
<!--
Describe the modifications you've done from a high level. What are the key technical decisions and why were they made?
-->
- Adds unit/integration tests to verify that the scheduler calls the transport func at defined intervals
- Stores `active_stake_roots` into context for each `chainId` (there should only be 1 present unless user modifies the L1 `chainId`)
- Adds `transport verify` subcommand to verify the context state against onchain state
- Adds extra step to `e2e` to call `transport verify` 

**Result:**
<!--
*After your change, what will change.
-->
- Transport behaviour is tested e2e
