### PR TITLE
fix: ensure context is upgraded before capturing artifact version

### DIFF
--- a/pkg/commands/build.go
+++ b/pkg/commands/build.go
@@ -49,12 +49,6 @@ var BuildCommand = &cli.Command{
 			}
 		}
 
-		// Handle version increment
-		version := cfg.Context["devnet"].Artifact.Version
-		if version == "" {
-			version = "0"
-		}
-
 		// Migrate config
 		configsMigratedCount, err := configs.MigrateConfig(logger)
 		if err != nil {
@@ -71,6 +65,12 @@ var BuildCommand = &cli.Command{
 		}
 		if contextsMigratedCount > 0 {
 			logger.Info("contexts migrated: %d", contextsMigratedCount)
+		}
+
+		// Handle version increment
+		version := cfg.Context["devnet"].Artifact.Version
+		if version == "" {
+			version = "0"
 		}
 
 		logger.Debug("Project Name: %s", cfg.Config.Project.Name)


### PR DESCRIPTION
<!-- 
    🚨 ATTENTION! 🚨 
    
    This PR template is REQUIRED. PRs not following this format will be closed without review.
    
    Requirements:
    - PR title must follow commit conventions: https://www.conventionalcommits.org/en/v1.0.0/
    - Label your PR with the correct type (e.g., 🐛 Bug, ✨ Enhancement, 🧪 Test, etc.)
    - Provide clear and specific details in each section
-->

**Motivation:**
<!--
Explain here the context, and why you're making that change. What is the problem you're trying to solve.
-->
As an AVS developer, I need my context to contain the default `artifact` mapping in my context so that I can correctly select the version.

**Modifications:**
<!--
Describe the modifications you've done from a high level. What are the key technical decisions and why were they made?
-->
- Moves version extraction after config and context migrations

**Result:**
<!--
*After your change, what will change.
-->
- `devkit avs build` runs without seg faulting

**Testing:**
<!--
*List testing procedures taken and useful artifacts.
-->
- Tested locally
