### PR TITLE
feat: add single-command install script

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,143 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+EigenLayer DevKit is a CLI toolkit for scaffolding, developing, and testing EigenLayer Autonomous Verifiable Services (AVS). It's built in Go and focuses on the Hourglass task-based architecture. The DevKit is currently in closed alpha and intended for local experimentation and development only.
+
+## Common Development Commands
+
+### Building and Testing
+```bash
+# Build the CLI binary
+make build
+
+# Run all tests (may be slow)
+make tests
+
+# Run fast tests (skips slow integration tests) 
+make tests-fast
+
+# Install binary to ~/bin/ and set up shell completion
+make install
+
+# Format code
+make fmt
+
+# Run linter
+make lint
+
+# Clean up build artifacts
+make clean
+```
+
+### Testing the CLI
+After building, test the CLI:
+```bash
+./bin/devkit --help
+./bin/devkit avs --help
+```
+
+### Cross-platform Builds
+```bash
+# Build for specific platforms
+make build/darwin-arm64
+make build/darwin-amd64  
+make build/linux-arm64
+make build/linux-amd64
+
+# Build all platforms
+make release
+```
+
+## Architecture Overview
+
+### CLI Command Structure
+The CLI is built with `urfave/cli/v2` and organized hierarchically:
+- **Main entry**: `cmd/devkit/main.go`
+- **Core commands**: All under `devkit avs` subcommand
+- **Command implementations**: `pkg/commands/` directory
+
+Key commands:
+- `devkit avs create` - Scaffold new AVS projects from templates
+- `devkit avs build` - Compile contracts and binaries via template scripts
+- `devkit avs devnet` - Manage local Docker-based development networks
+- `devkit avs call` - Simulate task execution
+- `devkit avs config/context` - Configuration management
+
+### Configuration System
+Multi-layered configuration with migration support:
+
+1. **Global Config** (`~/.config/devkit/config.yaml`): User preferences, telemetry settings
+2. **Project Config** (`config/config.yaml`): Project metadata, template info
+3. **Context Config** (`config/contexts/{context}.yaml`): Environment-specific settings (devnet, testnet, mainnet)
+
+**Current Versions**: Config v0.0.2, Context v0.0.6
+
+The system includes automatic migrations between versions via `pkg/migration/` that preserve user customizations.
+
+### Template System Architecture
+Projects are scaffolded from versioned Git templates:
+- **Template registry**: `config/templates.yaml` defines available templates
+- **Template fetching**: `pkg/template/git_fetcher.go` handles Git operations
+- **Project initialization**: Templates provide `.devkit/scripts/init` for setup
+- **Build/run integration**: Templates provide `.devkit/scripts/build` and `.devkit/scripts/run`
+
+### Devnet System
+The devnet management system (`pkg/commands/devnet.go`) provides:
+- Local Docker-based Anvil chains with EigenLayer state forked from Holesky
+- Automated contract deployment (L1/L2)
+- Pre-funded test operators with BLS keystores
+- AVS registration and operator management
+
+### Package Organization
+- **`pkg/commands/`**: CLI command implementations
+- **`pkg/common/`**: Shared utilities, configuration, contracts, logging
+- **`pkg/template/`**: Git-based template management
+- **`pkg/telemetry/`**: PostHog analytics integration  
+- **`pkg/migration/`**: Configuration migration system
+- **`pkg/hooks/`**: Command lifecycle hooks
+
+## Key Dependencies
+
+- **Go 1.23.6+** required
+- **EigenLayer contracts**: `github.com/Layr-Labs/eigenlayer-contracts`
+- **Hourglass AVS**: `github.com/Layr-Labs/hourglass-monorepo/ponos`
+- **External tools**: Docker, Foundry, Zeus (npm package `@layr-labs/zeus@1.5.2`)
+
+## Development Environment Setup
+
+1. Install prerequisites: Docker, Foundry, Go 1.23.6+, make, jq, yq
+2. Clone repository and run `make install`
+3. Zeus is automatically installed as npm global package during `make install`
+
+## Testing Patterns
+
+- Unit tests use standard Go testing
+- Integration tests may require Docker and external dependencies
+- Use `make tests-fast` for quick feedback during development
+- Integration tests in `test/integration/` directory
+
+## Configuration Migration
+
+When adding new configuration fields:
+1. Update config structs in `pkg/common/`
+2. Create migration in `config/configs/migrations/` or `config/contexts/migrations/`
+3. Update embedded config versions in `config/`
+4. Test migration with existing project configs
+
+## Template Development
+
+Templates must provide:
+- `.devkit/scripts/init` - Project initialization
+- `.devkit/scripts/build` - Build script for contracts/binaries
+- `.devkit/scripts/run` - Run script for AVS components
+- Standard Go project structure for task-based architecture
+
+## Telemetry System
+
+Optional PostHog-based telemetry with:
+- Global and project-level opt-in/opt-out
+- Privacy-conscious data collection
+- CI environment auto-detection (defaults to disabled)

