### PR TITLE
fix: update transporter private_keys in migration

### DIFF
--- a/config/contexts/migrations/v0.0.6-v0.0.7.go
+++ b/config/contexts/migrations/v0.0.6-v0.0.7.go
@@ -44,6 +44,22 @@ func Migration_0_0_6_to_0_0_7(user, old, new *yaml.Node) (*yaml.Node, error) {
 					return &yaml.Node{Kind: yaml.ScalarNode, Value: "31338"}
 				},
 			},
+			// Update the transporter private_key
+			{
+				Path:      []string{"context", "transporter", "private_key"},
+				Condition: migration.Always{},
+				Transform: func(_ *yaml.Node) *yaml.Node {
+					return &yaml.Node{Kind: yaml.ScalarNode, Value: "0x5f8e6420b9cb0c940e3d3f8b99177980785906d16fb3571f70d7a05ecf5f2172"}
+				},
+			},
+			// Update the transporter bls_private_key
+			{
+				Path:      []string{"context", "transporter", "bls_private_key"},
+				Condition: migration.Always{},
+				Transform: func(_ *yaml.Node) *yaml.Node {
+					return &yaml.Node{Kind: yaml.ScalarNode, Value: "0x5f8e6420b9cb0c940e3d3f8b99177980785906d16fb3571f70d7a05ecf5f2172"}
+				},
+			},
 			// Update allocation_manager for l1 chain
 			{
 				Path:      []string{"context", "eigenlayer", "l1", "allocation_manager"},


### PR DESCRIPTION
<!-- 
    🚨 ATTENTION! 🚨 
    
    This PR template is REQUIRED. PRs not following this format will be closed without review.
    
    Requirements:
    - PR title must follow commit conventions: https://www.conventionalcommits.org/en/v1.0.0/
    - Label your PR with the correct type (e.g., 🐛 Bug, ✨ Enhancement, 🧪 Test, etc.)
    - Provide clear and specific details in each section
-->

**Motivation:**
<!--
Explain here the context, and why you're making that change. What is the problem you're trying to solve.
-->
As a devkit user, I want to the migration process to update the transporter keys so that the transporter is correctly authed to work on sepolia.

**Modifications:**
<!--
Describe the modifications you've done from a high level. What are the key technical decisions and why were they made?
-->
- Updates v0.0.7 migration to copy new keys to context

**Result:**
<!--
*After your change, what will change.
-->
- Correct keys will be in place for transporter

**Testing:**
<!--
*List testing procedures taken and useful artifacts.
-->
- Tested locally against hotdog-havoc
