### PR TITLE
fix: update release workflow to use holesky rpc url

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,8 +7,8 @@ on:
 
 env:
   FOUNDRY_PROFILE: ci
-  L1_FORK_URL: ${{ secrets.L1_FORK_URL }}
-  L2_FORK_URL: ${{ secrets.L2_FORK_URL }}
+  L1_FORK_URL: ${{ secrets.HOLESKY_FORK_URL }}
+  L2_FORK_URL: ${{ secrets.HOLESKY_FORK_URL }}
 
 jobs:
   lint:


### PR DESCRIPTION
<!-- 
    🚨 ATTENTION! 🚨 
    
    This PR template is REQUIRED. PRs not following this format will be closed without review.
    
    Requirements:
    - PR title must follow commit conventions: https://www.conventionalcommits.org/en/v1.0.0/
    - Label your PR with the correct type (e.g., 🐛 Bug, ✨ Enhancement, 🧪 Test, etc.)
    - Provide clear and specific details in each section
-->

**Motivation:**
<!--
Explain here the context, and why you're making that change. What is the problem you're trying to solve.
-->
As a devkit dev, I want to be certain that the e2e flow functions correctly on all release binaries.

**Modifications:**
<!--
Describe the modifications you've done from a high level. What are the key technical decisions and why were they made?
-->
- Set `L1_FORK_URL` and `L2_FORK_URL` to `secrets.HOLESKY_FORK_URL`

**Result:**
<!--
*After your change, what will change.
-->
- Release workflow will fork from the correct network
