### PR TITLE
feat: upgrade commands to move to latest versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,7 +391,7 @@ View template information:
 devkit avs template info
 ```
 
-Upgrade to a specific template version (tag, branch, or commit hash):
+Upgrade to a specific template version (`"latest"`, tag, branch, or commit hash):
 ```bash
 devkit avs template upgrade --version v1.0.0
 ```
@@ -419,21 +419,27 @@ devkit avs build --verbose
 
 ### Upgrading the Devkit CLI
 
-To upgrade the Devkit CLI to the latest version, find the [latest release](releases) you want to download and re-run the curl install command:
+To upgrade the Devkit CLI to the latest version, you can use the `devkit upgrade` command.
 
 ```bash
-VERSION=v0.0.8
-ARCH=$(uname -m | tr '[:upper:]' '[:lower:]')
-DISTRO=$(uname -s | tr '[:upper:]' '[:lower:]')
+# installs the latest version of devkit 
+devkit upgrade
+```
 
-mkdir -p $HOME/bin
-curl -sL "https://s3.amazonaws.com/eigenlayer-devkit-releases/${VERSION}/devkit-${DISTRO}-${ARCH}-${VERSION}.tar.gz" | tar xv -C "$HOME/bin"
+To move to a specific release, find the [target release](releases) you want to install and run:
 
+```bash
+devkit upgrade --version <target-version>
 ```
 
 ### Upgrading your template
 
 To upgrade the template you created your project with (by calling `devkit avs create`) you can use the `devkit avs template` subcommands.
+
+```bash
+# installs the latest template version known to devkit
+devkit avs template upgrade
+```
 
 **_View which version you're currently using_**
 

--- a/cmd/devkit/main.go
+++ b/cmd/devkit/main.go
@@ -49,6 +49,7 @@ func main() {
 			commands.AVSCommand,
 			keystore.KeystoreCommand,
 			version.VersionCommand,
+			commands.UpgradeCommand,
 			commands.TelemetryCommand,
 		},
 		UseShortOptionHandling: true,

--- a/pkg/commands/template/upgrade.go
+++ b/pkg/commands/template/upgrade.go
@@ -18,6 +18,7 @@ import (
 type templateInfoGetter interface {
 	GetInfo() (string, string, string, error)
 	GetInfoDefault() (string, string, string, error)
+	GetTemplateVersionFromConfig(arch, lang string) (string, error)
 }
 
 // defaultTemplateInfoGetter implements templateInfoGetter using the real functions
@@ -31,6 +32,22 @@ func (g *defaultTemplateInfoGetter) GetInfoDefault() (string, string, string, er
 	return GetTemplateInfoDefault()
 }
 
+func (g *defaultTemplateInfoGetter) GetTemplateVersionFromConfig(arch, lang string) (string, error) {
+	cfg, err := template.LoadConfig()
+	if err != nil {
+		return "", fmt.Errorf("failed to load templates cfg: %w", err)
+	}
+	a, ok := cfg.Architectures[arch]
+	if !ok {
+		return "", fmt.Errorf("architecture %s not found", arch)
+	}
+	l, ok := a.Languages[lang]
+	if !ok {
+		return "", fmt.Errorf("language %s not found under architecture %s", lang, arch)
+	}
+	return l.Version, nil
+}
+
 // createUpgradeCommand creates an upgrade command with the given dependencies
 func createUpgradeCommand(
 	infoGetter templateInfoGetter,
@@ -40,9 +57,19 @@ func createUpgradeCommand(
 		Usage: "Upgrade project to a newer template version",
 		Flags: []cli.Flag{
 			&cli.StringFlag{
-				Name:     "version",
-				Usage:    "Template version (Git ref: tag, branch, or commit) to upgrade to",
-				Required: true,
+				Name:  "version",
+				Usage: "Template version (Git ref: tag, branch, or commit) to upgrade to",
+				Value: "latest",
+			},
+			&cli.StringFlag{
+				Name:  "lang",
+				Usage: "Programming language used to generate project files",
+				Value: "go",
+			},
+			&cli.StringFlag{
+				Name:  "arch",
+				Usage: "AVS architecture used to generate project files (task-based/hourglass, epoch-based, etc.)",
+				Value: "task",
 			},
 		},
 		Action: func(cCtx *cli.Context) error {
@@ -52,6 +79,17 @@ func createUpgradeCommand(
 
 			// Get the requested version
 			requestedVersion := cCtx.String("version")
+			if requestedVersion == "" || requestedVersion == "latest" {
+				arch := cCtx.String("arch")
+				lang := cCtx.String("lang")
+				version, err := infoGetter.GetTemplateVersionFromConfig(arch, lang)
+				if err != nil {
+					return fmt.Errorf("failed to get latest version: %w", err)
+				}
+				// Set requestedVersion to configs version (this is the latest this version of devkit is aware of)
+				requestedVersion = version
+			}
+			// Check again for nil requestedVersion after attempting to pull from template
 			if requestedVersion == "" {
 				return fmt.Errorf("template version is required. Use --version to specify")
 			}

--- a/pkg/commands/template/upgrade.go
+++ b/pkg/commands/template/upgrade.go
@@ -71,11 +71,6 @@ func createUpgradeCommand(
 				Usage: "AVS architecture used to generate project files (task-based/hourglass, epoch-based, etc.)",
 				Value: "task",
 			},
-			&cli.BoolFlag{
-				Name:  "force",
-				Usage: "Force upgrade to a newer version than devkit is aware of",
-				Value: false,
-			},
 		},
 		Action: func(cCtx *cli.Context) error {
 			// Get logger
@@ -109,9 +104,9 @@ func createUpgradeCommand(
 				if err != nil {
 					logger.Error("comparing versions failed: %w", err)
 				}
-				// Warn unless upgrading with force
-				if requestedIsBeyondKnown && !cCtx.Bool("force") {
-					return fmt.Errorf("requested version is greater than the latest version known to DevKit (%s).\n\n  - Run `devkit avs template upgrade --version=%s --force` if you are sure you want to upgrade to %s", latestVersion, requestedVersion, requestedVersion)
+				// Return error and prevent upgrade
+				if requestedIsBeyondKnown {
+					return fmt.Errorf("requested version is greater than the latest version known to DevKit (%s)", latestVersion)
 				}
 			}
 

--- a/pkg/commands/template/upgrade.go
+++ b/pkg/commands/template/upgrade.go
@@ -71,27 +71,48 @@ func createUpgradeCommand(
 				Usage: "AVS architecture used to generate project files (task-based/hourglass, epoch-based, etc.)",
 				Value: "task",
 			},
+			&cli.BoolFlag{
+				Name:  "force",
+				Usage: "Force upgrade to a newer version than devkit is aware of",
+				Value: false,
+			},
 		},
 		Action: func(cCtx *cli.Context) error {
 			// Get logger
 			logger := common.LoggerFromContext(cCtx.Context)
 			tracker := common.ProgressTrackerFromContext(cCtx.Context)
 
+			arch := cCtx.String("arch")
+			lang := cCtx.String("lang")
+			latestVersion, err := infoGetter.GetTemplateVersionFromConfig(arch, lang)
+			if err != nil {
+				return fmt.Errorf("failed to get latest version: %w", err)
+			}
+
 			// Get the requested version
 			requestedVersion := cCtx.String("version")
 			if requestedVersion == "" || requestedVersion == "latest" {
-				arch := cCtx.String("arch")
-				lang := cCtx.String("lang")
-				version, err := infoGetter.GetTemplateVersionFromConfig(arch, lang)
-				if err != nil {
-					return fmt.Errorf("failed to get latest version: %w", err)
-				}
 				// Set requestedVersion to configs version (this is the latest this version of devkit is aware of)
-				requestedVersion = version
+				requestedVersion = latestVersion
 			}
 			// Check again for nil requestedVersion after attempting to pull from template
 			if requestedVersion == "" {
 				return fmt.Errorf("template version is required. Use --version to specify")
+			}
+
+			// Check if the requested version is valid and known to DevKit
+			if common.IsSemver(requestedVersion) && common.IsSemver(latestVersion) {
+				// Compare semver strings
+				requestedIsBeyondKnown, err := common.CompareVersions(requestedVersion, latestVersion)
+
+				// On error log but don't exit
+				if err != nil {
+					logger.Error("comparing versions failed: %w", err)
+				}
+				// Warn unless upgrading with force
+				if requestedIsBeyondKnown && !cCtx.Bool("force") {
+					return fmt.Errorf("requested version is greater than the latest version known to DevKit (%s).\n\n  - Run `devkit avs template upgrade --version=%s --force` if you are sure you want to upgrade to %s", latestVersion, requestedVersion, requestedVersion)
+				}
 			}
 
 			// Get template information

--- a/pkg/commands/template/upgrade_test.go
+++ b/pkg/commands/template/upgrade_test.go
@@ -197,10 +197,59 @@ func TestUpgradeCommand(t *testing.T) {
 			}
 		}
 
+		// Run the upgrade command (which is our test command with mocks)
+		err := cmdWithLogger.Action(ctx)
+		if err != nil {
+			t.Errorf("UpgradeCommand action returned error: %v", err)
+		}
+
+		// Verify config was updated with new version
+		configData, err := os.ReadFile(configPath)
+		if err != nil {
+			t.Fatalf("Failed to read config file after upgrade: %v", err)
+		}
+
+		var configMap map[string]interface{}
+		if err := yaml.Unmarshal(configData, &configMap); err != nil {
+			t.Fatalf("Failed to parse config file after upgrade: %v", err)
+		}
+
+		var templateVersion string
+		if configSection, ok := configMap["config"].(map[string]interface{}); ok {
+			if projectMap, ok := configSection["project"].(map[string]interface{}); ok {
+				if version, ok := projectMap["templateVersion"].(string); ok {
+					templateVersion = version
+				}
+			}
+		}
+
+		if templateVersion != "v0.0.4" {
+			t.Errorf("Template version not updated. Expected 'v0.0.4', got '%s'", templateVersion)
+		}
+	})
+
+	// Test upgrade command with incompatible to devkit version
+	t.Run("Upgrade command with incompatible version", func(t *testing.T) {
+		// Create a flag set and context with no-op logger
+		set := flag.NewFlagSet("test", 0)
+		set.String("version", "v0.0.5", "")
+
+		// Create context with no-op logger and call Before hook
+		cmdWithLogger, _ := testutils.WithTestConfigAndNoopLoggerAndAccess(testCmd)
+		ctx := cli.NewContext(app, set, nil)
+
+		// Execute the Before hook to set up the logger context
+		if cmdWithLogger.Before != nil {
+			err := cmdWithLogger.Before(ctx)
+			if err != nil {
+				t.Fatalf("Before hook failed: %v", err)
+			}
+		}
+
 		// Run the upgrade command
 		err := cmdWithLogger.Action(ctx)
 		if err == nil {
-			t.Errorf("UpgradeCommand action should return error when version flag is missing")
+			t.Errorf("UpgradeCommand action should return error when using an incompatible version")
 		}
 	})
 

--- a/pkg/commands/template/upgrade_test.go
+++ b/pkg/commands/template/upgrade_test.go
@@ -63,6 +63,13 @@ func (m *MockTemplateInfoGetter) GetInfoDefault() (string, string, string, error
 	return m.projectName, m.templateURL, m.templateVersion, nil
 }
 
+func (m *MockTemplateInfoGetter) GetTemplateVersionFromConfig(arch, lang string) (string, error) {
+	if m.shouldReturnError {
+		return "", fmt.Errorf("config/config.yaml not found")
+	}
+	return m.templateVersion, nil
+}
+
 func TestUpgradeCommand(t *testing.T) {
 	// Create a temporary directory for testing
 	testProjectsDir, err := filepath.Abs(filepath.Join(os.TempDir(), "devkit-template-upgrade-test"))

--- a/pkg/commands/template/upgrade_test.go
+++ b/pkg/commands/template/upgrade_test.go
@@ -105,7 +105,7 @@ func TestUpgradeCommand(t *testing.T) {
 	mockTemplateInfoGetter := &MockTemplateInfoGetter{
 		projectName:     "template-upgrade-test",
 		templateURL:     "https://github.com/Layr-Labs/hourglass-avs-template",
-		templateVersion: "v0.0.3",
+		templateVersion: "v0.0.4",
 	}
 
 	// Create the test command with mocked dependencies

--- a/pkg/commands/transporter.go
+++ b/pkg/commands/transporter.go
@@ -392,6 +392,11 @@ func GetOnchainStakeTableRoots(cCtx *cli.Context) (map[uint64][32]byte, error) {
 
 	// Iterate and collect all roots for all chainIds
 	for i, chainId := range chainIds {
+		// Ignore 17000 from chainIds
+		if chainId.Uint64() == 17000 {
+			continue
+		}
+
 		// Use provided OperatorTableUpdaterTransactor address
 		addr := addresses[i]
 		chain, err := cm.GetChainForId(chainId.Uint64())

--- a/pkg/commands/upgrade.go
+++ b/pkg/commands/upgrade.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -86,7 +87,11 @@ func UpgradeDevkit(cCtx *cli.Context) error {
 	}
 
 	// Determine install location
-	binDir := filepath.Join(os.Getenv("HOME"), "bin")
+	path, err := exec.LookPath("devkit")
+	if err != nil {
+		return fmt.Errorf("could not locate current devkit binary: %w", err)
+	}
+	binDir := filepath.Dir(path)
 
 	// Perform the upgrade and source
 	return PerformUpgrade(targetVersion, binDir, logger)

--- a/pkg/commands/upgrade.go
+++ b/pkg/commands/upgrade.go
@@ -1,0 +1,187 @@
+package commands
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/Layr-Labs/devkit-cli/internal/version"
+	"github.com/Layr-Labs/devkit-cli/pkg/common"
+	"github.com/Layr-Labs/devkit-cli/pkg/common/iface"
+	"github.com/urfave/cli/v2"
+)
+
+// LatestRelease defines the subset of GitHub release fields we care about
+type LatestRelease struct {
+	TagName      string `json:"tag_name"`
+	TargetCommit string `json:"target_commitish"`
+}
+
+// UpgradeCommand defines the CLI command to upgrade the devkit binary and templates
+var UpgradeCommand = &cli.Command{
+	Name:  "upgrade",
+	Usage: "Upgrade devkit and template",
+	Flags: append([]cli.Flag{
+		&cli.StringFlag{
+			Name:  "version",
+			Usage: "Version to upgrade to (e.g. v0.0.8)",
+			Value: "latest",
+		},
+	}, common.GlobalFlags...),
+	Action: func(cCtx *cli.Context) error {
+		return UpgradeDevkit(cCtx)
+	},
+}
+
+// buildDownloadURL generates the download URL for a specific version and platform
+var buildDownloadURL = func(version, arch, distro string) string {
+	return "https://s3.amazonaws.com/eigenlayer-devkit-releases/" +
+		version + "/devkit-" + distro + "-" + arch + "-" + version + ".tar.gz"
+}
+
+// githubReleasesURL points to the latest GitHub release metadata
+var githubReleasesURL = "https://api.github.com/repos/Layr-Labs/devkit-cli/releases/latest"
+
+// UpgradeDevkit resolves the latest version if needed and invokes PerformUpgrade to install the new version
+func UpgradeDevkit(cCtx *cli.Context) error {
+	logger := common.LoggerFromContext(cCtx.Context)
+
+	// Get current version
+	currentVersion := version.GetVersion()
+	currentCommit := version.GetCommit()
+
+	// Get the version to be installed
+	targetVersion := cCtx.String("version")
+	var targetCommit = ""
+
+	// If version is 'latest', fetch it from GitHub
+	if targetVersion == "" || targetVersion == "latest" {
+		var err error
+		targetVersion, targetCommit, err = GetLatestVersionFromGitHub()
+		if err != nil {
+			return fmt.Errorf("could not get latest version: %w", err)
+		}
+	}
+
+	// Log upgrade
+	logger.Info("Upgrading devkit from %s (%s) to %s (%s)...", currentVersion, currentCommit, targetVersion, targetCommit[:7])
+
+	// Avoid redundant upgrade
+	if currentVersion == targetVersion && currentCommit == targetCommit[:7] {
+		return fmt.Errorf("already on latest version: %s commit: %s", currentVersion, currentCommit)
+	}
+
+	// Determine install location
+	binDir := filepath.Join(os.Getenv("HOME"), "bin")
+
+	// Perform the upgrade and source
+	return PerformUpgrade(targetVersion, binDir, logger)
+}
+
+// PerformUpgrade downloads and installs the target version of the devkit binary.
+// It supports both .tar.gz and raw .tar archive formats.
+func PerformUpgrade(version, binDir string, logger iface.Logger) error {
+	arch := strings.ToLower(runtime.GOARCH)
+	distro := strings.ToLower(runtime.GOOS)
+
+	url := buildDownloadURL(version, arch, distro)
+
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		return fmt.Errorf("failed to create bin dir: %w", err)
+	}
+
+	resp, err := http.Get(url)
+	if err != nil {
+		return fmt.Errorf("failed to download archive: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("bad response from server: %s", resp.Status)
+	}
+
+	// Detect format by content type and initialize appropriate tar reader
+	var tr *tar.Reader
+	contentType := resp.Header.Get("Content-Type")
+	switch {
+	case strings.Contains(contentType, "gzip"):
+		gzr, err := gzip.NewReader(resp.Body)
+		if err != nil {
+			return fmt.Errorf("gzip parse error: %w", err)
+		}
+		defer gzr.Close()
+		tr = tar.NewReader(gzr)
+
+	case strings.Contains(contentType, "x-tar"), strings.Contains(contentType, "application/octet-stream"):
+		tr = tar.NewReader(resp.Body)
+
+	default:
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("unexpected content type: %s\nBody: %s", contentType, string(body))
+	}
+
+	// Extract all files from the archive into the binDir
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("error reading tarball: %w", err)
+		}
+
+		targetPath := filepath.Join(binDir, filepath.Base(hdr.Name))
+		outFile, err := os.Create(targetPath)
+		if err != nil {
+			return fmt.Errorf("error creating file: %w", err)
+		}
+		if _, err := io.Copy(outFile, tr); err != nil {
+			outFile.Close()
+			return fmt.Errorf("error writing file: %w", err)
+		}
+		outFile.Close()
+
+		if err := os.Chmod(targetPath, 0755); err != nil {
+			return fmt.Errorf("error setting permissions: %w", err)
+		}
+		logger.Info("Installed: %s", targetPath)
+	}
+
+	logger.Info("Upgrade complete.")
+	return nil
+}
+
+// GetLatestVersionFromGitHub queries the GitHub releases API and returns the latest tag and commit
+func GetLatestVersionFromGitHub() (string, string, error) {
+	resp, err := http.Get(githubReleasesURL)
+	if err != nil {
+		return "", "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", "", fmt.Errorf("failed to fetch latest release: %s", resp.Status)
+	}
+
+	var data LatestRelease
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return "", "", err
+	}
+
+	if data.TagName == "" {
+		return "", "", fmt.Errorf("no tag_name in GitHub response")
+	}
+
+	if data.TargetCommit == "" {
+		return "", "", fmt.Errorf("no target_commitish in GitHub response")
+	}
+
+	return data.TagName, data.TargetCommit, nil
+}

--- a/pkg/commands/upgrade.go
+++ b/pkg/commands/upgrade.go
@@ -47,7 +47,14 @@ var buildDownloadURL = func(version, arch, distro string) string {
 }
 
 // githubReleasesURL points to the latest GitHub release metadata
-var githubReleasesURL = "https://api.github.com/repos/Layr-Labs/devkit-cli/releases/latest"
+var githubReleasesURL = func(version string) string {
+	baseUrl := "https://api.github.com/repos/Layr-Labs/devkit-cli/releases/"
+	if version == "latest" {
+		return baseUrl + version
+	} else {
+		return baseUrl + "tags/" + version
+	}
+}
 
 // UpgradeDevkit resolves the latest version if needed and invokes PerformUpgrade to install the new version
 func UpgradeDevkit(cCtx *cli.Context) error {
@@ -58,16 +65,16 @@ func UpgradeDevkit(cCtx *cli.Context) error {
 	currentCommit := version.GetCommit()
 
 	// Get the version to be installed
-	targetVersion := cCtx.String("version")
-	var targetCommit = ""
+	requestedVersion := cCtx.String("version")
+	// Default requestedVersion to "latest"
+	if requestedVersion == "" {
+		requestedVersion = "latest"
+	}
 
-	// If version is 'latest', fetch it from GitHub
-	if targetVersion == "" || targetVersion == "latest" {
-		var err error
-		targetVersion, targetCommit, err = GetLatestVersionFromGitHub()
-		if err != nil {
-			return fmt.Errorf("could not get latest version: %w", err)
-		}
+	// Pull release details from github
+	targetVersion, targetCommit, err := GetLatestVersionFromGitHub(requestedVersion)
+	if err != nil {
+		return fmt.Errorf("requested version %s does not exist: %w", requestedVersion, err)
 	}
 
 	// Log upgrade
@@ -159,15 +166,15 @@ func PerformUpgrade(version, binDir string, logger iface.Logger) error {
 }
 
 // GetLatestVersionFromGitHub queries the GitHub releases API and returns the latest tag and commit
-func GetLatestVersionFromGitHub() (string, string, error) {
-	resp, err := http.Get(githubReleasesURL)
+func GetLatestVersionFromGitHub(version string) (string, string, error) {
+	resp, err := http.Get(githubReleasesURL(version))
 	if err != nil {
 		return "", "", err
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return "", "", fmt.Errorf("failed to fetch latest release: %s", resp.Status)
+		return "", "", fmt.Errorf("failed to fetch release for version %s: %s", version, resp.Status)
 	}
 
 	var data LatestRelease

--- a/pkg/commands/upgrade_test.go
+++ b/pkg/commands/upgrade_test.go
@@ -73,10 +73,12 @@ func TestUpgrade_GetLatestVersionFromGitHub(t *testing.T) {
 
 	// Patch URL to use mock server
 	original := githubReleasesURL
-	githubReleasesURL = ts.URL + "/repos/Layr-Labs/devkit-cli/releases/latest"
+	githubReleasesURL = func(version string) string {
+		return ts.URL + "/repos/Layr-Labs/devkit-cli/releases/latest"
+	}
 	defer func() { githubReleasesURL = original }()
 
-	version, commit, err := GetLatestVersionFromGitHub()
+	version, commit, err := GetLatestVersionFromGitHub("latest")
 	assert.NoError(t, err)
 	assert.Equal(t, "v9.9.9", version)
 	assert.Equal(t, "aaaaaaa", commit)

--- a/pkg/commands/upgrade_test.go
+++ b/pkg/commands/upgrade_test.go
@@ -1,0 +1,83 @@
+package commands
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Layr-Labs/devkit-cli/pkg/common/logger"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUpgrade_PerformUpgrade(t *testing.T) {
+	// Create a fake tar.gz containing a single dummy binary file
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+
+	content := []byte("#!/bin/sh\necho devkit upgraded\n")
+	hdr := &tar.Header{
+		Name: "devkit",
+		Mode: 0755,
+		Size: int64(len(content)),
+	}
+	err := tw.WriteHeader(hdr)
+	assert.NoError(t, err)
+	_, err = tw.Write(content)
+	assert.NoError(t, err)
+	tw.Close()
+	gz.Close()
+
+	// Start a test server that returns the tarball
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(buf.Bytes())
+	}))
+	defer ts.Close()
+
+	// Patch the URL builder temporarily (for testing)
+	oldURLBuilder := buildDownloadURL
+	buildDownloadURL = func(version, arch, distro string) string {
+		return ts.URL // fake URL instead of real S3
+	}
+	defer func() { buildDownloadURL = oldURLBuilder }()
+
+	tmpDir := t.TempDir()
+	log := logger.NewNoopLogger()
+
+	err = PerformUpgrade("v0.0.1", tmpDir, log)
+	assert.NoError(t, err)
+
+	files, err := os.ReadDir(tmpDir)
+	assert.NoError(t, err)
+	assert.Len(t, files, 1)
+	assert.Equal(t, "devkit", files[0].Name())
+
+	path := filepath.Join(tmpDir, "devkit")
+	data, err := os.ReadFile(path)
+	assert.NoError(t, err)
+	assert.Contains(t, string(data), "echo devkit upgraded")
+}
+
+func TestUpgrade_GetLatestVersionFromGitHub(t *testing.T) {
+	// Fake GitHub API server
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/repos/Layr-Labs/devkit-cli/releases/latest", r.URL.Path)
+		_, _ = w.Write([]byte(`{"tag_name": "v9.9.9", "target_commitish": "aaaaaaa"}`))
+	}))
+	defer ts.Close()
+
+	// Patch URL to use mock server
+	original := githubReleasesURL
+	githubReleasesURL = ts.URL + "/repos/Layr-Labs/devkit-cli/releases/latest"
+	defer func() { githubReleasesURL = original }()
+
+	version, commit, err := GetLatestVersionFromGitHub()
+	assert.NoError(t, err)
+	assert.Equal(t, "v9.9.9", version)
+	assert.Equal(t, "aaaaaaa", commit)
+}

--- a/pkg/common/upgrade_context.go
+++ b/pkg/common/upgrade_context.go
@@ -1,1 +1,0 @@
-package common


### PR DESCRIPTION
<!-- 
    🚨 ATTENTION! 🚨 
    
    This PR template is REQUIRED. PRs not following this format will be closed without review.
    
    Requirements:
    - PR title must follow commit conventions: https://www.conventionalcommits.org/en/v1.0.0/
    - Label your PR with the correct type (e.g., 🐛 Bug, ✨ Enhancement, 🧪 Test, etc.)
    - Provide clear and specific details in each section
-->

**Motivation:**
<!--
Explain here the context, and why you're making that change. What is the problem you're trying to solve.
-->
As an AVS developer, I want a first-class command to upgrade my project to a newer version to take advtange of the latest features with no migration complexity.

**Modifications:**
<!--
Describe the modifications you've done from a high level. What are the key technical decisions and why were they made?
-->
- Adds `devkit upgrade` command
- Fetches latest release from github to pull version and commit
- Avoids redundant upgrades (by comparing current to target)
- Performs upgrade, installing to `~/bin`
- Updates `devkit avs template upgrade` to default to latest template known to devkit

**Result:**
<!--
*After your change, what will change.
-->
- Users can upgrade using `devkit upgrade` and `devkit avs template upgrade` without defining versions

**Testing:**
<!--
*List testing procedures taken and useful artifacts.
-->
- Added unit tests to verify upgrade logic
