### PR TITLE
feat: expose language selection to relevant template scripts

### DIFF
--- a/config/configs/migrations/v0.0.2-v0.0.3.go
+++ b/config/configs/migrations/v0.0.2-v0.0.3.go
@@ -1,0 +1,29 @@
+package configMigrations
+
+import (
+	"github.com/Layr-Labs/devkit-cli/pkg/migration"
+
+	"gopkg.in/yaml.v3"
+)
+
+func Migration_0_0_2_to_0_0_3(user, old, new *yaml.Node) (*yaml.Node, error) {
+	engine := migration.PatchEngine{
+		Old:  old,
+		New:  new,
+		User: user,
+		Rules: []migration.PatchRule{
+			// Add template version that should be present (leave unchanged if different)
+			{Path: []string{"config", "project", "templateLanguage"}, Condition: migration.IfUnchanged{}},
+		},
+	}
+	err := engine.Apply()
+	if err != nil {
+		return nil, err
+	}
+
+	// bump version node
+	if v := migration.ResolveNode(user, []string{"version"}); v != nil {
+		v.Value = "0.0.3"
+	}
+	return user, nil
+}

--- a/config/configs/registry.go
+++ b/config/configs/registry.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Set the latest version
-const LatestVersion = "0.0.2"
+const LatestVersion = "0.0.3"
 
 // --
 // Versioned configs
@@ -24,10 +24,14 @@ var v0_0_1_default []byte
 //go:embed v0.0.2.yaml
 var v0_0_2_default []byte
 
+//go:embed v0.0.3.yaml
+var v0_0_3_default []byte
+
 // Map of context name -> content
 var ConfigYamls = map[string][]byte{
 	"0.0.1": v0_0_1_default,
 	"0.0.2": v0_0_2_default,
+	"0.0.3": v0_0_2_default,
 }
 
 // Map of sequential migrations
@@ -38,6 +42,13 @@ var MigrationChain = []migration.MigrationStep{
 		Apply:   configMigrations.Migration_0_0_1_to_0_0_2,
 		OldYAML: v0_0_1_default,
 		NewYAML: v0_0_2_default,
+	},
+	{
+		From:    "0.0.2",
+		To:      "0.0.3",
+		Apply:   configMigrations.Migration_0_0_2_to_0_0_3,
+		OldYAML: v0_0_2_default,
+		NewYAML: v0_0_3_default,
 	},
 }
 

--- a/config/configs/v0.0.3.yaml
+++ b/config/configs/v0.0.3.yaml
@@ -1,0 +1,11 @@
+version: 0.0.3
+config:
+  project:
+    name: "my-avs"
+    version: "0.1.0"
+    context: "devnet"
+    project_uuid: ""
+    templateBaseUrl: "https://github.com/Layr-Labs/hourglass-avs-template"
+    templateVersion: "v0.0.14"
+    templateLanguage: "go"
+    telemetry_enabled: false

--- a/config/templates.yaml
+++ b/config/templates.yaml
@@ -1,12 +1,8 @@
-architectures:
-  task:
+framework:
+  hourglass:
+    template: "https://github.com/Layr-Labs/hourglass-avs-template"
+    version: "v0.0.18"
     languages:
-      go:
-        baseUrl: "https://github.com/Layr-Labs/hourglass-avs-template"
-        version: "v0.0.18"
-      ts:
-        baseUrl: ""
-        version: ""
-      rust:
-        baseUrl: ""
-        version: ""
+      - go
+      - ts
+      - rust

--- a/pkg/commands/build.go
+++ b/pkg/commands/build.go
@@ -69,6 +69,9 @@ var BuildCommand = &cli.Command{
 			language = "go"
 		}
 