--- a/README.md
+++ b/README.md
@@ -15,6 +15,47 @@ Use DevKit to get from AVS idea to Proof of Concept with a local testing environ
 
 > **Note:** The current DevKit features support local experimentation, development, and testing of AVS using the Hourglass task-based framework. We're actively expanding capabilities, so if there's a gap for your scenario, check out our roadmap to see what's coming, or let us know what would support you in building AVS.
 
+## 📦 Installation
+
+**Quick Install (Recommended):**
+```bash
+curl -fsSL https://raw.githubusercontent.com/Layr-Labs/devkit-cli/main/install-devkit.sh | bash
+```
+
+**Manual Installation:**
+
+Download the binary for your platform:
+```bash
+# macOS (Apple Silicon)
+mkdir -p $HOME/bin && curl -sL https://s3.amazonaws.com/eigenlayer-devkit-releases/v0.0.9/devkit-darwin-arm64-v0.0.9.tar.gz | tar xz -C "$HOME/bin"
+
+# macOS (Intel)
+mkdir -p $HOME/bin && curl -sL https://s3.amazonaws.com/eigenlayer-devkit-releases/v0.0.9/devkit-darwin-amd64-v0.0.9.tar.gz | tar xz -C "$HOME/bin"
+
+# Linux (x86_64 / AMD64)
+mkdir -p $HOME/bin && curl -sL https://s3.amazonaws.com/eigenlayer-devkit-releases/v0.0.9/devkit-linux-amd64-v0.0.9.tar.gz | tar xz -C "$HOME/bin"
+
+# Linux (ARM64 / aarch64)
+mkdir -p $HOME/bin && curl -sL https://s3.amazonaws.com/eigenlayer-devkit-releases/v0.0.9/devkit-linux-arm64-v0.0.9.tar.gz | tar xz -C "$HOME/bin"
+```
+
+Add to your PATH:
+```bash
+export PATH=$PATH:~/bin
+```
+
+**Install from Source:**
+```bash
+git clone https://github.com/Layr-Labs/devkit-cli
+cd devkit-cli
+make install
+```
+
+**Verify Installation:**
+```bash
+devkit --help
+```
+
 ![EigenLayer DevKit User Flow](assets/devkit-user-flow.png)
 
 ## 🌟 Key Commands Overview
@@ -53,43 +94,6 @@ devkit avs create my-avs-project ./
 
 
 
-### 📦 Installation
-
-To download a binary for the latest release, run:
-```bash
-# macOS (Apple Silicon)
-mkdir -p $HOME/bin && curl -sL https://s3.amazonaws.com/eigenlayer-devkit-releases/v0.0.9/devkit-darwin-arm64-v0.0.9.tar.gz | tar xv -C "$HOME/bin"
-
-# macOS (Intel)
-mkdir -p $HOME/bin && curl -sL https://s3.amazonaws.com/eigenlayer-devkit-releases/v0.0.9/devkit-darwin-amd64-v0.0.9.tar.gz | tar xv -C "$HOME/bin"
-
-# Linux (x86_64 / AMD64)
-mkdir -p $HOME/bin && curl -sL https://s3.amazonaws.com/eigenlayer-devkit-releases/v0.0.9/devkit-linux-amd64-v0.0.9.tar.gz | tar xv -C "$HOME/bin"
-
-# Linux (ARM64 / aarch64)
-mkdir -p $HOME/bin && curl -sL https://s3.amazonaws.com/eigenlayer-devkit-releases/v0.0.9/devkit-linux-arm64-v0.0.9.tar.gz | tar xv -C "$HOME/bin"
-```
-
-The binary will be installed inside the ~/bin directory.
-
-To add the binary to your path, run:
-```bash
-export PATH=$PATH:~/bin
-```
-
-To build and install the devkit cli from source:
-```bash
-mkdir -p $HOME/bin
-git clone https://github.com/Layr-Labs/devkit-cli
-cd devkit-cli
-make install
-export PATH=$PATH:~/bin
-```
-
-Verify your installation:
-```bash
-devkit --help
-```
 
 ### 🔧 Shell Completion (Optional)
 

