### PR TITLE
feat: add e2e coverage for release publish command

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -54,6 +54,11 @@ jobs:
           cd ./my-awesome-avs/
           devkit avs build
 
+      - name: Run devkit avs test
+        run: |
+          cd ./my-awesome-avs/
+          devkit avs test
+
       - name: Start devnet
         run: |
           cd ./my-awesome-avs/

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -87,6 +87,28 @@ jobs:
           cd ./my-awesome-avs/
           devkit avs transport verify
 
+      - name: Test release publish
+        run: |
+          cd ./my-awesome-avs/
+          
+          CURRENT_VERSION=$(grep -A 1 "artifact:" config/contexts/devnet.yaml | grep "version:" | awk '{print $2}' | tr -d '"')
+          echo "Current version: ${CURRENT_VERSION:-empty}"
+          
+          UPGRADE_TIME=$(date -d "+10 minutes" +%s)
+          
+          echo "Publishing release with upgrade time: $UPGRADE_TIME"
+          devkit avs release publish --upgrade-by-time $UPGRADE_TIME --registry localhost:5001
+          
+          NEW_VERSION=$(grep -A 1 "artifact:" config/contexts/devnet.yaml | grep "version:" | awk '{print $2}' | tr -d '"')
+          echo "New version: $NEW_VERSION"
+          
+          if [ "$NEW_VERSION" = "1" ] || [ "$NEW_VERSION" -gt 0 ]; then
+            echo "✅ Release published successfully, version updated to: $NEW_VERSION"
+          else
+            echo "❌ Release publish failed - version not updated"
+            exit 1
+          fi
+
       - name: Stop devnet
         run: |
           cd ./my-awesome-avs/

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -109,14 +109,6 @@ jobs:
           docker push localhost:5001/my-awesome-avs:latest
           echo "✅ AVS image pushed to local registry"
 
-      - name: Update config for local registry
-        run: |
-          cd ./my-awesome-avs/
-          # Update the artifact registry in context to use local registry
-          yq eval '.context.artifact.registry = "localhost:5001"' -i config/contexts/devnet.yaml
-          echo "Updated registry configuration:"
-          yq eval '.context.artifact' config/contexts/devnet.yaml
-
       - name: Publish AVS release
         run: |
           cd ./my-awesome-avs/
@@ -146,84 +138,48 @@ jobs:
           RELEASE_MANAGER_ADDRESS="0x323A9FcB2De80d04B5C4B0F72ee7799100D32F0F"
           echo "ReleaseManager Address: $RELEASE_MANAGER_ADDRESS"
           
-          # Query the ReleaseManager contract to verify the release
-          echo "Querying ReleaseManager for operator set 0..."
+          # Query the ReleaseManager contract to verify releases for both operator sets
+          echo "Verifying releases for operator sets 0 and 1..."
           
