### PR TITLE
feat: allow any context to feed core commands

### DIFF
--- a/pkg/commands/build.go
+++ b/pkg/commands/build.go
@@ -7,8 +7,6 @@ import (
 	"github.com/Layr-Labs/devkit-cli/config/configs"
 	"github.com/Layr-Labs/devkit-cli/config/contexts"
 	"github.com/Layr-Labs/devkit-cli/pkg/common"
-	"github.com/Layr-Labs/devkit-cli/pkg/common/devnet"
-	"github.com/Layr-Labs/devkit-cli/pkg/testutils"
 	"gopkg.in/yaml.v3"
 
 	"github.com/urfave/cli/v2"
@@ -54,21 +52,13 @@ var BuildCommand = &cli.Command{
 		// Load selected context
 		contextName := cCtx.String("context")
 
-		// First check if config is in context (for testing)
-		if cfgValue := cCtx.Context.Value(testutils.ConfigContextKey); cfgValue != nil {
-			// Use test config from context
-			cfg = cfgValue.(*common.ConfigWithContextConfig)
-			contextName = devnet.DEVNET_CONTEXT
-		} else {
-			// Load from file if not in context
-			var err error
-			cfg, err = common.LoadConfigWithContextConfig(contextName)
-			if err != nil {
-				return err
-			}
-			if contextName == "" {
-				contextName = cfg.Config.Project.Context
-			}
+		// Load from file if not in context
+		cfg, err = common.LoadConfigWithContextConfig(contextName)
+		if err != nil {
+			return err
+		}
+		if contextName == "" {
+			contextName = cfg.Config.Project.Context
 		}
 
 		// Handle version increment

--- a/pkg/commands/build.go
+++ b/pkg/commands/build.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Layr-Labs/devkit-cli/config/configs"
 	"github.com/Layr-Labs/devkit-cli/config/contexts"
 	"github.com/Layr-Labs/devkit-cli/pkg/common"
+	"github.com/Layr-Labs/devkit-cli/pkg/common/devnet"
 	"github.com/Layr-Labs/devkit-cli/pkg/testutils"
 	"gopkg.in/yaml.v3"
 
@@ -20,8 +21,7 @@ var BuildCommand = &cli.Command{
 	Flags: append([]cli.Flag{
 		&cli.StringFlag{
 			Name:  "context",
-			Usage: "devnet ,testnet or mainnet",
-			Value: "devnet",
+			Usage: "Select the context to use in this command (devnet, testnet or mainnet)",
 		},
 	}, common.GlobalFlags...),
 	Action: func(cCtx *cli.Context) error {
@@ -51,24 +51,28 @@ var BuildCommand = &cli.Command{
 		// Get the config (based on if we're in a test or not)
 		var cfg *common.ConfigWithContextConfig
 
+		// Load selected context
+		contextName := cCtx.String("context")
+
 		// First check if config is in context (for testing)
 		if cfgValue := cCtx.Context.Value(testutils.ConfigContextKey); cfgValue != nil {
 			// Use test config from context
 			cfg = cfgValue.(*common.ConfigWithContextConfig)
+			contextName = devnet.DEVNET_CONTEXT
 		} else {
-			// Load selected context
-			context := cCtx.String("context")
-
 			// Load from file if not in context
 			var err error
-			cfg, err = common.LoadConfigWithContextConfig(context)
+			cfg, err = common.LoadConfigWithContextConfig(contextName)
 			if err != nil {
 				return err
+			}
+			if contextName == "" {
+				contextName = cfg.Config.Project.Context
 			}
 		}
 
 		// Handle version increment
-		version := cfg.Context["devnet"].Artifact.Version
+		version := cfg.Context[contextName].Artifact.Version
 		if version == "" {
 			version = "0"
 		}
@@ -92,7 +96,7 @@ var BuildCommand = &cli.Command{
 		}
 
 		// Load the context yaml file
-		contextPath := filepath.Join("config", "contexts", fmt.Sprintf("%s.yaml", cCtx.String("context")))
+		contextPath := filepath.Join("config", "contexts", fmt.Sprintf("%s.yaml", contextName))
 		contextNode, err := common.LoadYAML(contextPath)
 		if err != nil {
 			return fmt.Errorf("failed to load context yaml: %w", err)

--- a/pkg/commands/build.go
+++ b/pkg/commands/build.go
@@ -52,10 +52,14 @@ var BuildCommand = &cli.Command{
 		// Load selected context
 		contextName := cCtx.String("context")
 
-		// Load from file if not in context
-		cfg, contextName, err = common.LoadConfigWithContextConfig(contextName)
+		// Load config according to provided contextName
+		if contextName == "" {
+			cfg, contextName, err = common.LoadDefaultConfigWithContextConfig()
+		} else {
+			cfg, contextName, err = common.LoadConfigWithContextConfig(contextName)
+		}
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to load configurations: %w", err)
 		}
 
 		// Handle version increment

--- a/pkg/commands/build.go
+++ b/pkg/commands/build.go
@@ -53,12 +53,9 @@ var BuildCommand = &cli.Command{
 		contextName := cCtx.String("context")
 
 		// Load from file if not in context
-		cfg, err = common.LoadConfigWithContextConfig(contextName)
+		cfg, contextName, err = common.LoadConfigWithContextConfig(contextName)
 		if err != nil {
 			return err
-		}
-		if contextName == "" {
-			contextName = cfg.Config.Project.Context
 		}
 
 		// Handle version increment

--- a/pkg/commands/build_test.go
+++ b/pkg/commands/build_test.go
@@ -8,8 +8,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Layr-Labs/devkit-cli/config/configs"
 	"github.com/Layr-Labs/devkit-cli/config/contexts"
 	"github.com/Layr-Labs/devkit-cli/pkg/common"
+	"github.com/Layr-Labs/devkit-cli/pkg/common/devnet"
 	"github.com/Layr-Labs/devkit-cli/pkg/testutils"
 
 	"github.com/urfave/cli/v2"
@@ -25,6 +27,9 @@ func TestBuildCommand(t *testing.T) {
 	}
 	contextsDir := filepath.Join(configDir, "contexts")
 	if err := os.MkdirAll(contextsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "config.yaml"), []byte(configs.ConfigYamls[configs.LatestVersion]), 0644); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(contextsDir, "devnet.yaml"), []byte(contexts.ContextYamls[contexts.LatestVersion]), 0644); err != nil {
@@ -75,7 +80,7 @@ build:
 		Commands: []*cli.Command{testutils.WithTestConfigAndNoopLogger(BuildCommand)},
 	}
 
-	if err := app.Run([]string{"app", "build"}); err != nil {
+	if err := app.Run([]string{"app", "build", "--context", devnet.DEVNET_CONTEXT}); err != nil {
 		t.Errorf("Failed to execute build command: %v", err)
 	}
 }
@@ -91,6 +96,9 @@ func TestBuildCommand_NoContracts(t *testing.T) {
 	}
 	contextsDir := filepath.Join(configDir, "contexts")
 	if err := os.MkdirAll(contextsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "config.yaml"), []byte(configs.ConfigYamls[configs.LatestVersion]), 0644); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(contextsDir, "devnet.yaml"), []byte(contexts.ContextYamls[contexts.LatestVersion]), 0644); err != nil {
@@ -126,7 +134,7 @@ echo "Mock build executed"`
 		Commands: []*cli.Command{testutils.WithTestConfigAndNoopLogger(BuildCommand)},
 	}
 
-	if err := app.Run([]string{"app", "build"}); err != nil {
+	if err := app.Run([]string{"app", "build", "--context", devnet.DEVNET_CONTEXT}); err != nil {
 		t.Errorf("Failed to execute build command: %v", err)
 	}
 }
@@ -141,6 +149,9 @@ func TestBuildCommand_ContextCancellation(t *testing.T) {
 	}
 	contextsDir := filepath.Join(configDir, "contexts")
 	if err := os.MkdirAll(contextsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "config.yaml"), []byte(configs.ConfigYamls[configs.LatestVersion]), 0644); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(contextsDir, "devnet.yaml"), []byte(contexts.ContextYamls[contexts.LatestVersion]), 0644); err != nil {
@@ -177,7 +188,7 @@ echo "Mock build executed"`
 
 	done := make(chan error, 1)
 	go func() {
-		done <- app.RunContext(ctx, []string{"app", "build"})
+		done <- app.RunContext(ctx, []string{"app", "build", "--context", devnet.DEVNET_CONTEXT})
 	}()
 
 	cancel()

--- a/pkg/commands/call.go
+++ b/pkg/commands/call.go
@@ -15,7 +15,12 @@ import (
 var CallCommand = &cli.Command{
 	Name:  "call",
 	Usage: "Submits tasks to the local devnet, triggers off-chain execution, and aggregates results",
-	Flags: common.GlobalFlags,
+	Flags: append([]cli.Flag{
+		&cli.StringFlag{
+			Name:  "context",
+			Usage: "Select the context to use in this command (devnet, testnet or mainnet)",
+		},
+	}, common.GlobalFlags...),
 	Action: func(cCtx *cli.Context) error {
 		// Get logger
 		logger := common.LoggerFromContext(cCtx.Context)
@@ -23,7 +28,7 @@ var CallCommand = &cli.Command{
 		logger.Debug("Testing AVS tasks...")
 
 		// Set path for context yaml
-		contextJSON, err := common.LoadRawContext("devnet") // @TODO: use selected context name
+		contextJSON, err := common.LoadRawContext(cCtx.String("context"))
 		if err != nil {
 			return fmt.Errorf("failed to load context %w", err)
 		}

--- a/pkg/commands/call.go
+++ b/pkg/commands/call.go
@@ -27,10 +27,19 @@ var CallCommand = &cli.Command{
 
 		logger.Debug("Testing AVS tasks...")
 
+		// Check for flagged contextName
+		contextName := cCtx.String("context")
+
 		// Set path for context yaml
-		contextJSON, err := common.LoadRawContext(cCtx.String("context"))
+		var err error
+		var contextJSON []byte
+		if contextName == "" {
+			contextJSON, _, err = common.LoadDefaultRawContext()
+		} else {
+			contextJSON, _, err = common.LoadRawContext(contextName)
+		}
 		if err != nil {
-			return fmt.Errorf("failed to load context %w", err)
+			return fmt.Errorf("failed to load context: %w", err)
 		}
 
 		// Run scriptPath from cwd

--- a/pkg/commands/context/context_create.go
+++ b/pkg/commands/context/context_create.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/Layr-Labs/devkit-cli/config/contexts"
 	"github.com/Layr-Labs/devkit-cli/pkg/common"
+	"github.com/Layr-Labs/devkit-cli/pkg/common/devnet"
 	"github.com/urfave/cli/v2"
 )
 
@@ -64,7 +65,7 @@ func CreateContext(contextPath, context string) error {
 	entryName := fmt.Sprintf("%s.yaml", context)
 
 	// Place the context name in place
-	contentString := strings.ReplaceAll(string(content), "devnet", context)
+	contentString := strings.ReplaceAll(string(content), devnet.DEVNET_CONTEXT, context)
 
 	// Write the new context
 	err := os.WriteFile(contextPath, []byte(contentString), 0644)

--- a/pkg/commands/create_test.go
+++ b/pkg/commands/create_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Layr-Labs/devkit-cli/config/configs"
 	"github.com/Layr-Labs/devkit-cli/config/contexts"
 	"github.com/Layr-Labs/devkit-cli/pkg/common"
+	"github.com/Layr-Labs/devkit-cli/pkg/common/devnet"
 	"github.com/Layr-Labs/devkit-cli/pkg/common/logger"
 	"github.com/Layr-Labs/devkit-cli/pkg/template"
 	"github.com/Layr-Labs/devkit-cli/pkg/testutils"
@@ -190,7 +191,7 @@ build:
 		Commands: []*cli.Command{testutils.WithTestConfigAndNoopLogger(BuildCommand)},
 	}
 
-	if err := buildApp.Run([]string{"app", "build"}); err != nil {
+	if err := buildApp.Run([]string{"app", "build", "--context", devnet.DEVNET_CONTEXT}); err != nil {
 		t.Errorf("Failed to execute build command: %v", err)
 	}
 }

--- a/pkg/commands/devnet.go
+++ b/pkg/commands/devnet.go
@@ -14,6 +14,10 @@ var DevnetCommand = &cli.Command{
 			Name:  "start",
 			Usage: "Starts Docker containers and deploys local contracts",
 			Flags: append([]cli.Flag{
+				&cli.StringFlag{
+					Name:  "context",
+					Usage: "Select the context to use in this command (devnet, testnet or mainnet)",
+				},
 				&cli.BoolFlag{
 					Name:  "reset",
 					Usage: "Wipe and restart the devnet from scratch",

--- a/pkg/commands/devnet_actions.go
+++ b/pkg/commands/devnet_actions.go
@@ -737,9 +737,6 @@ func StopDevnetAction(cCtx *cli.Context) error {
 		if err != nil {
 			return err
 		}
-		if contextName == "" {
-			contextName = config.Config.Project.Context
-		}
 
 		// Stop both L1 and L2 containers
 		l1Container := fmt.Sprintf("devkit-devnet-l1-%s", config.Config.Project.Name)

--- a/pkg/commands/devnet_actions.go
+++ b/pkg/commands/devnet_actions.go
@@ -88,12 +88,9 @@ func StartDevnetAction(cCtx *cli.Context) error {
 	}
 
 	// Load config for selected context
-	config, err := common.LoadConfigWithContextConfig(contextName)
+	config, contextName, err := common.LoadConfigWithContextConfig(contextName)
 	if err != nil {
 		return err
-	}
-	if contextName == "" {
-		contextName = config.Config.Project.Context
 	}
 
 	// Check for context
@@ -481,12 +478,9 @@ func DeployL2ContractsAction(cCtx *cli.Context) error {
 	}
 
 	// Check for context
-	yamlPath, rootNode, contextNode, err := common.LoadContext(contextName)
+	yamlPath, rootNode, contextNode, contextName, err := common.LoadContext(contextName)
 	if err != nil {
 		return fmt.Errorf("context loading failed: %w", err)
-	}
-	if contextName == "" {
-		contextName = common.GetChildByKey(contextNode, "name").Value
 	}
 
 	// Loop scripts with cloned context
@@ -587,12 +581,9 @@ func DeployContractsAction(cCtx *cli.Context) error {
 	}
 
 	// Check for context
-	yamlPath, rootNode, contextNode, err := common.LoadContext(contextName)
+	yamlPath, rootNode, contextNode, contextName, err := common.LoadContext(contextName)
 	if err != nil {
 		return fmt.Errorf("context loading failed: %w", err)
-	}
-	if contextName == "" {
-		contextName = common.GetChildByKey(contextNode, "name").Value
 	}
 
 	// Loop scripts with cloned context
@@ -733,7 +724,7 @@ func StopDevnetAction(cCtx *cli.Context) error {
 
 	if devnet.FileExistsInRoot(filepath.Join(common.DefaultConfigWithContextConfigPath, common.BaseConfig)) {
 		// Load config
-		config, err := common.LoadConfigWithContextConfig(contextName)
+		config, _, err := common.LoadConfigWithContextConfig(contextName)
 		if err != nil {
 			return err
 		}
@@ -744,7 +735,6 @@ func StopDevnetAction(cCtx *cli.Context) error {
 
 		devnet.StopAndRemoveContainer(cCtx, l1Container)
 		devnet.StopAndRemoveContainer(cCtx, l2Container)
-
 	} else {
 		log.Info("Run this command from the avs directory  or run %sdevkit avs devnet stop --help%s for available commands", devnet.Cyan, devnet.Reset)
 	}
@@ -786,12 +776,9 @@ func UpdateAVSMetadataAction(cCtx *cli.Context, logger iface.Logger) error {
 	// Extract vars
 	contextName := cCtx.String("context")
 
-	cfg, err := common.LoadConfigWithContextConfig(contextName)
+	cfg, contextName, err := common.LoadConfigWithContextConfig(contextName)
 	if err != nil {
 		return fmt.Errorf("failed to load configurations: %w", err)
-	}
-	if contextName == "" {
-		contextName = cfg.Config.Project.Context
 	}
 	uri := cCtx.String("uri")
 	envCtx, ok := cfg.Context[contextName]
@@ -833,14 +820,10 @@ func SetAVSRegistrarAction(cCtx *cli.Context, logger iface.Logger) error {
 	// Extract vars
 	contextName := cCtx.String("context")
 
-	cfg, err := common.LoadConfigWithContextConfig(contextName)
+	cfg, contextName, err := common.LoadConfigWithContextConfig(contextName)
 	if err != nil {
 		return fmt.Errorf("failed to load configurations: %w", err)
 	}
-	if contextName == "" {
-		contextName = cfg.Config.Project.Context
-	}
-
 	envCtx, ok := cfg.Context[contextName]
 	if !ok {
 		return fmt.Errorf("context '%s' not found in configuration", contextName)
@@ -895,14 +878,10 @@ func CreateAVSOperatorSetsAction(cCtx *cli.Context, logger iface.Logger) error {
 	// Extract vars
 	contextName := cCtx.String("context")
 
-	cfg, err := common.LoadConfigWithContextConfig(contextName)
+	cfg, contextName, err := common.LoadConfigWithContextConfig(contextName)
 	if err != nil {
 		return fmt.Errorf("failed to load configurations: %w", err)
 	}
-	if contextName == "" {
-		contextName = cfg.Config.Project.Context
-	}
-
 	envCtx, ok := cfg.Context[contextName]
 	if !ok {
 		return fmt.Errorf("context '%s' not found in configuration", contextName)
@@ -958,14 +937,10 @@ func DelegateToOperatorsAction(cCtx *cli.Context, logger iface.Logger) error {
 	// Extract vars
 	contextName := cCtx.String("context")
 
-	cfg, err := common.LoadConfigWithContextConfig(contextName)
+	cfg, contextName, err := common.LoadConfigWithContextConfig(contextName)
 	if err != nil {
 		return fmt.Errorf("failed to load configurations for delegate to operators: %w", err)
 	}
-	if contextName == "" {
-		contextName = cfg.Config.Project.Context
-	}
-
 	envCtx, ok := cfg.Context[contextName]
 	if !ok {
 		return fmt.Errorf("context '%s' not found in configuration", contextName)
@@ -988,14 +963,10 @@ func DepositIntoStrategiesAction(cCtx *cli.Context, logger iface.Logger) error {
 	// Extract vars
 	contextName := cCtx.String("context")
 
-	cfg, err := common.LoadConfigWithContextConfig(contextName)
+	cfg, contextName, err := common.LoadConfigWithContextConfig(contextName)
 	if err != nil {
 		return fmt.Errorf("failed to load configurations for deposit into strategies: %w", err)
 	}
-	if contextName == "" {
-		contextName = cfg.Config.Project.Context
-	}
-
 	envCtx, ok := cfg.Context[contextName]
 	if !ok {
 		return fmt.Errorf("context '%s' not found in configuration", contextName)
@@ -1017,12 +988,9 @@ func RegisterOperatorsToEigenLayerFromConfigAction(cCtx *cli.Context, logger ifa
 	// Extract vars
 	contextName := cCtx.String("context")
 
-	cfg, err := common.LoadConfigWithContextConfig(contextName)
+	cfg, contextName, err := common.LoadConfigWithContextConfig(contextName)
 	if err != nil {
 		return fmt.Errorf("failed to load configurations for operator registration: %w", err)
-	}
-	if contextName == "" {
-		contextName = cfg.Config.Project.Context
 	}
 	envCtx, ok := cfg.Context[contextName]
 	if !ok {
@@ -1050,12 +1018,9 @@ func RegisterOperatorsToAvsFromConfigAction(cCtx *cli.Context, logger iface.Logg
 	// Extract vars
 	contextName := cCtx.String("context")
 
-	cfg, err := common.LoadConfigWithContextConfig(contextName)
+	cfg, contextName, err := common.LoadConfigWithContextConfig(contextName)
 	if err != nil {
 		return fmt.Errorf("failed to load configurations for operator registration: %w", err)
-	}
-	if contextName == "" {
-		contextName = cfg.Config.Project.Context
 	}
 	envCtx, ok := cfg.Context[contextName]
 	if !ok {
@@ -1086,12 +1051,9 @@ func FetchZeusAddressesAction(cCtx *cli.Context) error {
 	contextName := cCtx.String("context")
 
 	// Check for context
-	yamlPath, rootNode, contextNode, err := common.LoadContext(contextName)
+	yamlPath, rootNode, contextNode, contextName, err := common.LoadContext(contextName)
 	if err != nil {
 		return fmt.Errorf("context loading failed: %w", err)
-	}
-	if contextName == "" {
-		contextName = common.GetChildByKey(contextNode, "name").Value
 	}
 
 	// Update the context with the fetched addresses
@@ -1126,14 +1088,10 @@ func registerOperatorEL(cCtx *cli.Context, operatorAddress string, logger iface.
 		return fmt.Errorf("operatorAddress parameter is required and cannot be empty")
 	}
 
-	cfg, err := common.LoadConfigWithContextConfig(contextName)
+	cfg, contextName, err := common.LoadConfigWithContextConfig(contextName)
 	if err != nil {
 		return fmt.Errorf("failed to load configurations: %w", err)
 	}
-	if contextName == "" {
-		contextName = cfg.Config.Project.Context
-	}
-
 	envCtx, ok := cfg.Context[contextName]
 	if !ok {
 		return fmt.Errorf("context '%s' not found in configuration", contextName)
@@ -1203,14 +1161,10 @@ func registerOperatorAVS(cCtx *cli.Context, logger iface.Logger, operatorAddress
 		return fmt.Errorf("payloadHex parameter is required and cannot be empty")
 	}
 
-	cfg, err := common.LoadConfigWithContextConfig(contextName)
+	cfg, contextName, err := common.LoadConfigWithContextConfig(contextName)
 	if err != nil {
 		return fmt.Errorf("failed to load configurations: %w", err)
 	}
-	if contextName == "" {
-		contextName = cfg.Config.Project.Context
-	}
-
 	envCtx, ok := cfg.Context[contextName]
 	if !ok {
 		return fmt.Errorf("context '%s' not found in configuration", contextName)
@@ -1289,14 +1243,10 @@ func depositIntoStrategy(cCtx *cli.Context, stakerSpec common.StakerSpec, logger
 		return fmt.Errorf("staker address parameter is required and cannot be empty")
 	}
 
-	cfg, err := common.LoadConfigWithContextConfig(contextName)
+	cfg, contextName, err := common.LoadConfigWithContextConfig(contextName)
 	if err != nil {
 		return fmt.Errorf("failed to load configurations: %w", err)
 	}
-	if contextName == "" {
-		contextName = cfg.Config.Project.Context
-	}
-
 	envCtx, ok := cfg.Context[contextName]
 	if !ok {
 		return fmt.Errorf("context '%s' not found in configuration", contextName)
@@ -1351,14 +1301,10 @@ func delegateToOperator(cCtx *cli.Context, stakerSpec common.StakerSpec, operato
 	// Extract vars
 	contextName := cCtx.String("context")
 
-	cfg, err := common.LoadConfigWithContextConfig(contextName)
+	cfg, contextName, err := common.LoadConfigWithContextConfig(contextName)
 	if err != nil {
 		return fmt.Errorf("failed to load configurations: %w", err)
 	}
-	if contextName == "" {
-		contextName = cfg.Config.Project.Context
-	}
-
 	envCtx, ok := cfg.Context[contextName]
 	if !ok {
 		return fmt.Errorf("context '%s' not found in configuration", contextName)
@@ -1504,12 +1450,9 @@ func ModifyAllocationsAction(cCtx *cli.Context, logger iface.Logger) error {
 	contextName := cCtx.String("context")
 
 	// Load context + config
-	cfg, err := common.LoadConfigWithContextConfig(contextName)
+	cfg, contextName, err := common.LoadConfigWithContextConfig(contextName)
 	if err != nil {
 		return fmt.Errorf("failed to load configurations for modify allocations: %w", err)
-	}
-	if contextName == "" {
-		contextName = cfg.Config.Project.Context
 	}
 	envCtx, ok := cfg.Context[contextName]
 	if !ok {
@@ -1545,12 +1488,9 @@ func modifyAllocations(cCtx *cli.Context, operatorAddress string, operatorPrivat
 		return fmt.Errorf("modifyAllocations:operatorAddress parameter is required and cannot be empty")
 	}
 
-	cfg, err := common.LoadConfigWithContextConfig(contextName)
+	cfg, contextName, err := common.LoadConfigWithContextConfig(contextName)
 	if err != nil {
 		return fmt.Errorf("failed to load configurations: %w", err)
-	}
-	if contextName == "" {
-		contextName = cfg.Config.Project.Context
 	}
 	envCtx, ok := cfg.Context[contextName]
 	if !ok {
@@ -1684,12 +1624,9 @@ func SetAllocationDelayAction(cCtx *cli.Context, logger iface.Logger) error {
 	// Extract vars
 	contextName := cCtx.String("context")
 
-	cfg, err := common.LoadConfigWithContextConfig(contextName)
+	cfg, contextName, err := common.LoadConfigWithContextConfig(contextName)
 	if err != nil {
 		return fmt.Errorf("failed to load configurations for set allocation delay: %w", err)
-	}
-	if contextName == "" {
-		contextName = cfg.Config.Project.Context
 	}
 	envCtx, ok := cfg.Context[contextName]
 	if !ok {
@@ -1784,12 +1721,9 @@ func ConfigureOpSetCurveTypeAction(cCtx *cli.Context, logger iface.Logger) error
 	// Extract vars
 	contextName := cCtx.String("context")
 
-	cfg, err := common.LoadConfigWithContextConfig(contextName)
+	cfg, contextName, err := common.LoadConfigWithContextConfig(contextName)
 	if err != nil {
 		return fmt.Errorf("failed to load configurations for configure op set curve type: %w", err)
-	}
-	if contextName == "" {
-		contextName = cfg.Config.Project.Context
 	}
 	envCtx, ok := cfg.Context[contextName]
 	if !ok {
@@ -1863,12 +1797,9 @@ func CreateGenerationReservationAction(cCtx *cli.Context, logger iface.Logger) e
 	// Extract vars
 	contextName := cCtx.String("context")
 
-	cfg, err := common.LoadConfigWithContextConfig(contextName)
+	cfg, contextName, err := common.LoadConfigWithContextConfig(contextName)
 	if err != nil {
 		return fmt.Errorf("failed to load configurations for request op set generation reservation: %w", err)
-	}
-	if contextName == "" {
-		contextName = cfg.Config.Project.Context
 	}
 	envCtx, ok := cfg.Context[contextName]
 	if !ok {
@@ -1929,12 +1860,9 @@ func WhitelistChainIdInCrossRegistryAction(cCtx *cli.Context, logger iface.Logge
 		return nil
 	}
 
-	cfg, err := common.LoadConfigWithContextConfig(contextName)
+	cfg, contextName, err := common.LoadConfigWithContextConfig(contextName)
 	if err != nil {
 		return fmt.Errorf("failed to load configurations for whitelist chain id in cross registry: %w", err)
-	}
-	if contextName == "" {
-		contextName = cfg.Config.Project.Context
 	}
 	envCtx, ok := cfg.Context[contextName]
 	if !ok {
@@ -1998,12 +1926,9 @@ func RegisterKeyInKeyRegistrarAction(cCtx *cli.Context, logger iface.Logger) err
 	// Extract vars
 	contextName := cCtx.String("context")
 
-	cfg, err := common.LoadConfigWithContextConfig(contextName)
+	cfg, contextName, err := common.LoadConfigWithContextConfig(contextName)
 	if err != nil {
 		return fmt.Errorf("failed to load configurations for register key in key registrar: %w", err)
-	}
-	if contextName == "" {
-		contextName = cfg.Config.Project.Context
 	}
 	envCtx, ok := cfg.Context[contextName]
 	if !ok {

--- a/pkg/commands/devnet_actions.go
+++ b/pkg/commands/devnet_actions.go
@@ -745,9 +745,9 @@ func StopDevnetAction(cCtx *cli.Context) error {
 		var err error
 		var config *common.ConfigWithContextConfig
 		if contextName == "" {
-			config, contextName, err = common.LoadDefaultConfigWithContextConfig()
+			config, _, err = common.LoadDefaultConfigWithContextConfig()
 		} else {
-			config, contextName, err = common.LoadConfigWithContextConfig(contextName)
+			config, _, err = common.LoadConfigWithContextConfig(contextName)
 		}
 		if err != nil {
 			return fmt.Errorf("loading config and context failed: %w", err)

--- a/pkg/commands/devnet_actions.go
+++ b/pkg/commands/devnet_actions.go
@@ -34,6 +34,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/urfave/cli/v2"
+	"gopkg.in/yaml.v3"
 )
 
 type DeployContractTransport struct {
@@ -88,15 +89,20 @@ func StartDevnetAction(cCtx *cli.Context) error {
 	}
 
 	// Load config for selected context
-	config, contextName, err := common.LoadConfigWithContextConfig(contextName)
+	var config *common.ConfigWithContextConfig
+	if contextName == "" {
+		config, contextName, err = common.LoadDefaultConfigWithContextConfig()
+	} else {
+		config, contextName, err = common.LoadConfigWithContextConfig(contextName)
+	}
 	if err != nil {
-		return err
+		return fmt.Errorf("loading config and context failed: %w", err)
 	}
 
-	// Check for context
-	yamlPath, rootNode, contextNode, err := common.LoadContext(contextName)
+	// Load the context nodes
+	yamlPath, rootNode, contextNode, contextName, err := common.LoadContext(contextName)
 	if err != nil {
-		return fmt.Errorf("context loading failed: %w", err)
+		return fmt.Errorf("loading context nodes failed: %w", err)
 	}
 
 	// Fetch EigenLayer addresses using Zeus if requested
@@ -451,9 +457,9 @@ func StartDevnetAction(cCtx *cli.Context) error {
 }
 
 func DeployL2ContractsAction(cCtx *cli.Context) error {
-
 	// Get logger
 	logger := common.LoggerFromContext(cCtx.Context)
+
 	// Check if docker is running, else try to start it
 	err := common.EnsureDockerIsRunning(cCtx)
 	if err != nil {
@@ -478,7 +484,13 @@ func DeployL2ContractsAction(cCtx *cli.Context) error {
 	}
 
 	// Check for context
-	yamlPath, rootNode, contextNode, contextName, err := common.LoadContext(contextName)
+	var yamlPath string
+	var rootNode, contextNode *yaml.Node
+	if contextName == "" {
+		yamlPath, rootNode, contextNode, contextName, err = common.LoadDefaultContext()
+	} else {
+		yamlPath, rootNode, contextNode, contextName, err = common.LoadContext(contextName)
+	}
 	if err != nil {
 		return fmt.Errorf("context loading failed: %w", err)
 	}
@@ -581,7 +593,13 @@ func DeployContractsAction(cCtx *cli.Context) error {
 	}
 
 	// Check for context
-	yamlPath, rootNode, contextNode, contextName, err := common.LoadContext(contextName)
+	var yamlPath string
+	var rootNode, contextNode *yaml.Node
+	if contextName == "" {
+		yamlPath, rootNode, contextNode, contextName, err = common.LoadDefaultContext()
+	} else {
+		yamlPath, rootNode, contextNode, contextName, err = common.LoadContext(contextName)
+	}
 	if err != nil {
 		return fmt.Errorf("context loading failed: %w", err)
 	}
@@ -724,9 +742,15 @@ func StopDevnetAction(cCtx *cli.Context) error {
 
 	if devnet.FileExistsInRoot(filepath.Join(common.DefaultConfigWithContextConfigPath, common.BaseConfig)) {
 		// Load config
-		config, _, err := common.LoadConfigWithContextConfig(contextName)
+		var err error
+		var config *common.ConfigWithContextConfig
+		if contextName == "" {
+			config, contextName, err = common.LoadDefaultConfigWithContextConfig()
+		} else {
+			config, contextName, err = common.LoadConfigWithContextConfig(contextName)
+		}
 		if err != nil {
-			return err
+			return fmt.Errorf("loading config and context failed: %w", err)
 		}
 
 		// Stop both L1 and L2 containers
@@ -776,10 +800,18 @@ func UpdateAVSMetadataAction(cCtx *cli.Context, logger iface.Logger) error {
 	// Extract vars
 	contextName := cCtx.String("context")
 
-	cfg, contextName, err := common.LoadConfigWithContextConfig(contextName)
-	if err != nil {
-		return fmt.Errorf("failed to load configurations: %w", err)
+	// Load config according to provided contextName
+	var err error
+	var cfg *common.ConfigWithContextConfig
+	if contextName == "" {
+		cfg, contextName, err = common.LoadDefaultConfigWithContextConfig()
+	} else {
+		cfg, contextName, err = common.LoadConfigWithContextConfig(contextName)
 	}
+	if err != nil {
+		return fmt.Errorf("loading config and context failed: %w", err)
+	}
+
 	uri := cCtx.String("uri")
 	envCtx, ok := cfg.Context[contextName]
 	if !ok {
@@ -820,10 +852,19 @@ func SetAVSRegistrarAction(cCtx *cli.Context, logger iface.Logger) error {
 	// Extract vars
 	contextName := cCtx.String("context")
 
-	cfg, contextName, err := common.LoadConfigWithContextConfig(contextName)
-	if err != nil {
-		return fmt.Errorf("failed to load configurations: %w", err)
+	// Load config according to provided contextName
+	var err error
+	var cfg *common.ConfigWithContextConfig
+	if contextName == "" {
+		cfg, contextName, err = common.LoadDefaultConfigWithContextConfig()
+	} else {
+		cfg, contextName, err = common.LoadConfigWithContextConfig(contextName)
 	}
+	if err != nil {
+		return fmt.Errorf("loading config and context failed: %w", err)
+	}
+
+	// Extract context details
 	envCtx, ok := cfg.Context[contextName]
 	if !ok {
 		return fmt.Errorf("context '%s' not found in configuration", contextName)
@@ -878,10 +919,19 @@ func CreateAVSOperatorSetsAction(cCtx *cli.Context, logger iface.Logger) error {
 	// Extract vars
 	contextName := cCtx.String("context")
 
-	cfg, contextName, err := common.LoadConfigWithContextConfig(contextName)
-	if err != nil {
-		return fmt.Errorf("failed to load configurations: %w", err)
+	// Load config according to provided contextName
+	var err error
+	var cfg *common.ConfigWithContextConfig
+	if contextName == "" {
+		cfg, contextName, err = common.LoadDefaultConfigWithContextConfig()
+	} else {
+		cfg, contextName, err = common.LoadConfigWithContextConfig(contextName)
 	}
+	if err != nil {
+		return fmt.Errorf("loading config and context failed: %w", err)
+	}
+
+	// Extract context details
 	envCtx, ok := cfg.Context[contextName]
 	if !ok {
 		return fmt.Errorf("context '%s' not found in configuration", contextName)
@@ -937,10 +987,19 @@ func DelegateToOperatorsAction(cCtx *cli.Context, logger iface.Logger) error {
 	// Extract vars
 	contextName := cCtx.String("context")
 
-	cfg, contextName, err := common.LoadConfigWithContextConfig(contextName)
+	// Load config according to provided contextName
+	var err error
+	var cfg *common.ConfigWithContextConfig
+	if contextName == "" {
+		cfg, contextName, err = common.LoadDefaultConfigWithContextConfig()
+	} else {
+		cfg, contextName, err = common.LoadConfigWithContextConfig(contextName)
+	}
 	if err != nil {
 		return fmt.Errorf("failed to load configurations for delegate to operators: %w", err)
 	}
+
+	// Extract context details
 	envCtx, ok := cfg.Context[contextName]
 	if !ok {
 		return fmt.Errorf("context '%s' not found in configuration", contextName)
@@ -963,10 +1022,19 @@ func DepositIntoStrategiesAction(cCtx *cli.Context, logger iface.Logger) error {
 	// Extract vars
 	contextName := cCtx.String("context")
 
-	cfg, contextName, err := common.LoadConfigWithContextConfig(contextName)
+	// Load config according to provided contextName
+	var err error
+	var cfg *common.ConfigWithContextConfig
+	if contextName == "" {
+		cfg, contextName, err = common.LoadDefaultConfigWithContextConfig()
+	} else {
+		cfg, contextName, err = common.LoadConfigWithContextConfig(contextName)
+	}
 	if err != nil {
 		return fmt.Errorf("failed to load configurations for deposit into strategies: %w", err)
 	}
+
+	// Extract context details
 	envCtx, ok := cfg.Context[contextName]
 	if !ok {
 		return fmt.Errorf("context '%s' not found in configuration", contextName)
@@ -988,10 +1056,19 @@ func RegisterOperatorsToEigenLayerFromConfigAction(cCtx *cli.Context, logger ifa
 	// Extract vars
 	contextName := cCtx.String("context")
 
-	cfg, contextName, err := common.LoadConfigWithContextConfig(contextName)
+	// Load config according to provided contextName
+	var err error
+	var cfg *common.ConfigWithContextConfig
+	if contextName == "" {
+		cfg, contextName, err = common.LoadDefaultConfigWithContextConfig()
+	} else {
+		cfg, contextName, err = common.LoadConfigWithContextConfig(contextName)
+	}
 	if err != nil {
 		return fmt.Errorf("failed to load configurations for operator registration: %w", err)
 	}
+
+	// Extract context details
 	envCtx, ok := cfg.Context[contextName]
 	if !ok {
 		return fmt.Errorf("context '%s' not found in configuration", contextName)
@@ -1018,10 +1095,19 @@ func RegisterOperatorsToAvsFromConfigAction(cCtx *cli.Context, logger iface.Logg
 	// Extract vars
 	contextName := cCtx.String("context")
 
-	cfg, contextName, err := common.LoadConfigWithContextConfig(contextName)
+	// Load config according to provided contextName
+	var err error
+	var cfg *common.ConfigWithContextConfig
+	if contextName == "" {
+		cfg, contextName, err = common.LoadDefaultConfigWithContextConfig()
+	} else {
+		cfg, contextName, err = common.LoadConfigWithContextConfig(contextName)
+	}
 	if err != nil {
 		return fmt.Errorf("failed to load configurations for operator registration: %w", err)
 	}
+
+	// Extract context details
 	envCtx, ok := cfg.Context[contextName]
 	if !ok {
 		return fmt.Errorf("context '%s' not found in configuration", contextName)
@@ -1051,7 +1137,14 @@ func FetchZeusAddressesAction(cCtx *cli.Context) error {
 	contextName := cCtx.String("context")
 
 	// Check for context
-	yamlPath, rootNode, contextNode, contextName, err := common.LoadContext(contextName)
+	var yamlPath string
+	var rootNode, contextNode *yaml.Node
+	var err error
+	if contextName == "" {
+		yamlPath, rootNode, contextNode, contextName, err = common.LoadDefaultContext()
+	} else {
+		yamlPath, rootNode, contextNode, contextName, err = common.LoadContext(contextName)
+	}
 	if err != nil {
 		return fmt.Errorf("context loading failed: %w", err)
 	}
@@ -1088,10 +1181,19 @@ func registerOperatorEL(cCtx *cli.Context, operatorAddress string, logger iface.
 		return fmt.Errorf("operatorAddress parameter is required and cannot be empty")
 	}
 
-	cfg, contextName, err := common.LoadConfigWithContextConfig(contextName)
+	// Load config according to provided contextName
+	var err error
+	var cfg *common.ConfigWithContextConfig
+	if contextName == "" {
+		cfg, contextName, err = common.LoadDefaultConfigWithContextConfig()
+	} else {
+		cfg, contextName, err = common.LoadConfigWithContextConfig(contextName)
+	}
 	if err != nil {
 		return fmt.Errorf("failed to load configurations: %w", err)
 	}
+
+	// Extract context details
 	envCtx, ok := cfg.Context[contextName]
 	if !ok {
 		return fmt.Errorf("context '%s' not found in configuration", contextName)
@@ -1161,10 +1263,19 @@ func registerOperatorAVS(cCtx *cli.Context, logger iface.Logger, operatorAddress
 		return fmt.Errorf("payloadHex parameter is required and cannot be empty")
 	}
 
-	cfg, contextName, err := common.LoadConfigWithContextConfig(contextName)
+	// Load config according to provided contextName
+	var err error
+	var cfg *common.ConfigWithContextConfig
+	if contextName == "" {
+		cfg, contextName, err = common.LoadDefaultConfigWithContextConfig()
+	} else {
+		cfg, contextName, err = common.LoadConfigWithContextConfig(contextName)
+	}
 	if err != nil {
 		return fmt.Errorf("failed to load configurations: %w", err)
 	}
+
+	// Extract context details
 	envCtx, ok := cfg.Context[contextName]
 	if !ok {
 		return fmt.Errorf("context '%s' not found in configuration", contextName)
@@ -1243,10 +1354,19 @@ func depositIntoStrategy(cCtx *cli.Context, stakerSpec common.StakerSpec, logger
 		return fmt.Errorf("staker address parameter is required and cannot be empty")
 	}
 
-	cfg, contextName, err := common.LoadConfigWithContextConfig(contextName)
+	// Load config according to provided contextName
+	var err error
+	var cfg *common.ConfigWithContextConfig
+	if contextName == "" {
+		cfg, contextName, err = common.LoadDefaultConfigWithContextConfig()
+	} else {
+		cfg, contextName, err = common.LoadConfigWithContextConfig(contextName)
+	}
 	if err != nil {
 		return fmt.Errorf("failed to load configurations: %w", err)
 	}
+
+	// Extract context details
 	envCtx, ok := cfg.Context[contextName]
 	if !ok {
 		return fmt.Errorf("context '%s' not found in configuration", contextName)
@@ -1301,10 +1421,19 @@ func delegateToOperator(cCtx *cli.Context, stakerSpec common.StakerSpec, operato
 	// Extract vars
 	contextName := cCtx.String("context")
 
-	cfg, contextName, err := common.LoadConfigWithContextConfig(contextName)
+	// Load config according to provided contextName
+	var err error
+	var cfg *common.ConfigWithContextConfig
+	if contextName == "" {
+		cfg, contextName, err = common.LoadDefaultConfigWithContextConfig()
+	} else {
+		cfg, contextName, err = common.LoadConfigWithContextConfig(contextName)
+	}
 	if err != nil {
 		return fmt.Errorf("failed to load configurations: %w", err)
 	}
+
+	// Extract context details
 	envCtx, ok := cfg.Context[contextName]
 	if !ok {
 		return fmt.Errorf("context '%s' not found in configuration", contextName)
@@ -1449,11 +1578,19 @@ func ModifyAllocationsAction(cCtx *cli.Context, logger iface.Logger) error {
 	// Extract vars
 	contextName := cCtx.String("context")
 
-	// Load context + config
-	cfg, contextName, err := common.LoadConfigWithContextConfig(contextName)
+	// Load config according to provided contextName
+	var err error
+	var cfg *common.ConfigWithContextConfig
+	if contextName == "" {
+		cfg, contextName, err = common.LoadDefaultConfigWithContextConfig()
+	} else {
+		cfg, contextName, err = common.LoadConfigWithContextConfig(contextName)
+	}
 	if err != nil {
 		return fmt.Errorf("failed to load configurations for modify allocations: %w", err)
 	}
+
+	// Extract context details
 	envCtx, ok := cfg.Context[contextName]
 	if !ok {
 		return fmt.Errorf("context '%s' not found in configuration", contextName)
@@ -1488,10 +1625,19 @@ func modifyAllocations(cCtx *cli.Context, operatorAddress string, operatorPrivat
 		return fmt.Errorf("modifyAllocations:operatorAddress parameter is required and cannot be empty")
 	}
 
-	cfg, contextName, err := common.LoadConfigWithContextConfig(contextName)
+	// Load config according to provided contextName
+	var err error
+	var cfg *common.ConfigWithContextConfig
+	if contextName == "" {
+		cfg, contextName, err = common.LoadDefaultConfigWithContextConfig()
+	} else {
+		cfg, contextName, err = common.LoadConfigWithContextConfig(contextName)
+	}
 	if err != nil {
 		return fmt.Errorf("failed to load configurations: %w", err)
 	}
+
+	// Extract context details
 	envCtx, ok := cfg.Context[contextName]
 	if !ok {
 		return fmt.Errorf("context '%s' not found in configuration", contextName)
@@ -1624,10 +1770,19 @@ func SetAllocationDelayAction(cCtx *cli.Context, logger iface.Logger) error {
 	// Extract vars
 	contextName := cCtx.String("context")
 
-	cfg, contextName, err := common.LoadConfigWithContextConfig(contextName)
+	// Load config according to provided contextName
+	var err error
+	var cfg *common.ConfigWithContextConfig
+	if contextName == "" {
+		cfg, contextName, err = common.LoadDefaultConfigWithContextConfig()
+	} else {
+		cfg, contextName, err = common.LoadConfigWithContextConfig(contextName)
+	}
 	if err != nil {
 		return fmt.Errorf("failed to load configurations for set allocation delay: %w", err)
 	}
+
+	// Extract context details
 	envCtx, ok := cfg.Context[contextName]
 	if !ok {
 		return fmt.Errorf("context '%s' not found in configuration", contextName)
@@ -1721,10 +1876,19 @@ func ConfigureOpSetCurveTypeAction(cCtx *cli.Context, logger iface.Logger) error
 	// Extract vars
 	contextName := cCtx.String("context")
 
-	cfg, contextName, err := common.LoadConfigWithContextConfig(contextName)
+	// Load config according to provided contextName
+	var err error
+	var cfg *common.ConfigWithContextConfig
+	if contextName == "" {
+		cfg, contextName, err = common.LoadDefaultConfigWithContextConfig()
+	} else {
+		cfg, contextName, err = common.LoadConfigWithContextConfig(contextName)
+	}
 	if err != nil {
 		return fmt.Errorf("failed to load configurations for configure op set curve type: %w", err)
 	}
+
+	// Extract context details
 	envCtx, ok := cfg.Context[contextName]
 	if !ok {
 		return fmt.Errorf("context '%s' not found in configuration", contextName)
@@ -1797,10 +1961,19 @@ func CreateGenerationReservationAction(cCtx *cli.Context, logger iface.Logger) e
 	// Extract vars
 	contextName := cCtx.String("context")
 
-	cfg, contextName, err := common.LoadConfigWithContextConfig(contextName)
+	// Load config according to provided contextName
+	var err error
+	var cfg *common.ConfigWithContextConfig
+	if contextName == "" {
+		cfg, contextName, err = common.LoadDefaultConfigWithContextConfig()
+	} else {
+		cfg, contextName, err = common.LoadConfigWithContextConfig(contextName)
+	}
 	if err != nil {
 		return fmt.Errorf("failed to load configurations for request op set generation reservation: %w", err)
 	}
+
+	// Extract context details
 	envCtx, ok := cfg.Context[contextName]
 	if !ok {
 		return fmt.Errorf("context '%s' not found in configuration", contextName)
@@ -1860,10 +2033,19 @@ func WhitelistChainIdInCrossRegistryAction(cCtx *cli.Context, logger iface.Logge
 		return nil
 	}
 
-	cfg, contextName, err := common.LoadConfigWithContextConfig(contextName)
+	// Load config according to provided contextName
+	var err error
+	var cfg *common.ConfigWithContextConfig
+	if contextName == "" {
+		cfg, contextName, err = common.LoadDefaultConfigWithContextConfig()
+	} else {
+		cfg, contextName, err = common.LoadConfigWithContextConfig(contextName)
+	}
 	if err != nil {
 		return fmt.Errorf("failed to load configurations for whitelist chain id in cross registry: %w", err)
 	}
+
+	// Extract context details
 	envCtx, ok := cfg.Context[contextName]
 	if !ok {
 		return fmt.Errorf("context '%s' not found in configuration", contextName)
@@ -1926,10 +2108,19 @@ func RegisterKeyInKeyRegistrarAction(cCtx *cli.Context, logger iface.Logger) err
 	// Extract vars
 	contextName := cCtx.String("context")
 
-	cfg, contextName, err := common.LoadConfigWithContextConfig(contextName)
+	// Load config according to provided contextName
+	var err error
+	var cfg *common.ConfigWithContextConfig
+	if contextName == "" {
+		cfg, contextName, err = common.LoadDefaultConfigWithContextConfig()
+	} else {
+		cfg, contextName, err = common.LoadConfigWithContextConfig(contextName)
+	}
 	if err != nil {
 		return fmt.Errorf("failed to load configurations for register key in key registrar: %w", err)
 	}
+
+	// Extract context details
 	envCtx, ok := cfg.Context[contextName]
 	if !ok {
 		return fmt.Errorf("context '%s' not found in configuration", contextName)

--- a/pkg/commands/release.go
+++ b/pkg/commands/release.go
@@ -21,6 +21,10 @@ var ReleaseCommand = &cli.Command{
 			Name:  "publish",
 			Usage: "Publish a new AVS release",
 			Flags: append(common.GlobalFlags, []cli.Flag{
+				&cli.StringFlag{
+					Name:  "context",
+					Usage: "Select the context to use in this command (devnet, testnet or mainnet)",
+				},
 				&cli.Int64Flag{
 					Name:     "upgrade-by-time",
 					Usage:    "Unix timestamp by which the upgrade must be completed",
@@ -37,6 +41,10 @@ var ReleaseCommand = &cli.Command{
 			Name:  "uri",
 			Usage: "Set release metadata URI for an operator set",
 			Flags: append(common.GlobalFlags, []cli.Flag{
+				&cli.StringFlag{
+					Name:  "context",
+					Usage: "Select the context to use in this command (devnet, testnet or mainnet)",
+				},
 				&cli.StringFlag{
 					Name:     "metadata-uri",
 					Usage:    "Metadata URI to set for the release",

--- a/pkg/commands/release_actions.go
+++ b/pkg/commands/release_actions.go
@@ -33,10 +33,18 @@ func publishReleaseAction(cCtx *cli.Context) error {
 	contextName := cCtx.String("context")
 
 	// Get build artifact from context first to read registry URL and version
-	cfg, contextName, err := common.LoadConfigWithContextConfig(contextName)
+	var err error
+	var cfg *common.ConfigWithContextConfig
+	if contextName == "" {
+		cfg, contextName, err = common.LoadDefaultConfigWithContextConfig()
+	} else {
+		cfg, contextName, err = common.LoadConfigWithContextConfig(contextName)
+	}
 	if err != nil {
 		return fmt.Errorf("failed to load context config: %w", err)
 	}
+
+	// Extract context details
 	if cfg.Context[contextName].Artifact == nil {
 		return fmt.Errorf("no artifact found in context. Please run 'devkit avs build' first")
 	}
@@ -154,7 +162,13 @@ func processOperatorSetsAndPublishReleaseOnChain(
 	ociBuilder := artifact.NewOCIArtifactBuilder(logger)
 
 	// Get AVS name from context for artifact naming
-	cfg, contextName, err := common.LoadConfigWithContextConfig(contextName)
+	var err error
+	var cfg *common.ConfigWithContextConfig
+	if contextName == "" {
+		cfg, contextName, err = common.LoadDefaultConfigWithContextConfig()
+	} else {
+		cfg, contextName, err = common.LoadConfigWithContextConfig(contextName)
+	}
 	if err != nil {
 		return fmt.Errorf("failed to load context config: %w", err)
 	}
@@ -320,10 +334,19 @@ func publishReleaseToReleaseManagerAction(
 	upgradeByTime int64,
 	artifacts []releasemanager.IReleaseManagerTypesArtifact,
 ) error {
-	cfg, contextName, err := common.LoadConfigWithContextConfig(contextName)
-	if err != nil {
-		return fmt.Errorf("failed to load configurations for operator registration: %w", err)
+	// Load config according to provided contextName
+	var err error
+	var cfg *common.ConfigWithContextConfig
+	if contextName == "" {
+		cfg, contextName, err = common.LoadDefaultConfigWithContextConfig()
+	} else {
+		cfg, contextName, err = common.LoadConfigWithContextConfig(contextName)
 	}
+	if err != nil {
+		return fmt.Errorf("failed to load configurations: %w", err)
+	}
+
+	// Extract context details
 	envCtx, ok := cfg.Context[contextName]
 	if !ok {
 		return fmt.Errorf("context '%s' not found in configuration", contextName)
@@ -383,11 +406,18 @@ func setReleaseMetadataURIAction(cCtx *cli.Context) error {
 	avsAddressStr := cCtx.String("avs-address")
 	contextName := cCtx.String("context")
 
-	// Load configuration
-	cfg, contextName, err := common.LoadConfigWithContextConfig(contextName)
+	// Load config according to provided contextName
+	var err error
+	var cfg *common.ConfigWithContextConfig
+	if contextName == "" {
+		cfg, contextName, err = common.LoadDefaultConfigWithContextConfig()
+	} else {
+		cfg, contextName, err = common.LoadConfigWithContextConfig(contextName)
+	}
 	if err != nil {
 		return fmt.Errorf("failed to load context config: %w", err)
 	}
+
 	// Get AVS address from flag or context
 	var avsAddress string
 	if avsAddressStr != "" {
@@ -542,9 +572,16 @@ func updateContextWithDigest(contextName, digest string) error {
 // updateContextWithVersion updates the context YAML file with the new version
 func updateContextWithVersion(contextName, version string) error {
 	// Load the context yaml file
-	yamlPath, rootNode, contextNode, err := common.LoadContext(contextName)
+	var yamlPath string
+	var rootNode, contextNode *yaml.Node
+	var err error
+	if contextName == "" {
+		yamlPath, rootNode, contextNode, contextName, err = common.LoadDefaultContext()
+	} else {
+		yamlPath, rootNode, contextNode, contextName, err = common.LoadContext(contextName)
+	}
 	if err != nil {
-		return err
+		return fmt.Errorf("context loading failed: %w", err)
 	}
 
 	// Get or create artifact section

--- a/pkg/commands/release_actions.go
+++ b/pkg/commands/release_actions.go
@@ -576,9 +576,9 @@ func updateContextWithVersion(contextName, version string) error {
 	var rootNode, contextNode *yaml.Node
 	var err error
 	if contextName == "" {
-		yamlPath, rootNode, contextNode, contextName, err = common.LoadDefaultContext()
+		yamlPath, rootNode, contextNode, _, err = common.LoadDefaultContext()
 	} else {
-		yamlPath, rootNode, contextNode, contextName, err = common.LoadContext(contextName)
+		yamlPath, rootNode, contextNode, _, err = common.LoadContext(contextName)
 	}
 	if err != nil {
 		return fmt.Errorf("context loading failed: %w", err)

--- a/pkg/commands/release_actions.go
+++ b/pkg/commands/release_actions.go
@@ -30,19 +30,23 @@ func publishReleaseAction(cCtx *cli.Context) error {
 	// Get values from flags
 	upgradeByTime := cCtx.Int64("upgrade-by-time")
 	registry := cCtx.String("registry")
+	contextName := cCtx.String("context")
 
 	// Get build artifact from context first to read registry URL and version
-	cfg, err := common.LoadConfigWithContextConfig(devnet.DEVNET_CONTEXT) // TODO: make context configurable
+	cfg, err := common.LoadConfigWithContextConfig(contextName)
 	if err != nil {
 		return fmt.Errorf("failed to load context config: %w", err)
 	}
+	if contextName == "" {
+		contextName = cfg.Config.Project.Context
+	}
 
-	if cfg.Context[devnet.DEVNET_CONTEXT].Artifact == nil {
+	if cfg.Context[contextName].Artifact == nil {
 		return fmt.Errorf("no artifact found in context. Please run 'devkit avs build' first")
 	}
 
-	artifact := cfg.Context[devnet.DEVNET_CONTEXT].Artifact
-	avs := cfg.Context[devnet.DEVNET_CONTEXT].Avs.Address
+	artifact := cfg.Context[contextName].Artifact
+	avs := cfg.Context[contextName].Avs.Address
 	// Validate AVS address
 	if avs == "" {
 		return fmt.Errorf("AVS addressempty in context")
@@ -50,7 +54,7 @@ func publishReleaseAction(cCtx *cli.Context) error {
 
 	// Check if metadata URI is set for any operator set before proceeding
 	logger.Info("Checking AVS metadata URI...")
-	if err := checkMetadataURIExists(logger, cfg, avs); err != nil {
+	if err := checkMetadataURIExists(logger, contextName, cfg, avs); err != nil {
 		return err
 	}
 
@@ -90,7 +94,7 @@ func publishReleaseAction(cCtx *cli.Context) error {
 	} else {
 		logger.Info("Using provided registry: %s", finalRegistry)
 	}
-	component := cfg.Context[devnet.DEVNET_CONTEXT].Artifact.Component
+	component := cfg.Context[contextName].Artifact.Component
 	// Execute release script with version and registry
 	releaseCmd := exec.CommandContext(cCtx.Context, "bash", releaseScriptPath,
 		"--version", version,
@@ -99,7 +103,7 @@ func publishReleaseAction(cCtx *cli.Context) error {
 	releaseCmd.Stderr = os.Stderr
 
 	// Add environment variable for context
-	releaseCmd.Env = append(os.Environ(), fmt.Sprintf("CONTEXT_NAME=%s", devnet.DEVNET_CONTEXT))
+	releaseCmd.Env = append(os.Environ(), fmt.Sprintf("CONTEXT_NAME=%s", contextName))
 
 	// Capture stdout to get the operator set mapping JSON
 	output, err := releaseCmd.Output()
@@ -119,7 +123,7 @@ func publishReleaseAction(cCtx *cli.Context) error {
 	logger.Info("Retrieved operator set mapping with %d operator sets", len(operatorSetMapping))
 
 	// Publish releases for each operator set
-	if err := processOperatorSetsAndPublishReleaseOnChain(cCtx, logger, operatorSetMapping, avs, upgradeByTime, finalRegistry, version); err != nil {
+	if err := processOperatorSetsAndPublishReleaseOnChain(cCtx, logger, contextName, operatorSetMapping, avs, upgradeByTime, finalRegistry, version); err != nil {
 		return err
 	}
 
@@ -130,7 +134,7 @@ func publishReleaseAction(cCtx *cli.Context) error {
 	}
 
 	// Update version in context
-	if err := updateContextWithVersion(newVersion); err != nil {
+	if err := updateContextWithVersion(contextName, newVersion); err != nil {
 		return fmt.Errorf("failed to update context with version: %w", err)
 	}
 
@@ -143,6 +147,7 @@ func publishReleaseAction(cCtx *cli.Context) error {
 func processOperatorSetsAndPublishReleaseOnChain(
 	cCtx *cli.Context,
 	logger iface.Logger,
+	contextName string,
 	operatorSetMapping map[string]OperatorSetRelease,
 	avs string,
 	upgradeByTime int64,
@@ -153,7 +158,7 @@ func processOperatorSetsAndPublishReleaseOnChain(
 	ociBuilder := artifact.NewOCIArtifactBuilder(logger)
 
 	// Get AVS name from context for artifact naming
-	cfg, err := common.LoadConfigWithContextConfig(devnet.DEVNET_CONTEXT)
+	cfg, err := common.LoadConfigWithContextConfig(contextName)
 	if err != nil {
 		return fmt.Errorf("failed to load context config: %w", err)
 	}
@@ -196,7 +201,7 @@ func processOperatorSetsAndPublishReleaseOnChain(
 		logger.Info("Successfully created OCI artifact with digest: %s", finalDigest)
 
 		// Update context with digest
-		err = updateContextWithDigest(finalDigest)
+		err = updateContextWithDigest(contextName, finalDigest)
 		if err != nil {
 			return fmt.Errorf("failed to update context with digest for operator set %s: %v", opSetId, err)
 		}
@@ -217,7 +222,7 @@ func processOperatorSetsAndPublishReleaseOnChain(
 		artifacts := []releasemanager.IReleaseManagerTypesArtifact{artifact}
 
 		logger.Info("Publishing release for operator set %s...", opSetId)
-		if err := publishReleaseToReleaseManagerAction(cCtx.Context, logger, avs, uint32(opSetIdInt), upgradeByTime, artifacts); err != nil {
+		if err := publishReleaseToReleaseManagerAction(cCtx.Context, logger, contextName, avs, uint32(opSetIdInt), upgradeByTime, artifacts); err != nil {
 			if strings.Contains(err.Error(), "connection refused") {
 				logger.Warn("Failed to publish release for operator set %s: %v", opSetId, err)
 				logger.Info("Check if devnet is running and try again")
@@ -241,16 +246,16 @@ func incrementVersion(version string) (string, error) {
 }
 
 // checkMetadataURIExists checks if metadata URI is set for at least one operator set
-func checkMetadataURIExists(logger iface.Logger, cfg *common.ConfigWithContextConfig, avsAddress string) error {
+func checkMetadataURIExists(logger iface.Logger, contextName string, cfg *common.ConfigWithContextConfig, avsAddress string) error {
 	// Get L1 chain config
-	envCtx, ok := cfg.Context[devnet.DEVNET_CONTEXT]
+	envCtx, ok := cfg.Context[contextName]
 	if !ok {
-		return fmt.Errorf("context '%s' not found in configuration", devnet.DEVNET_CONTEXT)
+		return fmt.Errorf("context '%s' not found in configuration", contextName)
 	}
 
 	l1Cfg, ok := envCtx.Chains[devnet.L1]
 	if !ok {
-		return fmt.Errorf("failed to get l1 chain config for context '%s'", devnet.DEVNET_CONTEXT)
+		return fmt.Errorf("failed to get l1 chain config for context '%s'", contextName)
 	}
 
 	// Connect to L1
@@ -313,24 +318,24 @@ func checkMetadataURIExists(logger iface.Logger, cfg *common.ConfigWithContextCo
 func publishReleaseToReleaseManagerAction(
 	ctx context.Context,
 	logger iface.Logger,
+	contextName string,
 	avs string,
 	operatorSetId uint32,
 	upgradeByTime int64,
 	artifacts []releasemanager.IReleaseManagerTypesArtifact,
 ) error {
-
-	cfg, err := common.LoadConfigWithContextConfig(devnet.DEVNET_CONTEXT)
+	cfg, err := common.LoadConfigWithContextConfig(contextName)
 	if err != nil {
 		return fmt.Errorf("failed to load configurations for operator registration: %w", err)
 	}
-	envCtx, ok := cfg.Context[devnet.DEVNET_CONTEXT]
+	envCtx, ok := cfg.Context[contextName]
 	if !ok {
-		return fmt.Errorf("context '%s' not found in configuration", devnet.DEVNET_CONTEXT)
+		return fmt.Errorf("context '%s' not found in configuration", contextName)
 	}
 
 	l1Cfg, ok := envCtx.Chains[devnet.L1]
 	if !ok {
-		return fmt.Errorf("failed to get l1 chain config for context '%s'", devnet.DEVNET_CONTEXT)
+		return fmt.Errorf("failed to get l1 chain config for context '%s'", contextName)
 	}
 
 	client, err := ethclient.Dial(l1Cfg.RPCURL)
@@ -380,11 +385,15 @@ func setReleaseMetadataURIAction(cCtx *cli.Context) error {
 	metadataURI := cCtx.String("metadata-uri")
 	operatorSetID := cCtx.Uint("operator-set-id")
 	avsAddressStr := cCtx.String("avs-address")
+	contextName := cCtx.String("context")
 
 	// Load configuration
-	cfg, err := common.LoadConfigWithContextConfig(devnet.DEVNET_CONTEXT) // TODO: make context configurable
+	cfg, err := common.LoadConfigWithContextConfig(contextName)
 	if err != nil {
 		return fmt.Errorf("failed to load context config: %w", err)
+	}
+	if contextName == "" {
+		contextName = cfg.Config.Project.Context
 	}
 
 	// Get AVS address from flag or context
@@ -392,7 +401,7 @@ func setReleaseMetadataURIAction(cCtx *cli.Context) error {
 	if avsAddressStr != "" {
 		avsAddress = avsAddressStr
 	} else {
-		avsAddress = cfg.Context[devnet.DEVNET_CONTEXT].Avs.Address
+		avsAddress = cfg.Context[contextName].Avs.Address
 		if avsAddress == "" {
 			return fmt.Errorf("AVS address not provided and not found in context")
 		}
@@ -404,14 +413,14 @@ func setReleaseMetadataURIAction(cCtx *cli.Context) error {
 	logger.Info("Metadata URI: %s", metadataURI)
 
 	// Get L1 chain config
-	envCtx, ok := cfg.Context[devnet.DEVNET_CONTEXT]
+	envCtx, ok := cfg.Context[contextName]
 	if !ok {
-		return fmt.Errorf("context '%s' not found in configuration", devnet.DEVNET_CONTEXT)
+		return fmt.Errorf("context '%s' not found in configuration", contextName)
 	}
 
 	l1Cfg, ok := envCtx.Chains[devnet.L1]
 	if !ok {
-		return fmt.Errorf("failed to get l1 chain config for context '%s'", devnet.DEVNET_CONTEXT)
+		return fmt.Errorf("failed to get l1 chain config for context '%s'", contextName)
 	}
 
 	// Connect to L1
@@ -502,9 +511,9 @@ func parseOperatorSetMapping(jsonOutput string) (map[string]OperatorSetRelease, 
 }
 
 // updateContextWithDigest updates the context YAML file with the digest after successful release
-func updateContextWithDigest(digest string) error {
+func updateContextWithDigest(contextName, digest string) error {
 	// Load the context yaml file
-	contextPath := filepath.Join("config", "contexts", "devnet.yaml") // TODO: make context configurable
+	contextPath := filepath.Join("config", "contexts", fmt.Sprintf("%s.yaml", contextName))
 	contextNode, err := common.LoadYAML(contextPath)
 	if err != nil {
 		return fmt.Errorf("failed to load context yaml: %w", err)
@@ -539,9 +548,9 @@ func updateContextWithDigest(digest string) error {
 }
 
 // updateContextWithVersion updates the context YAML file with the new version
-func updateContextWithVersion(version string) error {
+func updateContextWithVersion(contextName, version string) error {
 	// Load the context yaml file
-	yamlPath, rootNode, contextNode, err := common.LoadContext(devnet.DEVNET_CONTEXT)
+	yamlPath, rootNode, contextNode, err := common.LoadContext(contextName)
 	if err != nil {
 		return err
 	}

--- a/pkg/commands/release_actions.go
+++ b/pkg/commands/release_actions.go
@@ -33,14 +33,10 @@ func publishReleaseAction(cCtx *cli.Context) error {
 	contextName := cCtx.String("context")
 
 	// Get build artifact from context first to read registry URL and version
-	cfg, err := common.LoadConfigWithContextConfig(contextName)
+	cfg, contextName, err := common.LoadConfigWithContextConfig(contextName)
 	if err != nil {
 		return fmt.Errorf("failed to load context config: %w", err)
 	}
-	if contextName == "" {
-		contextName = cfg.Config.Project.Context
-	}
-
 	if cfg.Context[contextName].Artifact == nil {
 		return fmt.Errorf("no artifact found in context. Please run 'devkit avs build' first")
 	}
@@ -158,7 +154,7 @@ func processOperatorSetsAndPublishReleaseOnChain(
 	ociBuilder := artifact.NewOCIArtifactBuilder(logger)
 
 	// Get AVS name from context for artifact naming
-	cfg, err := common.LoadConfigWithContextConfig(contextName)
+	cfg, contextName, err := common.LoadConfigWithContextConfig(contextName)
 	if err != nil {
 		return fmt.Errorf("failed to load context config: %w", err)
 	}
@@ -324,7 +320,7 @@ func publishReleaseToReleaseManagerAction(
 	upgradeByTime int64,
 	artifacts []releasemanager.IReleaseManagerTypesArtifact,
 ) error {
-	cfg, err := common.LoadConfigWithContextConfig(contextName)
+	cfg, contextName, err := common.LoadConfigWithContextConfig(contextName)
 	if err != nil {
 		return fmt.Errorf("failed to load configurations for operator registration: %w", err)
 	}
@@ -388,14 +384,10 @@ func setReleaseMetadataURIAction(cCtx *cli.Context) error {
 	contextName := cCtx.String("context")
 
 	// Load configuration
-	cfg, err := common.LoadConfigWithContextConfig(contextName)
+	cfg, contextName, err := common.LoadConfigWithContextConfig(contextName)
 	if err != nil {
 		return fmt.Errorf("failed to load context config: %w", err)
 	}
-	if contextName == "" {
-		contextName = cfg.Config.Project.Context
-	}
-
 	// Get AVS address from flag or context
 	var avsAddress string
 	if avsAddressStr != "" {

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -13,7 +13,12 @@ import (
 var RunCommand = &cli.Command{
 	Name:  "run",
 	Usage: "Start offchain AVS components",
-	Flags: append([]cli.Flag{}, common.GlobalFlags...),
+	Flags: append([]cli.Flag{
+		&cli.StringFlag{
+			Name:  "context",
+			Usage: "Select the context to use in this command (devnet, testnet or mainnet)",
+		},
+	}, common.GlobalFlags...),
 	Action: func(cCtx *cli.Context) error {
 		// Invoke and return AVSRun
 		return AVSRun(cCtx)
@@ -35,7 +40,7 @@ func AVSRun(cCtx *cli.Context) error {
 	scriptPath := filepath.Join(".devkit", "scripts", "run")
 
 	// Set path for context yaml
-	contextJSON, err := common.LoadRawContext("devnet") // @TODO: use selected context name
+	contextJSON, err := common.LoadRawContext(cCtx.String("context"))
 	if err != nil {
 		return fmt.Errorf("failed to load context: %w", err)
 	}

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -39,8 +39,17 @@ func AVSRun(cCtx *cli.Context) error {
 	// Set path for .devkit scripts
 	scriptPath := filepath.Join(".devkit", "scripts", "run")
 
+	// Check for flagged contextName
+	contextName := cCtx.String("context")
+
 	// Set path for context yaml
-	contextJSON, err := common.LoadRawContext(cCtx.String("context"))
+	var err error
+	var contextJSON []byte
+	if contextName == "" {
+		contextJSON, _, err = common.LoadDefaultRawContext()
+	} else {
+		contextJSON, _, err = common.LoadRawContext(contextName)
+	}
 	if err != nil {
 		return fmt.Errorf("failed to load context: %w", err)
 	}

--- a/pkg/commands/test.go
+++ b/pkg/commands/test.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"fmt"
-	"github.com/Layr-Labs/devkit-cli/pkg/common/devnet"
 	"path/filepath"
 
 	"github.com/Layr-Labs/devkit-cli/pkg/common"
@@ -14,7 +13,12 @@ import (
 var TestCommand = &cli.Command{
 	Name:  "test",
 	Usage: "Run AVS tests",
-	Flags: append([]cli.Flag{}, common.GlobalFlags...),
+	Flags: append([]cli.Flag{
+		&cli.StringFlag{
+			Name:  "context",
+			Usage: "Select the context to use in this command (devnet, testnet or mainnet)",
+		},
+	}, common.GlobalFlags...),
 	Action: func(cCtx *cli.Context) error {
 		// Invoke and return AVSTest
 		return AVSTest(cCtx)
@@ -35,7 +39,7 @@ func AVSTest(cCtx *cli.Context) error {
 	scriptPath := filepath.Join(".devkit", "scripts", "test")
 
 	// Set path for context yaml
-	contextJSON, err := common.LoadRawContext(devnet.DEVNET_CONTEXT) // @TODO: use selected context name
+	contextJSON, err := common.LoadRawContext(cCtx.String("context"))
 	if err != nil {
 		return fmt.Errorf("failed to load context: %w", err)
 	}

--- a/pkg/commands/test.go
+++ b/pkg/commands/test.go
@@ -38,8 +38,17 @@ func AVSTest(cCtx *cli.Context) error {
 	// Set path for .devkit scripts
 	scriptPath := filepath.Join(".devkit", "scripts", "test")
 
+	// Check for flagged contextName
+	contextName := cCtx.String("context")
+
 	// Set path for context yaml
-	contextJSON, err := common.LoadRawContext(cCtx.String("context"))
+	var err error
+	var contextJSON []byte
+	if contextName == "" {
+		contextJSON, _, err = common.LoadDefaultRawContext()
+	} else {
+		contextJSON, _, err = common.LoadRawContext(contextName)
+	}
 	if err != nil {
 		return fmt.Errorf("failed to load context: %w", err)
 	}

--- a/pkg/commands/transporter.go
+++ b/pkg/commands/transporter.go
@@ -311,16 +311,10 @@ func Transport(cCtx *cli.Context) error {
 
 // Record StakeTableRoots in the context for later retrieval
 func WriteStakeTableRootsToContext(cCtx *cli.Context, roots map[uint64][32]byte) error {
-	// Pull selected context from global args
-	contextName := cCtx.String("context")
-
 	// Load and navigate context to arrive at context.transporter.active_stake_roots
-	yamlPath, rootNode, contextNode, err := common.LoadContext(contextName)
+	yamlPath, rootNode, contextNode, err := common.LoadContext(cCtx.String("context"))
 	if err != nil {
 		return err
-	}
-	if contextName == "" {
-		contextName = common.GetChildByKey(contextNode, "name").Value
 	}
 	transporterNode := common.GetChildByKey(contextNode, "transporter")
 	if transporterNode == nil {

--- a/pkg/commands/transporter.go
+++ b/pkg/commands/transporter.go
@@ -528,18 +528,11 @@ func VerifyActiveStakeTableRoots(cCtx *cli.Context) error {
 	// Get logger
 	logger := common.LoggerFromContext(cCtx.Context)
 
-	// Ref selected context
-	contextName := cCtx.String("context")
-
 	// Read expected roots from context
-	_, _, contextNode, err := common.LoadContext(contextName)
+	_, _, contextNode, err := common.LoadContext(cCtx.String("context"))
 	if err != nil {
 		return fmt.Errorf("failed to load context YAML: %w", err)
 	}
-	if contextName == "" {
-		contextName = common.GetChildByKey(contextNode, "name").Value
-	}
-
 	transporterNode := common.GetChildByKey(contextNode, "transporter")
 	if transporterNode == nil {
 		return fmt.Errorf("missing 'transporter' section in context")

--- a/pkg/commands/transporter.go
+++ b/pkg/commands/transporter.go
@@ -75,13 +75,9 @@ var TransportCommand = &cli.Command{
 				contextName := cCtx.String("context")
 
 				// Extract context
-				cfg, err := common.LoadConfigWithContextConfig(contextName)
+				cfg, contextName, err := common.LoadConfigWithContextConfig(contextName)
 				if err != nil {
 					return fmt.Errorf("failed to load configurations for whitelist chain id in cross registry: %w", err)
-				}
-				// Move to selectedContext if different
-				if contextName == "" {
-					contextName = cfg.Config.Project.Context
 				}
 				envCtx, ok := cfg.Context[contextName]
 				if !ok {
@@ -124,13 +120,9 @@ func Transport(cCtx *cli.Context) error {
 	contextName := cCtx.String("context")
 
 	// Extract context
-	cfg, err := common.LoadConfigWithContextConfig(contextName)
+	cfg, contextName, err := common.LoadConfigWithContextConfig(contextName)
 	if err != nil {
 		return fmt.Errorf("failed to load configurations for whitelist chain id in cross registry: %w", err)
-	}
-	// Move to selectedContext if different
-	if contextName == "" {
-		contextName = cfg.Config.Project.Context
 	}
 	envCtx, ok := cfg.Context[contextName]
 	if !ok {
@@ -416,13 +408,9 @@ func GetOnchainStakeTableRoots(cCtx *cli.Context) (map[uint64][32]byte, error) {
 	contextName := cCtx.String("context")
 
 	// Extract context
-	cfg, err := common.LoadConfigWithContextConfig(contextName)
+	cfg, contextName, err := common.LoadConfigWithContextConfig(contextName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load configurations for whitelist chain id in cross registry: %w", err)
-	}
-	// Move to selectedContext if different
-	if contextName == "" {
-		contextName = cfg.Config.Project.Context
 	}
 	envCtx, ok := cfg.Context[contextName]
 	if !ok {

--- a/pkg/commands/transporter.go
+++ b/pkg/commands/transporter.go
@@ -74,11 +74,19 @@ var TransportCommand = &cli.Command{
 				// Extract vars
 				contextName := cCtx.String("context")
 
-				// Extract context
-				cfg, contextName, err := common.LoadConfigWithContextConfig(contextName)
+				// Load config according to provided contextName
+				var err error
+				var cfg *common.ConfigWithContextConfig
+				if contextName == "" {
+					cfg, contextName, err = common.LoadDefaultConfigWithContextConfig()
+				} else {
+					cfg, contextName, err = common.LoadConfigWithContextConfig(contextName)
+				}
 				if err != nil {
 					return fmt.Errorf("failed to load configurations for whitelist chain id in cross registry: %w", err)
 				}
+
+				// Extract context details
 				envCtx, ok := cfg.Context[contextName]
 				if !ok {
 					return fmt.Errorf("context '%s' not found in configuration", contextName)
@@ -119,11 +127,18 @@ func Transport(cCtx *cli.Context) error {
 	// Extract vars
 	contextName := cCtx.String("context")
 
-	// Extract context
-	cfg, contextName, err := common.LoadConfigWithContextConfig(contextName)
+	// Load config according to provided contextName
+	var cfg *common.ConfigWithContextConfig
+	if contextName == "" {
+		cfg, contextName, err = common.LoadDefaultConfigWithContextConfig()
+	} else {
+		cfg, contextName, err = common.LoadConfigWithContextConfig(contextName)
+	}
 	if err != nil {
 		return fmt.Errorf("failed to load configurations for whitelist chain id in cross registry: %w", err)
 	}
+
+	// Extract context details
 	envCtx, ok := cfg.Context[contextName]
 	if !ok {
 		return fmt.Errorf("context '%s' not found in configuration", contextName)
@@ -303,11 +318,23 @@ func Transport(cCtx *cli.Context) error {
 
 // Record StakeTableRoots in the context for later retrieval
 func WriteStakeTableRootsToContext(cCtx *cli.Context, roots map[uint64][32]byte) error {
-	// Load and navigate context to arrive at context.transporter.active_stake_roots
-	yamlPath, rootNode, contextNode, err := common.LoadContext(cCtx.String("context"))
-	if err != nil {
-		return err
+	// Get flag selected contextName
+	contextName := cCtx.String("context")
+
+	// Check for context
+	var yamlPath string
+	var rootNode, contextNode *yaml.Node
+	var err error
+	if contextName == "" {
+		yamlPath, rootNode, contextNode, contextName, err = common.LoadDefaultContext()
+	} else {
+		yamlPath, rootNode, contextNode, contextName, err = common.LoadContext(contextName)
 	}
+	if err != nil {
+		return fmt.Errorf("context loading failed: %w", err)
+	}
+
+	// Navigate context to arrive at context.transporter.active_stake_roots
 	transporterNode := common.GetChildByKey(contextNode, "transporter")
 	if transporterNode == nil {
 		return fmt.Errorf("'transporter' section missing in context")
@@ -407,11 +434,19 @@ func GetOnchainStakeTableRoots(cCtx *cli.Context) (map[uint64][32]byte, error) {
 	// Extract vars
 	contextName := cCtx.String("context")
 
-	// Extract context
-	cfg, contextName, err := common.LoadConfigWithContextConfig(contextName)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load configurations for whitelist chain id in cross registry: %w", err)
+	// Load config according to provided contextName
+	var err error
+	var cfg *common.ConfigWithContextConfig
+	if contextName == "" {
+		cfg, contextName, err = common.LoadDefaultConfigWithContextConfig()
+	} else {
+		cfg, contextName, err = common.LoadConfigWithContextConfig(contextName)
 	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to load configurations for getting onchain stake table roots: %w", err)
+	}
+
+	// Extract context details
 	envCtx, ok := cfg.Context[contextName]
 	if !ok {
 		return nil, fmt.Errorf("context '%s' not found in configuration", contextName)
@@ -516,11 +551,22 @@ func VerifyActiveStakeTableRoots(cCtx *cli.Context) error {
 	// Get logger
 	logger := common.LoggerFromContext(cCtx.Context)
 
-	// Read expected roots from context
-	_, _, contextNode, err := common.LoadContext(cCtx.String("context"))
-	if err != nil {
-		return fmt.Errorf("failed to load context YAML: %w", err)
+	// Get flag selected contextName
+	contextName := cCtx.String("context")
+
+	// Check for context
+	var contextNode *yaml.Node
+	var err error
+	if contextName == "" {
+		_, _, contextNode, _, err = common.LoadDefaultContext()
+	} else {
+		_, _, contextNode, _, err = common.LoadContext(contextName)
 	}
+	if err != nil {
+		return fmt.Errorf("context loading failed: %w", err)
+	}
+
+	// Navigate context to arrive at context.transporter.active_stake_roots
 	transporterNode := common.GetChildByKey(contextNode, "transporter")
 	if transporterNode == nil {
 		return fmt.Errorf("missing 'transporter' section in context")

--- a/pkg/commands/transporter.go
+++ b/pkg/commands/transporter.go
@@ -326,9 +326,9 @@ func WriteStakeTableRootsToContext(cCtx *cli.Context, roots map[uint64][32]byte)
 	var rootNode, contextNode *yaml.Node
 	var err error
 	if contextName == "" {
-		yamlPath, rootNode, contextNode, contextName, err = common.LoadDefaultContext()
+		yamlPath, rootNode, contextNode, _, err = common.LoadDefaultContext()
 	} else {
-		yamlPath, rootNode, contextNode, contextName, err = common.LoadContext(contextName)
+		yamlPath, rootNode, contextNode, _, err = common.LoadContext(contextName)
 	}
 	if err != nil {
 		return fmt.Errorf("context loading failed: %w", err)

--- a/pkg/common/config.go
+++ b/pkg/common/config.go
@@ -240,7 +240,7 @@ func LoadBaseConfigYaml() (*Config, error) {
 	return cfg, nil
 }
 
-func LoadConfigWithContextConfig(context string) (*ConfigWithContextConfig, error) {
+func LoadConfigWithContextConfig(context string) (*ConfigWithContextConfig, string, error) {
 	// Use provided context if not empty
 	var selectedContext = context
 	if selectedContext == "" {
@@ -248,7 +248,7 @@ func LoadConfigWithContextConfig(context string) (*ConfigWithContextConfig, erro
 		currentConfig, err := LoadBaseConfigYaml()
 		// If there is any error loading the yaml
 		if err != nil {
-			return nil, fmt.Errorf("error loading yaml: %w", err)
+			return nil, "", fmt.Errorf("error loading yaml: %w", err)
 		}
 		// Default to project selected context
 		selectedContext = currentConfig.Config.Project.Context
@@ -258,19 +258,19 @@ func LoadConfigWithContextConfig(context string) (*ConfigWithContextConfig, erro
 	configPath := filepath.Join(DefaultConfigWithContextConfigPath, BaseConfig)
 	data, err := os.ReadFile(configPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read base config: %w", err)
+		return nil, "", fmt.Errorf("failed to read base config: %w", err)
 	}
 
 	var cfg ConfigWithContextConfig
 	if err := yaml.Unmarshal(data, &cfg); err != nil {
-		return nil, fmt.Errorf("failed to parse base config: %w", err)
+		return nil, "", fmt.Errorf("failed to parse base config: %w", err)
 	}
 
 	// Load requested context file
 	contextFile := filepath.Join(DefaultConfigWithContextConfigPath, "contexts", selectedContext+".yaml")
 	ctxData, err := os.ReadFile(contextFile)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read context %q file: %w", selectedContext, err)
+		return nil, "", fmt.Errorf("failed to read context %q file: %w", selectedContext, err)
 	}
 
 	var wrapper struct {
@@ -279,17 +279,17 @@ func LoadConfigWithContextConfig(context string) (*ConfigWithContextConfig, erro
 	}
 
 	if err := yaml.Unmarshal(ctxData, &wrapper); err != nil {
-		return nil, fmt.Errorf("failed to parse context file %q: %w", contextFile, err)
+		return nil, "", fmt.Errorf("failed to parse context file %q: %w", contextFile, err)
 	}
 
 	cfg.Context = map[string]ChainContextConfig{
 		selectedContext: wrapper.Context,
 	}
 
-	return &cfg, nil
+	return &cfg, selectedContext, nil
 }
 
-func LoadContext(context string) (string, *yaml.Node, *yaml.Node, error) {
+func LoadContext(context string) (string, *yaml.Node, *yaml.Node, string, error) {
 	// Use provided context if not empty
 	var selectedContext = context
 	if selectedContext == "" {
@@ -297,7 +297,7 @@ func LoadContext(context string) (string, *yaml.Node, *yaml.Node, error) {
 		currentConfig, err := LoadBaseConfigYaml()
 		// If there is any error loading the yaml
 		if err != nil {
-			return "", nil, nil, fmt.Errorf("error loading yaml: %w", err)
+			return "", nil, nil, "", fmt.Errorf("error loading yaml: %w", err)
 		}
 		// Default to project selected context
 		selectedContext = currentConfig.Config.Project.Context
@@ -310,23 +310,23 @@ func LoadContext(context string) (string, *yaml.Node, *yaml.Node, error) {
 	// Load YAML as *yaml.Node
 	rootNode, err := LoadYAML(yamlPath)
 	if err != nil {
-		return yamlPath, nil, nil, err
+		return yamlPath, nil, nil, selectedContext, err
 	}
 
 	// YAML is parsed into a DocumentNode:
 	//   - rootNode.Content[0] is the top-level MappingNode
 	//   - It contains the 'context' mapping we're interested in
 	if len(rootNode.Content) == 0 {
-		return yamlPath, rootNode, nil, fmt.Errorf("empty YAML root node")
+		return yamlPath, rootNode, nil, selectedContext, fmt.Errorf("empty YAML root node")
 	}
 
 	// Navigate context to arrive at context.transporter.active_stake_roots
 	contextNode := GetChildByKey(rootNode.Content[0], "context")
 	if contextNode == nil {
-		return yamlPath, rootNode, nil, fmt.Errorf("missing 'context' key in ./config/contexts/%s.yaml", selectedContext)
+		return yamlPath, rootNode, nil, selectedContext, fmt.Errorf("missing 'context' key in ./config/contexts/%s.yaml", selectedContext)
 	}
 
-	return yamlPath, rootNode, contextNode, nil
+	return yamlPath, rootNode, contextNode, selectedContext, nil
 }
 
 func LoadRawContext(context string) ([]byte, error) {

--- a/pkg/common/config.go
+++ b/pkg/common/config.go
@@ -240,20 +240,21 @@ func LoadBaseConfigYaml() (*Config, error) {
 	return cfg, nil
 }
 
-func LoadConfigWithContextConfig(context string) (*ConfigWithContextConfig, string, error) {
-	// Use provided context if not empty
-	var selectedContext = context
-	if selectedContext == "" {
-		// Load the projects config
-		currentConfig, err := LoadBaseConfigYaml()
-		// If there is any error loading the yaml
-		if err != nil {
-			return nil, "", fmt.Errorf("error loading yaml: %w", err)
-		}
-		// Default to project selected context
-		selectedContext = currentConfig.Config.Project.Context
+func LoadDefaultConfigWithContextConfig() (*ConfigWithContextConfig, string, error) {
+	// Load the projects config
+	currentConfig, err := LoadBaseConfigYaml()
+	// If there is any error loading the yaml
+	if err != nil {
+		return nil, "", fmt.Errorf("error loading yaml: %w", err)
 	}
+	// Default to project selected context
+	contextName := currentConfig.Config.Project.Context
 
+	// Return the selected context
+	return LoadConfigWithContextConfig(contextName)
+}
+
+func LoadConfigWithContextConfig(contextName string) (*ConfigWithContextConfig, string, error) {
 	// Load base config
 	configPath := filepath.Join(DefaultConfigWithContextConfigPath, BaseConfig)
 	data, err := os.ReadFile(configPath)
@@ -267,10 +268,10 @@ func LoadConfigWithContextConfig(context string) (*ConfigWithContextConfig, stri
 	}
 
 	// Load requested context file
-	contextFile := filepath.Join(DefaultConfigWithContextConfigPath, "contexts", selectedContext+".yaml")
+	contextFile := filepath.Join(DefaultConfigWithContextConfigPath, "contexts", contextName+".yaml")
 	ctxData, err := os.ReadFile(contextFile)
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to read context %q file: %w", selectedContext, err)
+		return nil, "", fmt.Errorf("failed to read context %q file: %w", contextName, err)
 	}
 
 	var wrapper struct {
@@ -283,83 +284,85 @@ func LoadConfigWithContextConfig(context string) (*ConfigWithContextConfig, stri
 	}
 
 	cfg.Context = map[string]ChainContextConfig{
-		selectedContext: wrapper.Context,
+		contextName: wrapper.Context,
 	}
 
-	return &cfg, selectedContext, nil
+	return &cfg, contextName, nil
 }
 
-func LoadContext(context string) (string, *yaml.Node, *yaml.Node, string, error) {
-	// Use provided context if not empty
-	var selectedContext = context
-	if selectedContext == "" {
-		// Load the projects config
-		currentConfig, err := LoadBaseConfigYaml()
-		// If there is any error loading the yaml
-		if err != nil {
-			return "", nil, nil, "", fmt.Errorf("error loading yaml: %w", err)
-		}
-		// Default to project selected context
-		selectedContext = currentConfig.Config.Project.Context
+func LoadDefaultContext() (string, *yaml.Node, *yaml.Node, string, error) {
+	// Load the projects config
+	currentConfig, err := LoadBaseConfigYaml()
+	// If there is any error loading the yaml
+	if err != nil {
+		return "", nil, nil, "", fmt.Errorf("error loading yaml: %w", err)
 	}
 
+	// Default to project selected context
+	selectedContext := currentConfig.Config.Project.Context
+
+	// Return the selected context
+	return LoadContext(selectedContext)
+}
+
+func LoadContext(contextName string) (string, *yaml.Node, *yaml.Node, string, error) {
 	// Set path for context yaml
 	contextDir := filepath.Join("config", "contexts")
-	yamlPath := path.Join(contextDir, fmt.Sprintf("%s.%s", selectedContext, "yaml"))
+	yamlPath := path.Join(contextDir, fmt.Sprintf("%s.%s", contextName, "yaml"))
 
 	// Load YAML as *yaml.Node
 	rootNode, err := LoadYAML(yamlPath)
 	if err != nil {
-		return yamlPath, nil, nil, selectedContext, err
+		return yamlPath, nil, nil, contextName, err
 	}
 
 	// YAML is parsed into a DocumentNode:
 	//   - rootNode.Content[0] is the top-level MappingNode
 	//   - It contains the 'context' mapping we're interested in
 	if len(rootNode.Content) == 0 {
-		return yamlPath, rootNode, nil, selectedContext, fmt.Errorf("empty YAML root node")
+		return yamlPath, rootNode, nil, contextName, fmt.Errorf("empty YAML root node")
 	}
 
 	// Navigate context to arrive at context.transporter.active_stake_roots
 	contextNode := GetChildByKey(rootNode.Content[0], "context")
 	if contextNode == nil {
-		return yamlPath, rootNode, nil, selectedContext, fmt.Errorf("missing 'context' key in ./config/contexts/%s.yaml", selectedContext)
+		return yamlPath, rootNode, nil, contextName, fmt.Errorf("missing 'context' key in ./config/contexts/%s.yaml", contextName)
 	}
 
-	return yamlPath, rootNode, contextNode, selectedContext, nil
+	return yamlPath, rootNode, contextNode, contextName, nil
 }
 
-func LoadRawContext(context string) ([]byte, error) {
-	// Use provided context if not empty
-	var selectedContext = context
-	if selectedContext == "" {
-		// Load the projects config
-		currentConfig, err := LoadBaseConfigYaml()
-		// If there is any error loading the yaml
-		if err != nil {
-			return nil, fmt.Errorf("error loading yaml: %w", err)
-		}
-		// Default to project selected context
-		selectedContext = currentConfig.Config.Project.Context
-	}
-
-	// Load the current config according to selected context
-	_, _, contextNode, err := LoadContext(selectedContext)
+func LoadDefaultRawContext() ([]byte, string, error) {
+	// Load the projects config
+	currentConfig, err := LoadBaseConfigYaml()
+	// If there is any error loading the yaml
 	if err != nil {
-		return nil, err
+		return nil, "", fmt.Errorf("error loading yaml: %w", err)
+	}
+	// Default to project selected context
+	contextName := currentConfig.Config.Project.Context
+
+	return LoadRawContext(contextName)
+}
+
+func LoadRawContext(contextName string) ([]byte, string, error) {
+	// Load the current config according to selected context
+	_, _, contextNode, contextName, err := LoadContext(contextName)
+	if err != nil {
+		return nil, contextName, err
 	}
 
 	var ctxMap map[string]interface{}
 	if err := contextNode.Decode(&ctxMap); err != nil {
-		return nil, fmt.Errorf("decode context node: %w", err)
+		return nil, contextName, fmt.Errorf("decode context node: %w", err)
 	}
 
 	contextBytes, err := json.Marshal(map[string]interface{}{"context": ctxMap})
 	if err != nil {
-		return nil, fmt.Errorf("marshal context: %w", err)
+		return nil, contextName, fmt.Errorf("marshal context: %w", err)
 	}
 
-	return contextBytes, nil
+	return contextBytes, contextName, nil
 }
 
 func RequireNonZero(s interface{}) error {


### PR DESCRIPTION
<!-- 
    🚨 ATTENTION! 🚨 
    
    This PR template is REQUIRED. PRs not following this format will be closed without review.
    
    Requirements:
    - PR title must follow commit conventions: https://www.conventionalcommits.org/en/v1.0.0/
    - Label your PR with the correct type (e.g., 🐛 Bug, ✨ Enhancement, 🧪 Test, etc.)
    - Provide clear and specific details in each section
-->

**Motivation:**
<!--
Explain here the context, and why you're making that change. What is the problem you're trying to solve.
-->
As an AVS developer, I want to be able to select the chosen context and have my selected context available to all commands. I also want to be able to override the config set context using a `--context` flag where appropriate

**Modifications:**
<!--
Describe the modifications you've done from a high level. What are the key technical decisions and why were they made?
-->
- Reads selected context from config
- Override using `--context` flag

**Result:**
<!--
*After your change, what will change.
-->
- Context is controlled by config and command flags

**Testing:**
<!--
*List testing procedures taken and useful artifacts.
-->
- All tests are pulling default devnet context and passing
- Coverage already exist for context selection etc...