+		// Log the type of project being ran
+		logger.Info("Building %s AVS project", language)
+
 		// Handle version increment
 		version := cfg.Context[contextName].Artifact.Version
 		if version == "" {

--- a/pkg/commands/build.go
+++ b/pkg/commands/build.go
@@ -63,6 +63,12 @@ var BuildCommand = &cli.Command{
 			return fmt.Errorf("failed to load configurations: %w", err)
 		}
 
+		// Pull template language from config
+		language := cfg.Config.Project.TemplateLanguage
+		if language == "" {
+			language = "go"
+		}
+
 		// Handle version increment
 		version := cfg.Context[contextName].Artifact.Version
 		if version == "" {
@@ -81,6 +87,8 @@ var BuildCommand = &cli.Command{
 			[]byte(cfg.Config.Project.Name),
 			[]byte("--tag"),
 			[]byte(version),
+			[]byte("--lang"),
+			[]byte(language),
 		)
 		if err != nil {
 			logger.Error("Build script failed with error: %v", err)

--- a/pkg/commands/create.go
+++ b/pkg/commands/create.go
@@ -39,9 +39,9 @@ var CreateCommand = &cli.Command{
 			Value: "go",
 		},
 		&cli.StringFlag{
-			Name:  "arch",
+			Name:  "framework",
 			Usage: "Specifies AVS architecture (task-based/hourglass, epoch-based, etc.)",
-			Value: "task",
+			Value: "hourglass",
 		},
 		&cli.StringFlag{
 			Name:  "template-url",
@@ -70,8 +70,7 @@ var CreateCommand = &cli.Command{
 		dest := cCtx.Args().Get(1)
 
 		// get logger
-		logger := common.LoggerFromContext(cCtx.Context)
-		tracker := common.ProgressTrackerFromContext(cCtx.Context)
+		logger, tracker := common.GetLoggerFromCLIContext(cCtx)
 
 		// use dest from dir flag or positional
 		var targetDir string
@@ -90,15 +89,15 @@ var CreateCommand = &cli.Command{
 		// in verbose mode, detail the situation
 		logger.Debug("Creating new AVS project: %s", projectName)
 		logger.Debug("Directory: %s", cCtx.String("dir"))
+		logger.Debug("Framework: %s", cCtx.String("framework"))
 		logger.Debug("Language: %s", cCtx.String("lang"))
-		logger.Debug("Architecture: %s", cCtx.String("arch"))
 		logger.Debug("Environment: %s", cCtx.String("env"))
 		if cCtx.String("template-path") != "" {
 			logger.Debug("Template Path: %s", cCtx.String("template-path"))
 		}
 
 		// Get template URLs
-		mainBaseURL, mainVersion, err := getTemplateURLs(cCtx)
+		mainBaseURL, mainVersion, mainLang, err := getTemplateURLs(cCtx)
 		if err != nil {
 			return err
 		}
@@ -149,7 +148,7 @@ var CreateCommand = &cli.Command{
 		logger.Info("Installing template dependencies\n\n")
 
 		// Run init on the template init script
-		if _, err = common.CallTemplateScript(cCtx.Context, logger, targetDir, scriptPath, common.ExpectNonJSONResponse, nil); err != nil {
+		if _, err = common.CallTemplateScript(cCtx.Context, logger, targetDir, scriptPath, common.ExpectNonJSONResponse, []byte(mainLang)); err != nil {
 			return fmt.Errorf("failed to initialize %s: %w", scriptPath, err)
 		}
 
@@ -187,7 +186,7 @@ var CreateCommand = &cli.Command{
 		}
 
 		// Copy config.yaml to the project directory with UUID and telemetry settings
-		if err := copyDefaultConfigToProject(logger, targetDir, projectName, appEnv.ProjectUUID, mainBaseURL, mainVersion, telemetryEnabled); err != nil {
+		if err := copyDefaultConfigToProject(logger, targetDir, projectName, appEnv.ProjectUUID, mainBaseURL, mainVersion, mainLang, telemetryEnabled); err != nil {
 			return fmt.Errorf("failed to initialize %s: %w", common.BaseConfig, err)
 		}
 
@@ -211,35 +210,37 @@ var CreateCommand = &cli.Command{
 	},
 }
 
-func getTemplateURLs(cCtx *cli.Context) (string, string, error) {
+func getTemplateURLs(cCtx *cli.Context) (string, string, string, error) {
+	// If overrides are provided, we do not need to check the templates.yaml for content
 	templateBaseOverride := cCtx.String("template-url")
 	templateVersionOverride := cCtx.String("template-version")
 
-	cfg, err := template.LoadConfig()
-	if err != nil {
-		return "", "", fmt.Errorf("failed to load templates cfg: %w", err)
+	// If no overrides are provided, we check the templates.yaml for available frameworks
+	mainBaseURL, mainVersion, mainLang := "", "", cCtx.String("lang")
+	if templateBaseOverride == "" && templateVersionOverride == "" {
+		cfg, err := template.LoadConfig()
+		if err != nil {
+			return "", "", "", fmt.Errorf("failed to load templates cfg: %w", err)
+		}
+		framework := cCtx.String("framework")
+		mainBaseURL, mainVersion, err = template.GetTemplateURLs(cfg, framework, mainLang)
+		if err != nil {
+			return "", "", "", fmt.Errorf("failed to get template URLs: %w", err)
+		}
+		if mainBaseURL == "" {
+			return "", "", "", fmt.Errorf("no template found for framework %s and language %s", framework, mainLang)
+		}
 	}
 
-	arch := cCtx.String("arch")
-	lang := cCtx.String("lang")
-
-	mainBaseURL, mainVersion, err := template.GetTemplateURLs(cfg, arch, lang)
-	if err != nil {
-		return "", "", fmt.Errorf("failed to get template URLs: %w", err)
-	}
+	// If overrides are provided, they take precedence over the details in templates.yaml
 	if templateBaseOverride != "" {
 		mainBaseURL = templateBaseOverride
 	}
-	if mainBaseURL == "" {
-		return "", "", fmt.Errorf("no template found for architecture %s and language %s", arch, lang)
-	}
-
-	// If templateVersionOverride is provided, it takes precedence over the version from templates.yaml
 	if templateVersionOverride != "" {
 		mainVersion = templateVersionOverride
 	}
 
-	return mainBaseURL, mainVersion, nil
+	return mainBaseURL, mainVersion, mainLang, nil
 }
 
 func createProjectDir(logger iface.Logger, targetDir string, overwrite bool) error {
@@ -264,7 +265,7 @@ func createProjectDir(logger iface.Logger, targetDir string, overwrite bool) err
 }
 
 // copyDefaultConfigToProject copies config to the project directory with updated project name, UUID, and telemetry settings
-func copyDefaultConfigToProject(logger iface.Logger, targetDir, projectName, projectUUID string, templateBaseURL, templateVersion string, telemetryEnabled bool) error {
+func copyDefaultConfigToProject(logger iface.Logger, targetDir, projectName, projectUUID string, templateBaseURL, templateVersion string, templatelanguage string, telemetryEnabled bool) error {
 	// Create and ensure target config directory exists
 	destConfigDir := filepath.Join(targetDir, "config")
 	if err := os.MkdirAll(destConfigDir, 0755); err != nil {
@@ -284,6 +285,7 @@ func copyDefaultConfigToProject(logger iface.Logger, targetDir, projectName, pro
 	cfg.Config.Project.TelemetryEnabled = telemetryEnabled
 	cfg.Config.Project.TemplateBaseURL = templateBaseURL
 	cfg.Config.Project.TemplateVersion = templateVersion
+	cfg.Config.Project.TemplateLanguage = templatelanguage
 
 	// Marshal the modified configuration back to YAML
 	newContentBytes, err := yaml.Marshal(&cfg)

--- a/pkg/commands/create.go
+++ b/pkg/commands/create.go
@@ -39,7 +39,7 @@ var CreateCommand = &cli.Command{
 			Value: "go",
 		},
 		&cli.StringFlag{
-			Name:  "framework",
+			Name:  "template",
 			Usage: "Specifies AVS architecture (task-based/hourglass, epoch-based, etc.)",
 			Value: "hourglass",
 		},
@@ -89,7 +89,7 @@ var CreateCommand = &cli.Command{
 		// in verbose mode, detail the situation
 		logger.Debug("Creating new AVS project: %s", projectName)
 		logger.Debug("Directory: %s", cCtx.String("dir"))
-		logger.Debug("Framework: %s", cCtx.String("framework"))
+		logger.Debug("Template: %s", cCtx.String("template"))
 		logger.Debug("Language: %s", cCtx.String("lang"))
 		logger.Debug("Environment: %s", cCtx.String("env"))
 		if cCtx.String("template-path") != "" {
@@ -222,14 +222,14 @@ func getTemplateURLs(cCtx *cli.Context) (string, string, string, error) {
 			return "", "", "", fmt.Errorf("failed to load templates cfg: %w", err)
 		}
 
-		framework := cCtx.String("framework")
-		baseURL, version, err = template.GetTemplateURLs(cfg, framework, lang)
+		selectedTemplate := cCtx.String("template")
+		baseURL, version, err = template.GetTemplateURLs(cfg, selectedTemplate, lang)
 		if err != nil {
 			return "", "", "", fmt.Errorf("failed to get template URLs: %w", err)
 		}
 
 		if baseURL == "" {
-			return "", "", "", fmt.Errorf("no template found for framework %s and language %s", framework, lang)
+			return "", "", "", fmt.Errorf("no template found for template %s and language %s", selectedTemplate, lang)
 		}
 	}
 

--- a/pkg/commands/create.go
+++ b/pkg/commands/create.go
@@ -211,36 +211,29 @@ var CreateCommand = &cli.Command{
 }
 
 func getTemplateURLs(cCtx *cli.Context) (string, string, string, error) {
-	// If overrides are provided, we do not need to check the templates.yaml for content
-	templateBaseOverride := cCtx.String("template-url")
-	templateVersionOverride := cCtx.String("template-version")
+	baseURL := cCtx.String("template-url")
+	version := cCtx.String("template-version")
+	lang := cCtx.String("lang")
 
-	// If no overrides are provided, we check the templates.yaml for available frameworks
-	mainBaseURL, mainVersion, mainLang := "", "", cCtx.String("lang")
-	if templateBaseOverride == "" && templateVersionOverride == "" {
+	// If no overrides provided, get from config
+	if baseURL == "" && version == "" {
 		cfg, err := template.LoadConfig()
 		if err != nil {
 			return "", "", "", fmt.Errorf("failed to load templates cfg: %w", err)
 		}
+
 		framework := cCtx.String("framework")
-		mainBaseURL, mainVersion, err = template.GetTemplateURLs(cfg, framework, mainLang)
+		baseURL, version, err = template.GetTemplateURLs(cfg, framework, lang)
 		if err != nil {
 			return "", "", "", fmt.Errorf("failed to get template URLs: %w", err)
 		}
-		if mainBaseURL == "" {
-			return "", "", "", fmt.Errorf("no template found for framework %s and language %s", framework, mainLang)
+
+		if baseURL == "" {
+			return "", "", "", fmt.Errorf("no template found for framework %s and language %s", framework, lang)
 		}
 	}
 
-	// If overrides are provided, they take precedence over the details in templates.yaml
-	if templateBaseOverride != "" {
-		mainBaseURL = templateBaseOverride
-	}
-	if templateVersionOverride != "" {
-		mainVersion = templateVersionOverride
-	}
-
-	return mainBaseURL, mainVersion, mainLang, nil
+	return baseURL, version, lang, nil
 }
 
 func createProjectDir(logger iface.Logger, targetDir string, overwrite bool) error {

--- a/pkg/commands/create_test.go
+++ b/pkg/commands/create_test.go
@@ -104,13 +104,13 @@ func TestCreateCommand(t *testing.T) {
 		}
 
 		// Test template URL lookup
-		mainBaseURL, mainVersion, err := template.GetTemplateURLs(config, "task", "go")
+		mainBaseURL, mainVersion, err := template.GetTemplateURLs(config, "hourglass", "go")
 		if err != nil {
 			t.Fatalf("Failed to get template URLs: %v", err)
 		}
 
 		// Create config.yaml
-		return copyDefaultConfigToProject(logger, targetDir, projectName, "test-uuid", mainBaseURL, mainVersion, false)
+		return copyDefaultConfigToProject(logger, targetDir, projectName, "test-uuid", mainBaseURL, mainVersion, "go", false)
 	}
 
 	app := &cli.App{

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/Layr-Labs/devkit-cli/pkg/common"
 	"github.com/Layr-Labs/devkit-cli/pkg/common/devnet"
-	"github.com/Layr-Labs/devkit-cli/pkg/testutils"
 
 	"github.com/urfave/cli/v2"
 )
@@ -54,23 +53,10 @@ func AVSRun(cCtx *cli.Context) error {
 	// Print task if verbose
 	logger.Debug("Starting offchain AVS components...")
 
-	// Get the config (based on if we're in a test or not)
-	var cfg *common.ConfigWithContextConfig
-
-	// First check if config is in context (for testing)
-	if cfgValue := cCtx.Context.Value(testutils.ConfigContextKey); cfgValue != nil {
-		// Use test config from context
-		cfg = cfgValue.(*common.ConfigWithContextConfig)
-	} else {
-		// Load selected context
-		context := cCtx.String("context")
-
-		// Load from file if not in context
-		var err error
-		cfg, err = common.LoadConfigWithContextConfig(context)
-		if err != nil {
-			return err
-		}
+	// Load the config fetch templateLanguage
+	cfg, _, err := common.LoadConfigWithContextConfig(contextName)
+	if err != nil {
+		return err
 	}
 
 	// Pull template language from config

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -79,6 +79,9 @@ func AVSRun(cCtx *cli.Context) error {
 		language = "go"
 	}
 
+	// Log the type of project being ran
+	logger.Info("Running %s AVS project", language)
+
 	// Run the script from root of project dir
 	// (@TODO (GD): this should always be the root of the project, but we need to do this everywhere (ie reading ctx/config etc))
 	const dir = ""

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Layr-Labs/devkit-cli/pkg/common"
 	"github.com/Layr-Labs/devkit-cli/pkg/common/devnet"
+	"github.com/Layr-Labs/devkit-cli/pkg/testutils"
 
 	"github.com/urfave/cli/v2"
 )
@@ -53,6 +54,31 @@ func AVSRun(cCtx *cli.Context) error {
 	// Print task if verbose
 	logger.Debug("Starting offchain AVS components...")
 
+	// Get the config (based on if we're in a test or not)
+	var cfg *common.ConfigWithContextConfig
+
+	// First check if config is in context (for testing)
+	if cfgValue := cCtx.Context.Value(testutils.ConfigContextKey); cfgValue != nil {
+		// Use test config from context
+		cfg = cfgValue.(*common.ConfigWithContextConfig)
+	} else {
+		// Load selected context
+		context := cCtx.String("context")
+
+		// Load from file if not in context
+		var err error
+		cfg, err = common.LoadConfigWithContextConfig(context)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Pull template language from config
+	language := cfg.Config.Project.TemplateLanguage
+	if language == "" {
+		language = "go"
+	}
+
 	// Run the script from root of project dir
 	// (@TODO (GD): this should always be the root of the project, but we need to do this everywhere (ie reading ctx/config etc))
 	const dir = ""
@@ -61,7 +87,7 @@ func AVSRun(cCtx *cli.Context) error {
 	scriptPath := filepath.Join(".devkit", "scripts", "run")
 
 	// Run init on the template init script
-	if _, err := common.CallTemplateScript(cCtx.Context, logger, dir, scriptPath, common.ExpectNonJSONResponse, contextJSON); err != nil {
+	if _, err := common.CallTemplateScript(cCtx.Context, logger, dir, scriptPath, common.ExpectNonJSONResponse, contextJSON, []byte(language)); err != nil {
 		return fmt.Errorf("run failed: %w", err)
 	}
 

--- a/pkg/commands/template/info.go
+++ b/pkg/commands/template/info.go
@@ -14,7 +14,7 @@ var InfoCommand = &cli.Command{
 		logger := common.LoggerFromContext(cCtx.Context)
 
 		// Get template information
-		projectName, templateBaseURL, templateVersion, err := GetTemplateInfo()
+		projectName, templateBaseURL, templateVersion, templateLanguage, err := GetTemplateInfo()
 		if err != nil {
 			return err
 		}
@@ -26,6 +26,7 @@ var InfoCommand = &cli.Command{
 		}
 		logger.Info("  Template URL: %s", templateBaseURL)
 		logger.Info("  Version: %s", templateVersion)
+		logger.Info("  Language: %s", templateLanguage)
 
 		return nil
 	},

--- a/pkg/commands/template/template.go
+++ b/pkg/commands/template/template.go
@@ -12,29 +12,30 @@ import (
 )
 
 // GetTemplateInfo reads the template information from the project config
-// Returns projectName, templateBaseURL, templateVersion, error
-func GetTemplateInfo() (string, string, string, error) {
+// Returns projectName, templateBaseURL, templateVersion, templateLanguage, error
+func GetTemplateInfo() (string, string, string, string, error) {
 	// Ensure we're in a project directory (check for config/config.yaml)
 	configPath := filepath.Join("config", common.BaseConfig)
 	if _, err := os.Stat(configPath); os.IsNotExist(err) {
-		return "", "", "", fmt.Errorf("config/config.yaml not found. Make sure you're in a devkit project directory")
+		return "", "", "", "", fmt.Errorf("config/config.yaml not found. Make sure you're in a devkit project directory")
 	}
 
 	// Read the config file to get the template URL
 	configData, err := os.ReadFile(configPath)
 	if err != nil {
-		return "", "", "", fmt.Errorf("failed to read config file: %w", err)
+		return "", "", "", "", fmt.Errorf("failed to read config file: %w", err)
 	}
 
 	var configMap map[string]interface{}
 	if err := yaml.Unmarshal(configData, &configMap); err != nil {
-		return "", "", "", fmt.Errorf("failed to parse config file: %w", err)
+		return "", "", "", "", fmt.Errorf("failed to parse config file: %w", err)
 	}
 
 	// Extract project name and template info
 	projectName := ""
 	templateBaseURL := ""
 	templateVersion := "unknown" // Default version
+	templateLanguage := "go"
 
 	if configSection, ok := configMap["config"].(map[string]interface{}); ok {
 		if projectMap, ok := configSection["project"].(map[string]interface{}); ok {
@@ -47,6 +48,9 @@ func GetTemplateInfo() (string, string, string, error) {
 			if version, ok := projectMap["templateVersion"].(string); ok {
 				templateVersion = version
 			}
+			if language, ok := projectMap["templateLanguage"].(string); ok {
+				templateLanguage = language
+			}
 		}
 	}
 
@@ -55,12 +59,12 @@ func GetTemplateInfo() (string, string, string, error) {
 		// Load templates configuration
 		templateConfig, err := template.LoadConfig()
 		if err == nil {
-			// Default to "task" architecture and "go" language
-			defaultArch := "task"
+			// Default to "hourglass" framework and "go" language
+			defaultFramework := "hourglass"
 			defaultLang := "go"
 
 			// Look up the default template URL
-			mainBaseURL, _, _ := template.GetTemplateURLs(templateConfig, defaultArch, defaultLang)
+			mainBaseURL, _, _ := template.GetTemplateURLs(templateConfig, defaultFramework, defaultLang)
 
 			// Use the default values
 			templateBaseURL = mainBaseURL
@@ -70,28 +74,34 @@ func GetTemplateInfo() (string, string, string, error) {
 		if templateBaseURL == "" {
 			templateBaseURL = "https://github.com/Layr-Labs/hourglass-avs-template"
 		}
+
+		// If we still don't have a language, fallback to go
+		if templateLanguage == "" {
+			templateLanguage = "go"
+		}
 	}
 
-	return projectName, templateBaseURL, templateVersion, nil
+	return projectName, templateBaseURL, templateVersion, templateLanguage, nil
 }
 
 // GetTemplateInfoDefault returns default template information without requiring a config file
 // Returns projectName, templateBaseURL, templateVersion, error
-func GetTemplateInfoDefault() (string, string, string, error) {
+func GetTemplateInfoDefault() (string, string, string, string, error) {
 	// Default values
 	projectName := ""
 	templateBaseURL := ""
 	templateVersion := "unknown"
+	templateLanguage := "go"
 
 	// Try to load templates configuration
 	templateConfig, err := template.LoadConfig()
 	if err == nil {
-		// Default to "task" architecture and "go" language
-		defaultArch := "task"
+		// Default to "hourglass" framework and "go" language
+		defaultFramework := "hourglass"
 		defaultLang := "go"
 
 		// Look up the default template URL
-		mainBaseURL, _, _ := template.GetTemplateURLs(templateConfig, defaultArch, defaultLang)
+		mainBaseURL, _, _ := template.GetTemplateURLs(templateConfig, defaultFramework, defaultLang)
 
 		// Use the default values
 		templateBaseURL = mainBaseURL
@@ -102,7 +112,12 @@ func GetTemplateInfoDefault() (string, string, string, error) {
 		templateBaseURL = "https://github.com/Layr-Labs/hourglass-avs-template"
 	}
 
-	return projectName, templateBaseURL, templateVersion, nil
+	// If we still don't have a language, fallback to go
+	if templateLanguage == "" {
+		templateLanguage = "go"
+	}
+
+	return projectName, templateBaseURL, templateVersion, templateLanguage, nil
 }
 
 // Command defines the main "template" command for template operations

--- a/pkg/commands/template/template.go
+++ b/pkg/commands/template/template.go
@@ -14,13 +14,13 @@ import (
 // GetTemplateInfo reads the template information from the project config
 // Returns projectName, templateBaseURL, templateVersion, templateLanguage, error
 func GetTemplateInfo() (string, string, string, string, error) {
-	// Ensure we're in a project directory (check for config/config.yaml)
+	// Check for config file
 	configPath := filepath.Join("config", common.BaseConfig)
 	if _, err := os.Stat(configPath); os.IsNotExist(err) {
 		return "", "", "", "", fmt.Errorf("config/config.yaml not found. Make sure you're in a devkit project directory")
 	}
 
-	// Read the config file to get the template URL
+	// Read and parse config
 	configData, err := os.ReadFile(configPath)
 	if err != nil {
 		return "", "", "", "", fmt.Errorf("failed to read config file: %w", err)
@@ -31,53 +31,31 @@ func GetTemplateInfo() (string, string, string, string, error) {
 		return "", "", "", "", fmt.Errorf("failed to parse config file: %w", err)
 	}
 
-	// Extract project name and template info
+	// Extract values with defaults
 	projectName := ""
 	templateBaseURL := ""
-	templateVersion := "unknown" // Default version
+	templateVersion := "unknown"
 	templateLanguage := "go"
 
-	if configSection, ok := configMap["config"].(map[string]interface{}); ok {
-		if projectMap, ok := configSection["project"].(map[string]interface{}); ok {
-			if name, ok := projectMap["name"].(string); ok {
-				projectName = name
-			}
-			if url, ok := projectMap["templateBaseUrl"].(string); ok {
-				templateBaseURL = url
-			}
-			if version, ok := projectMap["templateVersion"].(string); ok {
-				templateVersion = version
-			}
-			if language, ok := projectMap["templateLanguage"].(string); ok {
-				templateLanguage = language
-			}
+	// Navigate to config.project section and extract values
+	if config, ok := configMap["config"].(map[string]interface{}); ok {
+		if project, ok := config["project"].(map[string]interface{}); ok {
+			projectName, _ = project["name"].(string)
+			templateBaseURL, _ = project["templateURL"].(string)
+			templateVersion = getStringOrDefault(project, "templateVersion", templateVersion)
+			templateLanguage = getStringOrDefault(project, "templateLanguage", templateLanguage)
 		}
 	}
 
-	// If no template URL was found in the config, use the default from templates.yaml
+	// Use defaults if templateBaseURL is empty
 	if templateBaseURL == "" {
-		// Load templates configuration
-		templateConfig, err := template.LoadConfig()
-		if err == nil {
-			// Default to "hourglass" framework and "go" language
-			defaultFramework := "hourglass"
-			defaultLang := "go"
+		templateBaseURL = "https://github.com/Layr-Labs/hourglass-avs-template"
 
-			// Look up the default template URL
-			mainBaseURL, _, _ := template.GetTemplateURLs(templateConfig, defaultFramework, defaultLang)
-
-			// Use the default values
-			templateBaseURL = mainBaseURL
-		}
-
-		// If we still don't have a URL, use a hardcoded fallback
-		if templateBaseURL == "" {
-			templateBaseURL = "https://github.com/Layr-Labs/hourglass-avs-template"
-		}
-
-		// If we still don't have a language, fallback to go
-		if templateLanguage == "" {
-			templateLanguage = "go"
+		// Try to get from template config (optional)
+		if cfg, err := template.LoadConfig(); err == nil {
+			if url, _, _ := template.GetTemplateURLs(cfg, "hourglass", "go"); url != "" {
+				templateBaseURL = url
+			}
 		}
 	}
 
@@ -90,7 +68,7 @@ func GetTemplateInfoDefault() (string, string, string, string, error) {
 	// Default values
 	projectName := ""
 	templateBaseURL := ""
-	templateVersion := "unknown"
+	templateVersion := "https://github.com/Layr-Labs/hourglass-avs-template"
 	templateLanguage := "go"
 
 	// Try to load templates configuration
@@ -107,17 +85,15 @@ func GetTemplateInfoDefault() (string, string, string, string, error) {
 		templateBaseURL = mainBaseURL
 	}
 
-	// If we still don't have a URL, use a hardcoded fallback
-	if templateBaseURL == "" {
-		templateBaseURL = "https://github.com/Layr-Labs/hourglass-avs-template"
-	}
-
-	// If we still don't have a language, fallback to go
-	if templateLanguage == "" {
-		templateLanguage = "go"
-	}
-
 	return projectName, templateBaseURL, templateVersion, templateLanguage, nil
+}
+
+// Helper function to get string value or return default
+func getStringOrDefault(m map[string]interface{}, key, defaultValue string) string {
+	if val, ok := m[key].(string); ok {
+		return val
+	}
+	return defaultValue
 }
 
 // Command defines the main "template" command for template operations

--- a/pkg/commands/template/template_test.go
+++ b/pkg/commands/template/template_test.go
@@ -41,6 +41,7 @@ func TestGetTemplateInfo(t *testing.T) {
     name: test-project
     templateBaseUrl: https://github.com/Layr-Labs/hourglass-avs-template
     templateVersion: v0.0.3
+    templateLanguage: go
 `
 		configPath := filepath.Join(configDir, common.BaseConfig)
 		err = os.WriteFile(configPath, []byte(configContent), 0644)
@@ -48,7 +49,7 @@ func TestGetTemplateInfo(t *testing.T) {
 			t.Fatalf("Failed to write config file: %v", err)
 		}
 
-		projectName, templateURL, templateVersion, err := GetTemplateInfo()
+		projectName, templateURL, templateVersion, templateLanguage, err := GetTemplateInfo()
 		if err != nil {
 			t.Fatalf("GetTemplateInfo failed: %v", err)
 		}
@@ -61,6 +62,9 @@ func TestGetTemplateInfo(t *testing.T) {
 		}
 		if templateVersion != "v0.0.3" {
 			t.Errorf("Expected template version 'v0.0.3', got '%s'", templateVersion)
+		}
+		if templateLanguage != "go" {
+			t.Errorf("Expected template language 'go', got '%s'", templateLanguage)
 		}
 	})
 
@@ -77,7 +81,7 @@ func TestGetTemplateInfo(t *testing.T) {
 			t.Fatalf("Failed to write config file: %v", err)
 		}
 
-		projectName, templateURL, templateVersion, err := GetTemplateInfo()
+		projectName, templateURL, templateVersion, templateLanguage, err := GetTemplateInfo()
 		if err != nil {
 			t.Fatalf("GetTemplateInfo failed: %v", err)
 		}
@@ -95,6 +99,9 @@ func TestGetTemplateInfo(t *testing.T) {
 		if templateVersion != "unknown" && templateVersion == "" {
 			t.Errorf("Expected template version to be populated, got '%s'", templateVersion)
 		}
+		if templateLanguage == "" {
+			t.Errorf("Expected template language to be populated, got '%s'", templateLanguage)
+		}
 	})
 
 	// Test with missing config file
@@ -105,7 +112,7 @@ func TestGetTemplateInfo(t *testing.T) {
 			t.Fatalf("Failed to remove config file: %v", err)
 		}
 
-		_, _, _, err := GetTemplateInfo()
+		_, _, _, _, err := GetTemplateInfo()
 		if err == nil {
 			t.Errorf("Expected error for missing config file, got nil")
 		}

--- a/pkg/commands/template/upgrade.go
+++ b/pkg/commands/template/upgrade.go
@@ -16,36 +16,50 @@ import (
 
 // For testability, we'll define interfaces for our dependencies
 type templateInfoGetter interface {
-	GetInfo() (string, string, string, error)
-	GetInfoDefault() (string, string, string, error)
+	GetInfo() (string, string, string, string, error)
+	GetInfoDefault() (string, string, string, string, error)
 	GetTemplateVersionFromConfig(arch, lang string) (string, error)
 }
 
 // defaultTemplateInfoGetter implements templateInfoGetter using the real functions
 type defaultTemplateInfoGetter struct{}
 
-func (g *defaultTemplateInfoGetter) GetInfo() (string, string, string, error) {
+func (g *defaultTemplateInfoGetter) GetInfo() (string, string, string, string, error) {
 	return GetTemplateInfo()
 }
 
-func (g *defaultTemplateInfoGetter) GetInfoDefault() (string, string, string, error) {
+func (g *defaultTemplateInfoGetter) GetInfoDefault() (string, string, string, string, error) {
 	return GetTemplateInfoDefault()
 }
 
-func (g *defaultTemplateInfoGetter) GetTemplateVersionFromConfig(arch, lang string) (string, error) {
+// GetTemplateVersionFromConfig returns the version field for a framework-specific template
+// and validates that the requested language is present in the declared list.
+// An empty Languages slice means “any language”.
+func (g *defaultTemplateInfoGetter) GetTemplateVersionFromConfig(framework, lang string) (string, error) {
 	cfg, err := template.LoadConfig()
 	if err != nil {
-		return "", fmt.Errorf("failed to load templates cfg: %w", err)
+		return "", fmt.Errorf("load template cfg: %w", err)
 	}
-	a, ok := cfg.Architectures[arch]
+
+	fw, ok := cfg.Framework[framework]
 	if !ok {
-		return "", fmt.Errorf("architecture %s not found", arch)
+		return "", fmt.Errorf("framework %s not found", framework)
 	}
-	l, ok := a.Languages[lang]
-	if !ok {
-		return "", fmt.Errorf("language %s not found under architecture %s", lang, arch)
+
+	if len(fw.Languages) > 0 {
+		found := false
+		for _, l := range fw.Languages {
+			if l == lang {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return "", fmt.Errorf("language %s not available for framework %s - available languages: %s", lang, framework, strings.Join(fw.Languages, ", "))
+		}
 	}
-	return l.Version, nil
+
+	return fw.Version, nil
 }
 
 // createUpgradeCommand creates an upgrade command with the given dependencies
@@ -67,9 +81,9 @@ func createUpgradeCommand(
 				Value: "go",
 			},
 			&cli.StringFlag{
-				Name:  "arch",
+				Name:  "framework",
 				Usage: "AVS architecture used to generate project files (task-based/hourglass, epoch-based, etc.)",
-				Value: "task",
+				Value: "hourglass",
 			},
 		},
 		Action: func(cCtx *cli.Context) error {
@@ -77,9 +91,9 @@ func createUpgradeCommand(
 			logger := common.LoggerFromContext(cCtx.Context)
 			tracker := common.ProgressTrackerFromContext(cCtx.Context)
 
-			arch := cCtx.String("arch")
+			framework := cCtx.String("framework")
 			lang := cCtx.String("lang")
-			latestVersion, err := infoGetter.GetTemplateVersionFromConfig(arch, lang)
+			latestVersion, err := infoGetter.GetTemplateVersionFromConfig(framework, lang)
 			if err != nil {
 				return fmt.Errorf("failed to get latest version: %w", err)
 			}
@@ -111,14 +125,14 @@ func createUpgradeCommand(
 			}
 
 			// Get template information
-			projectName, templateBaseURL, currentVersion, err := infoGetter.GetInfo()
+			projectName, templateBaseURL, currentVersion, language, err := infoGetter.GetInfo()
 			if err != nil {
 				return err
 			}
 
 			// If the template URL is missing, use the default URL from the getter function
 			if templateBaseURL == "" {
-				_, templateBaseURL, _, _ = infoGetter.GetInfoDefault()
+				_, templateBaseURL, _, _, _ = infoGetter.GetInfoDefault()
 				if templateBaseURL == "" {
 					return fmt.Errorf("no template URL found in config and no default available")
 				}
@@ -147,6 +161,7 @@ func createUpgradeCommand(
 			logger.Info("Upgrading project template:")
 			logger.Info("  Project: %s", projectName)
 			logger.Info("  Template URL: %s", templateBaseURL)
+			logger.Info("  Template Language: %s", language)
 			logger.Info("  Current version: %s", currentVersion)
 			logger.Info("  Target version: %s", requestedVersion)
 			logger.Info("")
@@ -179,7 +194,7 @@ func createUpgradeCommand(
 			logger.Info("Running upgrade script...")
 
 			// Execute the upgrade script, passing the project path as an argument
-			_, err = common.CallTemplateScript(cCtx.Context, logger, tempDir, upgradeScriptPath, common.ExpectNonJSONResponse, []byte(absProjectPath), []byte(currentVersion), []byte(requestedVersion))
+			_, err = common.CallTemplateScript(cCtx.Context, logger, tempDir, upgradeScriptPath, common.ExpectNonJSONResponse, []byte(absProjectPath), []byte(currentVersion), []byte(requestedVersion), []byte(language))
 			if err != nil {
 				return fmt.Errorf("upgrade script execution failed: %w", err)
 			}

--- a/pkg/commands/template/upgrade.go
+++ b/pkg/commands/template/upgrade.go
@@ -35,15 +35,15 @@ func (g *defaultTemplateInfoGetter) GetInfoDefault() (string, string, string, st
 // GetTemplateVersionFromConfig returns the version field for a framework-specific template
 // and validates that the requested language is present in the declared list.
 // An empty Languages slice means “any language”.
-func (g *defaultTemplateInfoGetter) GetTemplateVersionFromConfig(framework, lang string) (string, error) {
+func (g *defaultTemplateInfoGetter) GetTemplateVersionFromConfig(selectedTemplate, lang string) (string, error) {
 	cfg, err := template.LoadConfig()
 	if err != nil {
 		return "", fmt.Errorf("load template cfg: %w", err)
 	}
 
-	fw, ok := cfg.Framework[framework]
+	fw, ok := cfg.Framework[selectedTemplate]
 	if !ok {
-		return "", fmt.Errorf("framework %s not found", framework)
+		return "", fmt.Errorf("framework %s not found", selectedTemplate)
 	}
 
 	if len(fw.Languages) > 0 {
@@ -55,7 +55,7 @@ func (g *defaultTemplateInfoGetter) GetTemplateVersionFromConfig(framework, lang
 			}
 		}
 		if !found {
-			return "", fmt.Errorf("language %s not available for framework %s - available languages: %s", lang, framework, strings.Join(fw.Languages, ", "))
+			return "", fmt.Errorf("language %s not available for framework %s - available languages: %s", lang, selectedTemplate, strings.Join(fw.Languages, ", "))
 		}
 	}
 
@@ -81,7 +81,7 @@ func createUpgradeCommand(
 				Value: "go",
 			},
 			&cli.StringFlag{
-				Name:  "framework",
+				Name:  "template",
 				Usage: "AVS architecture used to generate project files (task-based/hourglass, epoch-based, etc.)",
 				Value: "hourglass",
 			},
@@ -91,9 +91,9 @@ func createUpgradeCommand(
 			logger := common.LoggerFromContext(cCtx.Context)
 			tracker := common.ProgressTrackerFromContext(cCtx.Context)
 
-			framework := cCtx.String("framework")
+			selectedTemplate := cCtx.String("template")
 			lang := cCtx.String("lang")
-			latestVersion, err := infoGetter.GetTemplateVersionFromConfig(framework, lang)
+			latestVersion, err := infoGetter.GetTemplateVersionFromConfig(selectedTemplate, lang)
 			if err != nil {
 				return fmt.Errorf("failed to get latest version: %w", err)
 			}

--- a/pkg/commands/template/upgrade_test.go
+++ b/pkg/commands/template/upgrade_test.go
@@ -46,21 +46,22 @@ type MockTemplateInfoGetter struct {
 	projectName       string
 	templateURL       string
 	templateVersion   string
+	templateLanguage  string
 	shouldReturnError bool
 }
 
-func (m *MockTemplateInfoGetter) GetInfo() (string, string, string, error) {
+func (m *MockTemplateInfoGetter) GetInfo() (string, string, string, string, error) {
 	if m.shouldReturnError {
-		return "", "", "", fmt.Errorf("config/config.yaml not found")
+		return "", "", "", "", fmt.Errorf("config/config.yaml not found")
 	}
-	return m.projectName, m.templateURL, m.templateVersion, nil
+	return m.projectName, m.templateURL, m.templateVersion, m.templateLanguage, nil
 }
 
-func (m *MockTemplateInfoGetter) GetInfoDefault() (string, string, string, error) {
+func (m *MockTemplateInfoGetter) GetInfoDefault() (string, string, string, string, error) {
 	if m.shouldReturnError {
-		return "", "", "", fmt.Errorf("config/config.yaml not found")
+		return "", "", "", "", fmt.Errorf("config/config.yaml not found")
 	}
-	return m.projectName, m.templateURL, m.templateVersion, nil
+	return m.projectName, m.templateURL, m.templateVersion, m.templateLanguage, nil
 }
 
 func (m *MockTemplateInfoGetter) GetTemplateVersionFromConfig(arch, lang string) (string, error) {
@@ -94,6 +95,7 @@ func TestUpgradeCommand(t *testing.T) {
     name: template-upgrade-test
     templateBaseUrl: https://github.com/Layr-Labs/hourglass-avs-template
     templateVersion: v0.0.3
+    templateLanguage: go
 `
 	configPath := filepath.Join(configDir, common.BaseConfig)
 	err = os.WriteFile(configPath, []byte(configContent), 0644)
@@ -103,9 +105,10 @@ func TestUpgradeCommand(t *testing.T) {
 
 	// Create mock template info getter
 	mockTemplateInfoGetter := &MockTemplateInfoGetter{
-		projectName:     "template-upgrade-test",
-		templateURL:     "https://github.com/Layr-Labs/hourglass-avs-template",
-		templateVersion: "v0.0.4",
+		projectName:      "template-upgrade-test",
+		templateURL:      "https://github.com/Layr-Labs/hourglass-avs-template",
+		templateVersion:  "v0.0.4",
+		templateLanguage: "go",
 	}
 
 	// Create the test command with mocked dependencies

--- a/pkg/common/config.go
+++ b/pkg/common/config.go
@@ -26,6 +26,7 @@ type ProjectConfig struct {
 	TelemetryEnabled bool   `json:"telemetry_enabled" yaml:"telemetry_enabled"`
 	TemplateBaseURL  string `json:"templateBaseUrl,omitempty" yaml:"templateBaseUrl,omitempty"`
 	TemplateVersion  string `json:"templateVersion,omitempty" yaml:"templateVersion,omitempty"`
+	TemplateLanguage string `json:"templatelanguage,omitempty" yaml:"templatelanguage,omitempty"`
 }
 
 type ForkConfig struct {

--- a/pkg/template/config_test.go
+++ b/pkg/template/config_test.go
@@ -11,7 +11,7 @@ func TestLoadConfig(t *testing.T) {
 	}
 
 	// Test template URL lookup
-	mainBaseURL, mainVersion, err := GetTemplateURLs(config, "task", "go")
+	mainBaseURL, mainVersion, err := GetTemplateURLs(config, "hourglass", "go")
 	if err != nil {
 		t.Fatalf("Failed to get template URLs: %v", err)
 	}
@@ -29,13 +29,25 @@ func TestLoadConfig(t *testing.T) {
 
 	// Test non-existent architecture
 	mainBaseURL, mainVersion, err = GetTemplateURLs(config, "nonexistent", "go")
-	if err != nil {
-		t.Fatalf("Failed to get template URLs: %v", err)
+	if err == nil {
+		t.Fatalf("Expected to fail to get template URLs: %v", err)
 	}
 	if mainBaseURL != "" {
 		t.Errorf("Expected empty URL for nonexistent architecture, got %s", mainBaseURL)
 	}
 	if mainVersion != "" {
 		t.Errorf("Expected empty version for nonexistent architecture, got %s", mainVersion)
+	}
+
+	// Test non-existent language
+	mainBaseURL, mainVersion, err = GetTemplateURLs(config, "hourglass", "nonexistent")
+	if err == nil {
+		t.Fatalf("Expected to fail to get template URLs: %v", err)
+	}
+	if mainBaseURL != "" {
+		t.Errorf("Expected empty URL for nonexistent language, got %s", mainBaseURL)
+	}
+	if mainVersion != "" {
+		t.Errorf("Expected empty version for nonexistent language, got %s", mainVersion)
 	}
 }

--- a/pkg/template/git_fetcher_test.go
+++ b/pkg/template/git_fetcher_test.go
@@ -145,8 +145,8 @@ func TestCloneRealRepo(t *testing.T) {
 		t.Fatalf("failed to load templates cfg: %v", err)
 	}
 
-	// Use the default task.go template
-	mainBaseURL, mainVersion, err := template.GetTemplateURLs(cfg, "task", "go")
+	// Use the default hourglass.go template
+	mainBaseURL, mainVersion, err := template.GetTemplateURLs(cfg, "hourglass", "go")
 	if err != nil {
 		t.Fatalf("GetTemplateURLs failed: %v", err)
 	}

--- a/pkg/template/git_fetcher_test.go
+++ b/pkg/template/git_fetcher_test.go
@@ -145,7 +145,7 @@ func TestCloneRealRepo(t *testing.T) {
 		t.Fatalf("failed to load templates cfg: %v", err)
 	}
 
-	// Use the default hourglass.go template
+	// Use the default hourglass go template
 	mainBaseURL, mainVersion, err := template.GetTemplateURLs(cfg, "hourglass", "go")
 	if err != nil {
 		t.Fatalf("GetTemplateURLs failed: %v", err)
@@ -185,5 +185,4 @@ func TestCloneRealRepo(t *testing.T) {
 	if len(rows) > 0 {
 		t.Error("expected at least one completed progress row, got none")
 	}
-
 }


### PR DESCRIPTION
<!-- 
    🚨 ATTENTION! 🚨 
    
    This PR template is REQUIRED. PRs not following this format will be closed without review.
    
    Requirements:
    - PR title must follow commit conventions: https://www.conventionalcommits.org/en/v1.0.0/
    - Label your PR with the correct type (e.g., 🐛 Bug, ✨ Enhancement, 🧪 Test, etc.)
    - Provide clear and specific details in each section
-->

**Motivation:**
<!--
Explain here the context, and why you're making that change. What is the problem you're trying to solve.
-->
As a devkit template developer, I need to be responsive to the users template language selection so that I can serve up the correct template on `init`, `build` and `run`.

**Modifications:**
<!--
Describe the modifications you've done from a high level. What are the key technical decisions and why were they made?
-->
- Restructures `templates.yaml` to more closely match new direction (available languages in a framework)
- Store selected `language` into projects `config.yaml`
- Pass selected `language` through to template scripts on `init`, `build` and `run`

**Result:**
<!--
*After your change, what will change.
-->
- Users template language selection can be used by template to construct appropriate project cmd files and makeFile.

**Testing:**
<!--
*List testing procedures taken and useful artifacts.
-->
- Updated unit/integration tests and tested locally

**Open questions:**
<!--
(optional) Any open questions or feedback on design desired?
-->
- Atm, if a user provides custom `templateUrls`/`version`, we do not check that the `language` matches to allow third party templates, in the future, we might want to lock this down (`--experimental` flag?) to prevent invalid `language` selection.