-          # Get the latest version
-          LATEST_VERSION=$(cast call $RELEASE_MANAGER_ADDRESS \
-            "latestVersion(address,uint32)" \
-            $AVS_ADDRESS 0 \
-            --rpc-url http://localhost:8545)
-          
-          echo "Latest version for operator set 0: $LATEST_VERSION"
-          
-          VERSION_DEC=$((LATEST_VERSION))
-          echo "Latest version (decimal): $VERSION_DEC"
-          
-          if [ $VERSION_DEC -eq 0 ]; then
-            echo "❌ No release found on ReleaseManager"
-            exit 1
-          fi
-          
-          # Get release details
-          RELEASE_DATA=$(cast call $RELEASE_MANAGER_ADDRESS \
-            "getRelease(address,uint32,uint256)" \
-            $AVS_ADDRESS 0 $((VERSION_DEC - 1)) \
-            --rpc-url http://localhost:8545)
-          
-          echo "Release data retrieved: $RELEASE_DATA"
-          
-          if [ -z "$RELEASE_DATA" ] || [ "$RELEASE_DATA" = "0x" ]; then
-            echo "❌ Release data is empty"
-            exit 1
-          fi
-          
-          echo "✅ Release verified on ReleaseManager contract"
-
-      - name: Test multiple operator sets release
-        run: |
-          cd ./my-awesome-avs/
-          
-          # Create another operator set
-          echo "Creating operator set 1..."
-          DEPLOYER_KEY=$(yq eval '.context.deployer_private_key' config/contexts/devnet.yaml)
-          AVS_ADDRESS=$(yq eval '.context.avs.address' config/contexts/devnet.yaml)
-          ALLOCATION_MANAGER_ADDRESS="0x76f67c84eF6F6cF76ec52b4cEFa28ca7492Bd43a"
-          
-          # Use cast to create operator set
-          cast send $ALLOCATION_MANAGER_ADDRESS \
-            "createOperatorSets(address,(uint32,address[])[])" \
-            $AVS_ADDRESS "[(1,[])]" \
-            --private-key $DEPLOYER_KEY \
-            --rpc-url http://localhost:8545
-          
-          echo "✅ Operator set 1 created"
-          
-          # Publish release for multiple operator sets
-          UPGRADE_BY_TIME=$(($(date +%s) + 7200))  # 2 hours from now
-          
-          devkit avs release publish --upgrade-by-time $UPGRADE_BY_TIME --registry localhost:5001
-          
-          # Verify both operator sets have releases
+          # The release publish command updates both operator sets 0 and 1
           for OPSET in 0 1; do
+            echo "Checking operator set $OPSET..."
+            
+            # Get the latest version
             LATEST_VERSION=$(cast call $RELEASE_MANAGER_ADDRESS \
               "latestVersion(address,uint32)" \
               $AVS_ADDRESS $OPSET \
               --rpc-url http://localhost:8545)
             
+            echo "Latest version for operator set $OPSET: $LATEST_VERSION"
+            
             VERSION_DEC=$((LATEST_VERSION))
-            echo "Operator set $OPSET latest version: $VERSION_DEC"
+            echo "Latest version (decimal): $VERSION_DEC"
             
             if [ $VERSION_DEC -eq 0 ]; then
               echo "❌ No release found for operator set $OPSET"
               exit 1
             fi
+            
+            # Get release details
+            RELEASE_DATA=$(cast call $RELEASE_MANAGER_ADDRESS \
+              "getRelease(address,uint32,uint256)" \
+              $AVS_ADDRESS $OPSET $((VERSION_DEC - 1)) \
+              --rpc-url http://localhost:8545)
+            
+            echo "Release data retrieved for operator set $OPSET: $RELEASE_DATA"
+            
+            if [ -z "$RELEASE_DATA" ] || [ "$RELEASE_DATA" = "0x" ]; then
+              echo "❌ Release data is empty for operator set $OPSET"
+              exit 1
+            fi
+            
+            echo "✅ Release verified for operator set $OPSET"
           done
           
-          echo "✅ Releases published for multiple operator sets"
+          echo "✅ All releases verified on ReleaseManager contract"
 
       - name: Stop local Docker registry
-        if: always()
         run: |
           docker stop registry || true
           docker rm registry || true

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -143,7 +143,6 @@ jobs:
           AVS_ADDRESS=$(yq eval '.context.avs.address' config/contexts/devnet.yaml)
           echo "AVS Address: $AVS_ADDRESS"
           
-          # Use the correct ReleaseManager address from devnet constants
           RELEASE_MANAGER_ADDRESS="0x323A9FcB2De80d04B5C4B0F72ee7799100D32F0F"
           echo "ReleaseManager Address: $RELEASE_MANAGER_ADDRESS"
           
@@ -158,7 +157,6 @@ jobs:
           
           echo "Latest version for operator set 0: $LATEST_VERSION"
           
-          # Convert hex to decimal
           VERSION_DEC=$((LATEST_VERSION))
           echo "Latest version (decimal): $VERSION_DEC"
           
@@ -175,7 +173,6 @@ jobs:
           
           echo "Release data retrieved: $RELEASE_DATA"
           
-          # Check if release data is not empty
           if [ -z "$RELEASE_DATA" ] || [ "$RELEASE_DATA" = "0x" ]; then
             echo "❌ Release data is empty"
             exit 1
@@ -205,7 +202,6 @@ jobs:
           # Publish release for multiple operator sets
           UPGRADE_BY_TIME=$(($(date +%s) + 7200))  # 2 hours from now
           
-          # The release script should handle multiple operator sets
           devkit avs release publish --upgrade-by-time $UPGRADE_BY_TIME --registry localhost:5001
           
           # Verify both operator sets have releases

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -87,27 +87,150 @@ jobs:
           cd ./my-awesome-avs/
           devkit avs transport verify
 
-      - name: Test release publish
+      - name: Start local Docker registry
+        run: |
+          docker run -d --name registry -p 5001:5000 registry:2
+          echo "Waiting for registry to be ready..."
+          for i in {1..10}; do
+            if nc -z localhost 5001; then
+              echo "✅ Registry is ready"
+              break
+            fi
+            echo "Waiting for registry... ($i/10)"
+            sleep 2
+          done
+
+      - name: Build and push AVS image to local registry
+        run: |
+          cd ./my-awesome-avs/
+          # Build the AVS image
+          docker build -t localhost:5001/my-awesome-avs:latest .
+          # Push to local registry
+          docker push localhost:5001/my-awesome-avs:latest
+          echo "✅ AVS image pushed to local registry"
+
+      - name: Update config for local registry
+        run: |
+          cd ./my-awesome-avs/
+          # Update the artifact registry in context to use local registry
+          yq eval '.context.artifact.registry = "localhost:5001"' -i config/contexts/devnet.yaml
+          echo "Updated registry configuration:"
+          yq eval '.context.artifact' config/contexts/devnet.yaml
+
+      - name: Publish AVS release
+        run: |
+          cd ./my-awesome-avs/
+          # Get current timestamp + 1 hour for upgrade-by-time
+          UPGRADE_BY_TIME=$(($(date +%s) + 3600))
+          echo "Publishing release with upgrade-by-time: $UPGRADE_BY_TIME ($(date -d @$UPGRADE_BY_TIME))"
+          
+          # Run the release publish command
+          devkit avs release publish --upgrade-by-time $UPGRADE_BY_TIME --registry localhost:5001
+          
+          # Check if the command succeeded
+          if [ $? -eq 0 ]; then
+            echo "✅ Release published successfully"
+          else
+            echo "❌ Release publish failed"
+            exit 1
+          fi
+
+      - name: Verify release on ReleaseManager contract
         run: |
           cd ./my-awesome-avs/
           
-          CURRENT_VERSION=$(grep -A 1 "artifact:" config/contexts/devnet.yaml | grep "version:" | awk '{print $2}' | tr -d '"')
-          echo "Current version: ${CURRENT_VERSION:-empty}"
+          # Get AVS address from context
+          AVS_ADDRESS=$(yq eval '.context.avs.address' config/contexts/devnet.yaml)
+          echo "AVS Address: $AVS_ADDRESS"
           
-          UPGRADE_TIME=$(date -d "+10 minutes" +%s)
+          # Use the correct ReleaseManager address from devnet constants
+          RELEASE_MANAGER_ADDRESS="0x323A9FcB2De80d04B5C4B0F72ee7799100D32F0F"
+          echo "ReleaseManager Address: $RELEASE_MANAGER_ADDRESS"
           
-          echo "Publishing release with upgrade time: $UPGRADE_TIME"
-          devkit avs release publish --upgrade-by-time $UPGRADE_TIME --registry localhost:5001
+          # Query the ReleaseManager contract to verify the release
+          echo "Querying ReleaseManager for operator set 0..."
           
-          NEW_VERSION=$(grep -A 1 "artifact:" config/contexts/devnet.yaml | grep "version:" | awk '{print $2}' | tr -d '"')
-          echo "New version: $NEW_VERSION"
+          # Get the latest version
+          LATEST_VERSION=$(cast call $RELEASE_MANAGER_ADDRESS \
+            "latestVersion(address,uint32)" \
+            $AVS_ADDRESS 0 \
+            --rpc-url http://localhost:8545)
           
-          if [ "$NEW_VERSION" = "1" ] || [ "$NEW_VERSION" -gt 0 ]; then
-            echo "✅ Release published successfully, version updated to: $NEW_VERSION"
-          else
-            echo "❌ Release publish failed - version not updated"
+          echo "Latest version for operator set 0: $LATEST_VERSION"
+          
+          # Convert hex to decimal
+          VERSION_DEC=$((LATEST_VERSION))
+          echo "Latest version (decimal): $VERSION_DEC"
+          
+          if [ $VERSION_DEC -eq 0 ]; then
+            echo "❌ No release found on ReleaseManager"
             exit 1
           fi
+          
+          # Get release details
+          RELEASE_DATA=$(cast call $RELEASE_MANAGER_ADDRESS \
+            "getRelease(address,uint32,uint256)" \
+            $AVS_ADDRESS 0 $((VERSION_DEC - 1)) \
+            --rpc-url http://localhost:8545)
+          
+          echo "Release data retrieved: $RELEASE_DATA"
+          
+          # Check if release data is not empty
+          if [ -z "$RELEASE_DATA" ] || [ "$RELEASE_DATA" = "0x" ]; then
+            echo "❌ Release data is empty"
+            exit 1
+          fi
+          
+          echo "✅ Release verified on ReleaseManager contract"
+
+      - name: Test multiple operator sets release
+        run: |
+          cd ./my-awesome-avs/
+          
+          # Create another operator set
+          echo "Creating operator set 1..."
+          DEPLOYER_KEY=$(yq eval '.context.deployer_private_key' config/contexts/devnet.yaml)
+          AVS_ADDRESS=$(yq eval '.context.avs.address' config/contexts/devnet.yaml)
+          ALLOCATION_MANAGER_ADDRESS="0x76f67c84eF6F6cF76ec52b4cEFa28ca7492Bd43a"
+          
+          # Use cast to create operator set
+          cast send $ALLOCATION_MANAGER_ADDRESS \
+            "createOperatorSets(address,(uint32,address[])[])" \
+            $AVS_ADDRESS "[(1,[])]" \
+            --private-key $DEPLOYER_KEY \
+            --rpc-url http://localhost:8545
+          
+          echo "✅ Operator set 1 created"
+          
+          # Publish release for multiple operator sets
+          UPGRADE_BY_TIME=$(($(date +%s) + 7200))  # 2 hours from now
+          
+          # The release script should handle multiple operator sets
+          devkit avs release publish --upgrade-by-time $UPGRADE_BY_TIME --registry localhost:5001
+          
+          # Verify both operator sets have releases
+          for OPSET in 0 1; do
+            LATEST_VERSION=$(cast call $RELEASE_MANAGER_ADDRESS \
+              "latestVersion(address,uint32)" \
+              $AVS_ADDRESS $OPSET \
+              --rpc-url http://localhost:8545)
+            
+            VERSION_DEC=$((LATEST_VERSION))
+            echo "Operator set $OPSET latest version: $VERSION_DEC"
+            
+            if [ $VERSION_DEC -eq 0 ]; then
+              echo "❌ No release found for operator set $OPSET"
+              exit 1
+            fi
+          done
+          
+          echo "✅ Releases published for multiple operator sets"
+
+      - name: Stop local Docker registry
+        if: always()
+        run: |
+          docker stop registry || true
+          docker rm registry || true
 
       - name: Stop devnet
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -383,6 +383,36 @@ jobs:
           cd ./my-awesome-avs/
           devkit avs call -- signature="(uint256,string)" args='(5,"hello")'
 
+      - name: Test release publish
+        run: |
+          cd ./my-awesome-avs/
+          
+          CURRENT_VERSION=$(grep -A 1 "artifact:" config/contexts/devnet.yaml | grep "version:" | awk '{print $2}' | tr -d '"')
+          echo "Current version: ${CURRENT_VERSION:-empty}"
+          
+          # Calculate upgrade time (10 minutes from now)
+          if [ "${{ matrix.os }}" = "macos-latest" ]; then
+            UPGRADE_TIME=$(date -v +10M +%s)
+          else
+            UPGRADE_TIME=$(date -d "+10 minutes" +%s)
+          fi
+          
+          # Run release publish with explicit registry
+          echo "Publishing release with upgrade time: $UPGRADE_TIME"
+          devkit avs release publish --upgrade-by-time $UPGRADE_TIME --registry localhost:5001
+          
+          # Check that version was updated
+          NEW_VERSION=$(grep -A 1 "artifact:" config/contexts/devnet.yaml | grep "version:" | awk '{print $2}' | tr -d '"')
+          echo "New version: $NEW_VERSION"
+          
+          # Verify version was incremented
+          if [ "$NEW_VERSION" = "1" ] || [ "$NEW_VERSION" -gt 0 ]; then
+            echo "✅ Release published successfully, version updated to: $NEW_VERSION"
+          else
+            echo "❌ Release publish failed - version not updated"
+            exit 1
+          fi
+
       - name: Stop devnet
         run: |
           cd ./my-awesome-avs/

--- a/config/templates.yaml
+++ b/config/templates.yaml
@@ -3,7 +3,7 @@ architectures:
     languages:
       go:
         baseUrl: "https://github.com/Layr-Labs/hourglass-avs-template"
-        version: "95f9067bd35b770e989d7d6442003e405d7639ae"
+        version: "a39911dd514ae2ca8248b871037f93b35685129a"
       ts:
         baseUrl: ""
         version: ""


### PR DESCRIPTION
**Motivation:**
To provide e2e testing coverage for the release publish command. Ensuring that local docker registry is spun up and ReleaseManager contract is queried and updated correctly 

**Modifications:**
Added e2e coverage testing to e2e.yml workflow file. 

**Result:**
Added E2E coverage testing for release publish command. 

**Testing:**
Queries the ReleaseManager contract for version and checks the devnet.yaml context for artifacts proving release publish command was successful.