### PR TITLE
fix: pin template to avs script commit

### DIFF
--- a/config/templates.yaml
+++ b/config/templates.yaml
@@ -3,7 +3,7 @@ architectures:
     languages:
       go:
         baseUrl: "https://github.com/Layr-Labs/hourglass-avs-template"
-        version: "1fe8f8bddac1276993d4d80bbc5fc98d4bd77966"
+        version: "a39911dd514ae2ca8248b871037f93b35685129a"
       ts:
         baseUrl: ""
         version: ""

--- a/pkg/template/config_test.go
+++ b/pkg/template/config_test.go
@@ -17,7 +17,7 @@ func TestLoadConfig(t *testing.T) {
 	}
 
 	expectedBaseURL := "https://github.com/Layr-Labs/hourglass-avs-template"
-	expectedVersion := "1fe8f8bddac1276993d4d80bbc5fc98d4bd77966"
+	expectedVersion := "a39911dd514ae2ca8248b871037f93b35685129a"
 
 	if mainBaseURL != expectedBaseURL {
 		t.Errorf("Unexpected main template base URL: got %s, want %s", mainBaseURL, expectedBaseURL)


### PR DESCRIPTION
<!-- 
    🚨 ATTENTION! 🚨 
    
    This PR template is REQUIRED. PRs not following this format will be closed without review.
    
    Requirements:
    - PR title must follow commit conventions: https://www.conventionalcommits.org/en/v1.0.0/
    - Label your PR with the correct type (e.g., 🐛 Bug, ✨ Enhancement, 🧪 Test, etc.)
    - Provide clear and specific details in each section
-->

**Motivation:**
<!--
Explain here the context, and why you're making that change. What is the problem you're trying to solve.
-->
The pinned template commit has been merged into https://github.com/Layr-Labs/hourglass-avs-template/commits/release/l1-l2-support/ and is missing from the `hourglass-avs-template` repo.

**Modifications:**
<!--
Describe the modifications you've done from a high level. What are the key technical decisions and why were they made?
-->
- Pins to the merged commit

**Result:**
<!--
*After your change, what will change.
-->
- Creates succeed