--- a/install-devkit.sh
+++ b/install-devkit.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+set -e
+
+# DevKit version
+DEVKIT_VERSION="v0.0.9"
+DEVKIT_BASE_URL="https://s3.amazonaws.com/eigenlayer-devkit-releases"
+
+# Detect platform
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m)
+
+case $OS in
+    darwin) OS="darwin" ;;
+    linux) OS="linux" ;;
+    *) echo "Error: Unsupported OS: $OS"; exit 1 ;;
+esac
+
+case $ARCH in
+    x86_64|amd64) ARCH="amd64" ;;
+    arm64|aarch64) ARCH="arm64" ;;
+    *) echo "Error: Unsupported architecture: $ARCH"; exit 1 ;;
+esac
+
+PLATFORM="${OS}-${ARCH}"
+
+# Prompt for installation directory
+echo "Where would you like to install DevKit?"
+echo "1) $HOME/bin (recommended)"
+echo "2) /usr/local/bin (system-wide, requires sudo)"
+echo "3) Custom path"
+read -p "Enter choice (1-3) [1]: " choice
+
+case ${choice:-1} in
+    1) INSTALL_DIR="$HOME/bin" ;;
+    2) INSTALL_DIR="/usr/local/bin" ;;
+    3) 
+        read -p "Enter custom path: " INSTALL_DIR
+        if [[ -z "$INSTALL_DIR" ]]; then
+            echo "Error: No path provided"
+            exit 1
+        fi
+        ;;
+    *) echo "Invalid choice"; exit 1 ;;
+esac
+
+# Create directory if it doesn't exist
+if [[ "$INSTALL_DIR" == "/usr/local/bin" ]]; then
+    sudo mkdir -p "$INSTALL_DIR"
+else
+    mkdir -p "$INSTALL_DIR"
+fi
+
+# Download and install
+DEVKIT_URL="${DEVKIT_BASE_URL}/${DEVKIT_VERSION}/devkit-${PLATFORM}-${DEVKIT_VERSION}.tar.gz"
+echo "Downloading DevKit ${DEVKIT_VERSION} for ${PLATFORM}..."
+
+if [[ "$INSTALL_DIR" == "/usr/local/bin" ]]; then
+    curl -sL "$DEVKIT_URL" | sudo tar xz -C "$INSTALL_DIR"
+else
+    curl -sL "$DEVKIT_URL" | tar xz -C "$INSTALL_DIR"
+fi
+
+echo "✅ DevKit installed to $INSTALL_DIR/devkit"
+
+# Add to PATH if needed
+if [[ "$INSTALL_DIR" == "$HOME/bin" ]] && [[ ":$PATH:" != *":$HOME/bin:"* ]]; then
+    echo "💡 Add $HOME/bin to your PATH:"
+    echo "   echo 'export PATH=\"\$HOME/bin:\$PATH\"' >> ~/.$(basename $SHELL)rc"
+fi
+
+echo "🚀 Verify installation: $INSTALL_DIR/devkit --help"

--- a/install-devkit.sh
+++ b/install-devkit.sh
@@ -25,11 +25,18 @@ esac
 PLATFORM="${OS}-${ARCH}"
 
 # Prompt for installation directory
-echo "Where would you like to install DevKit?"
-echo "1) $HOME/bin (recommended)"
-echo "2) /usr/local/bin (system-wide, requires sudo)"
-echo "3) Custom path"
-read -p "Enter choice (1-3) [1]: " choice
+if [[ -t 0 ]]; then
+    # Interactive terminal available
+    echo "Where would you like to install DevKit?"
+    echo "1) $HOME/bin (recommended)"
+    echo "2) /usr/local/bin (system-wide, requires sudo)"
+    echo "3) Custom path"
+    read -p "Enter choice (1-3) [1]: " choice
+else
+    # Non-interactive (piped), use default
+    echo "Installing to $HOME/bin (default for non-interactive install)"
+    choice=1
+fi
 
 case ${choice:-1} in
     1) INSTALL_DIR="$HOME/bin" ;;

--- a/install-devkit.sh
+++ b/install-devkit.sh
@@ -3,7 +3,7 @@
 set -e
 
 # DevKit version
-DEVKIT_VERSION="v0.0.9"
+DEVKIT_VERSION=$(curl -fsSL https://raw.githubusercontent.com/Layr-Labs/devkit-cli/main/VERSION)
 DEVKIT_BASE_URL="https://s3.amazonaws.com/eigenlayer-devkit-releases"
 
 # Detect platform


### PR DESCRIPTION
**Motivation:**

Give new users a single "curl-pipe-bash" one-liner to install the devkit. Move the install instructions to the top of the readme to make it more accessible.

**Modifications:**

* `install-devkit.sh` script
* updated readme
* introduce the AI overlord, I mean, Claude
