### PR TITLE
feat: devkit avs test command support

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -54,6 +54,11 @@ jobs:
           cd ./my-awesome-avs/
           devkit avs build
 
+      - name: Run devkit avs test
+        run: |
+          cd ./my-awesome-avs/
+          devkit avs test
+
       - name: Start devnet
         run: |
           cd ./my-awesome-avs/

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Use DevKit to get from AVS idea to Proof of Concept with a local testing environ
 | `devkit avs config`   | Configure your Project (`config/config.yaml`) |
 | `devkit avs context`   | Configure your environment and AVS (`config/devnet.yaml`...) |
 | `devkit avs build`    | Compile AVS smart contracts and binaries                          |
+| `devkit avs test`     | Run Go and Forge tests for your AVS                              |
 | `devkit avs devnet`   | Manage local development network                                  |
 | `devkit avs call`     | Simulate AVS task execution locally                               |
 
@@ -219,7 +220,22 @@ Ensure you're in your project directory before running:
 devkit avs build
 ```
 
-### 5️⃣ Launch Local DevNet (`devkit avs devnet`)
+### 5️⃣ Test Your AVS (`devkit avs test`)
+
+Runs both off-chain unit tests and on-chain contract tests for your AVS. This command ensures your business logic and smart contracts are functioning correctly before deployment.
+
+* Executes Go tests for your offchain AVS logic
+* Runs Forge tests for your smart contracts
+
+Run this from your project directory:
+
+```bash
+devkit avs test
+```
+
+Both test suites must pass for the command to succeed.
+
+### 6️⃣ Launch Local DevNet (`devkit avs devnet`)
 
 Starts a local devnet to simulate the full AVS environment. This step deploys contracts, registers operators, and runs offchain infrastructure, allowing you to test and iterate without needing to interact with testnet or mainnet.
 
@@ -248,7 +264,7 @@ DevNet management commands:
 | `stop --project.name`  | Stops the specific project's devnet                                  |
 | `stop --port`  | Stops the specific port e.g.: `stop --port 8545`                                  |
 
-### 6️⃣ Simulate Task Execution (`devkit avs call`)
+### 7️⃣ Simulate Task Execution (`devkit avs call`)
 
 Triggers task execution through your AVS, simulating how a task would be submitted, processed, and validated. Useful for testing end-to-end behavior of your logic in a local environment.
 
@@ -264,7 +280,7 @@ devkit avs call --signature="(uint256,string)" args='(5,"hello")'
 
 Optionally, submit tasks directly to the on-chain TaskMailBox contract via a frontend or another method for more realistic testing scenarios.
 
-### 7️⃣ Publish AVS Release (`devkit avs release`)
+### 8️⃣ Publish AVS Release (`devkit avs release`)
 
 Publishes your AVS release to the EigenLayer ReleaseManager contract, making it available for operators to upgrade to.
 

--- a/config/templates.yaml
+++ b/config/templates.yaml
@@ -3,7 +3,7 @@ architectures:
     languages:
       go:
         baseUrl: "https://github.com/Layr-Labs/hourglass-avs-template"
-        version: "95f9067bd35b770e989d7d6442003e405d7639ae"
+        version: "1fe8f8bddac1276993d4d80bbc5fc98d4bd77966"
       ts:
         baseUrl: ""
         version: ""

--- a/pkg/commands/avs.go
+++ b/pkg/commands/avs.go
@@ -18,6 +18,7 @@ var AVSCommand = &cli.Command{
 		DevnetCommand,
 		TransportCommand,
 		RunCommand,
+		TestCommand,
 		CallCommand,
 		ReleaseCommand,
 		template.Command,

--- a/pkg/commands/test.go
+++ b/pkg/commands/test.go
@@ -1,0 +1,51 @@
+package commands
+
+import (
+	"fmt"
+	"github.com/Layr-Labs/devkit-cli/pkg/common/devnet"
+	"path/filepath"
+
+	"github.com/Layr-Labs/devkit-cli/pkg/common"
+
+	"github.com/urfave/cli/v2"
+)
+
+// TestCommand defines the "test" command
+var TestCommand = &cli.Command{
+	Name:  "test",
+	Usage: "Run AVS tests",
+	Flags: append([]cli.Flag{}, common.GlobalFlags...),
+	Action: func(cCtx *cli.Context) error {
+		// Invoke and return AVSTest
+		return AVSTest(cCtx)
+	},
+}
+
+func AVSTest(cCtx *cli.Context) error {
+	// Get logger
+	logger := common.LoggerFromContext(cCtx.Context)
+
+	// Print task if verbose
+	logger.Debug("Running AVS tests...")
+
+	// Run the script from root of project dir
+	const dir = ""
+
+	// Set path for .devkit scripts
+	scriptPath := filepath.Join(".devkit", "scripts", "test")
+
+	// Set path for context yaml
+	contextJSON, err := common.LoadRawContext(devnet.DEVNET_CONTEXT) // @TODO: use selected context name
+	if err != nil {
+		return fmt.Errorf("failed to load context: %w", err)
+	}
+
+	// Run test on the template test script
+	if _, err := common.CallTemplateScript(cCtx.Context, logger, dir, scriptPath, common.ExpectNonJSONResponse, contextJSON); err != nil {
+		return fmt.Errorf("test failed: %w", err)
+	}
+
+	logger.Info("AVS tests completed successfully!")
+
+	return nil
+}

--- a/pkg/commands/test_test.go
+++ b/pkg/commands/test_test.go
@@ -1,0 +1,117 @@
+package commands
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Layr-Labs/devkit-cli/pkg/common/logger"
+	"github.com/Layr-Labs/devkit-cli/pkg/testutils"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/urfave/cli/v2"
+)
+
+func setupTestApp(t *testing.T) (tmpDir string, restoreWD func(), app *cli.App, noopLogger *logger.NoopLogger) {
+	tmpDir, err := testutils.CreateTempAVSProject(t)
+	assert.NoError(t, err)
+
+	// Create the test script
+	scriptsDir := filepath.Join(tmpDir, ".devkit", "scripts")
+	testScript := `#!/bin/bash
+echo "Running tests..."
+exit 0`
+	err = os.WriteFile(filepath.Join(scriptsDir, "test"), []byte(testScript), 0755)
+	assert.NoError(t, err)
+
+	oldWD, err := os.Getwd()
+	assert.NoError(t, err)
+	assert.NoError(t, os.Chdir(tmpDir))
+
+	restore := func() {
+		_ = os.Chdir(oldWD)
+		os.RemoveAll(tmpDir)
+	}
+
+	cmdWithLogger, logger := testutils.WithTestConfigAndNoopLoggerAndAccess(TestCommand)
+	app = &cli.App{
+		Name:     "test",
+		Commands: []*cli.Command{cmdWithLogger},
+	}
+
+	return tmpDir, restore, app, logger
+}
+
+func TestTestCommand_ExecutesSuccessfully(t *testing.T) {
+	_, restore, app, l := setupTestApp(t)
+	defer restore()
+
+	err := app.Run([]string{"app", "test", "--verbose"})
+	assert.NoError(t, err)
+
+	// Check that the expected message was logged
+	assert.True(t, l.Contains("AVS tests completed successfully"),
+		"Expected 'AVS tests completed successfully' to be logged")
+}
+
+func TestTestCommand_MissingDevnetYAML(t *testing.T) {
+	tmpDir, restore, app, _ := setupTestApp(t)
+	defer restore()
+
+	os.Remove(filepath.Join(tmpDir, "config", "contexts", "devnet.yaml"))
+
+	err := app.Run([]string{"app", "test"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to load context")
+}
+
+func TestTestCommand_MissingScript(t *testing.T) {
+	tmpDir, restore, app, _ := setupTestApp(t)
+	defer restore()
+
+	os.Remove(filepath.Join(tmpDir, ".devkit", "scripts", "test"))
+
+	err := app.Run([]string{"app", "test"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no such file or directory")
+}
+
+func TestTestCommand_ScriptReturnsNonZero(t *testing.T) {
+	tmpDir, restore, app, _ := setupTestApp(t)
+	defer restore()
+
+	scriptPath := filepath.Join(tmpDir, ".devkit", "scripts", "test")
+	failScript := "#!/bin/bash\nexit 1"
+	err := os.WriteFile(scriptPath, []byte(failScript), 0755)
+	assert.NoError(t, err)
+
+	err = app.Run([]string{"app", "test"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "test failed")
+}
+
+func TestTestCommand_Cancelled(t *testing.T) {
+	_, restore, app, _ := setupTestApp(t)
+	defer restore()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	result := make(chan error)
+	go func() {
+		result <- app.RunContext(ctx, []string{"app", "test"})
+	}()
+	cancel()
+
+	select {
+	case err := <-result:
+		if err != nil && errors.Is(err, context.Canceled) {
+			t.Log("Test exited cleanly after context cancellation")
+		} else {
+			t.Errorf("Unexpected exit result: %v", err)
+		}
+	case <-time.After(1 * time.Second):
+		t.Error("Test command did not exit after context cancellation")
+	}
+}

--- a/pkg/template/config_test.go
+++ b/pkg/template/config_test.go
@@ -17,7 +17,7 @@ func TestLoadConfig(t *testing.T) {
 	}
 
 	expectedBaseURL := "https://github.com/Layr-Labs/hourglass-avs-template"
-	expectedVersion := "95f9067bd35b770e989d7d6442003e405d7639ae"
+	expectedVersion := "1fe8f8bddac1276993d4d80bbc5fc98d4bd77966"
 
 	if mainBaseURL != expectedBaseURL {
 		t.Errorf("Unexpected main template base URL: got %s, want %s", mainBaseURL, expectedBaseURL)


### PR DESCRIPTION
<!-- 
    🚨 ATTENTION! 🚨 
    
    This PR template is REQUIRED. PRs not following this format will be closed without review.
    
    Requirements:
    - PR title must follow commit conventions: https://www.conventionalcommits.org/en/v1.0.0/
    - Label your PR with the correct type (e.g., 🐛 Bug, ✨ Enhancement, 🧪 Test, etc.)
    - Provide clear and specific details in each section
-->

**Motivation:**
To improve the development & release cycle of AVS development we are introducing a `devkit avs test` command which invokes the template's test harness. This harness can do arbitrary things, like configure integration test assets or generate test bindings. For now, it just invokes the `make test` target.

**Modifications:**
- Basic test command implementation to invoke the template hook.

**Result:**
- AVS templates now have a standardized means to provide testing resources for AVS developers.

**Testing:**
Tested Locally

``` 
brandonchatham@Brandons-MacBook-Pro boop % ./devkit avs test
Warning: This is a nightly build of Foundry. It is recommended to use the latest stable version. Visit https://book.getfoundry.sh/announcements for more information. 
To mute this warning set `FOUNDRY_DISABLE_NIGHTLY_WARNING` in your environment. 

