### PR TITLE
fix: remove remote origin from config to ensure we create a clean repo

### DIFF
--- a/pkg/commands/create.go
+++ b/pkg/commands/create.go
@@ -402,6 +402,14 @@ func initGitRepo(ctx *cli.Context, targetDir string, logger iface.Logger) error 
 		return fmt.Errorf("git submodule registration failed: %w", err)
 	}
 
+	// remove remote origin from config
+	cmd = exec.CommandContext(ctx.Context, "git", "remote", "remove", "origin")
+	cmd.Dir = targetDir
+	output, err = cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to remove remote origin: %w\nOutput: %s", err, string(output))
+	}
+
 	// cleanup submodule backups
 	err = deleteBackup(targetDir)
 	if err != nil {


### PR DESCRIPTION
<!-- 
    🚨 ATTENTION! 🚨 
    
    This PR template is REQUIRED. PRs not following this format will be closed without review.
    
    Requirements:
    - PR title must follow commit conventions: https://www.conventionalcommits.org/en/v1.0.0/
    - Label your PR with the correct type (e.g., 🐛 Bug, ✨ Enhancement, 🧪 Test, etc.)
    - Provide clear and specific details in each section
-->

**Motivation:**
<!--
Explain here the context, and why you're making that change. What is the problem you're trying to solve.
-->
As a devkit user, I want to be able to create a project from the `hourglass-avs-template` and have a clean copy to work from in my projects repo.

**Modifications:**
<!--
Describe the modifications you've done from a high level. What are the key technical decisions and why were they made?
-->
- Added a `git remove remote origin` after cloning to ensure we start clean

**Result:**
<!--
*After your change, what will change.
-->
- New project will have no association to the repo we cloned from

**Testing:**
<!--
*List testing procedures taken and useful artifacts.
-->
- Tested manually