2025/06/30 10:43:58 go test ./... -v -p 1
2025/06/30 10:43:58 === RUN   Test_TaskRequestPayload
2025/06/30 10:43:58 2025-06-30T10:14:32.839-0700	INFO	cmd/main.go:31	Validating task	{"task": "task_id:\"test-task-id\"  payload:\"test-data\"  metadata:\"test-metadata\""}
2025/06/30 10:43:58 2025-06-30T10:14:32.840-0700	INFO	cmd/main.go:45	Handling task	{"task": "task_id:\"test-task-id\"  payload:\"test-data\"  metadata:\"test-metadata\""}
2025/06/30 10:43:58     main_test.go:38: Response: task_id:"test-task-id"
2025/06/30 10:43:58 --- PASS: Test_TaskRequestPayload (0.00s)
2025/06/30 10:43:58 PASS
2025/06/30 10:43:58 ok  	github.com/Layr-Labs/hourglass-avs-template/cmd	(cached)
2025/06/30 10:43:58 cd .devkit/contracts && forge test
2025/06/30 10:43:58 Compiling 21 files with Solc 0.8.27
2025/06/30 10:43:58 Solc 0.8.27 finished in 479.88ms
2025/06/30 10:43:58 Compiler run successful!
2025/06/30 10:43:58 /Users/brandonchatham/sandbox/ponos/devkit-cli/boop/contracts/test/HelloWorld.t.sol:HelloWorldTest
2025/06/30 10:43:58   ↪ Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 3.54ms (687.88µs CPU time)
2025/06/30 10:43:58 
2025/06/30 10:43:58 Ran 1 test for /Users/brandonchatham/sandbox/ponos/devkit-cli/boop/contracts/test/HelloWorld.t.sol:HelloWorldTest
2025/06/30 10:43:58 [PASS] testSetMessage() (gas: 13520)
2025/06/30 10:43:58 Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 3.54ms (687.88µs CPU time)
2025/06/30 10:43:58 
2025/06/30 10:43:58 Ran 1 test suite in 128.32ms (3.54ms CPU time): 1 tests passed, 0 failed, 0 skipped (1 total tests)
2025/06/30 10:43:58 AVS tests completed successfully!
```

**Open questions:**
- What sorts of bootstrapped tooling might AVS developers want?