### PR TITLE
feat: restrict devnet only cmds

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ Triggers task execution through your AVS, simulating how a task would be submitt
 Run this from your project directory:
 
 ```bash
-devkit avs call --signature="(uint256,string)" args='(5,"hello")'
+devkit avs call signature="(uint256,string)" args='(5,"hello")'
 ```
 
 Optionally, submit tasks directly to the on-chain TaskMailbox contract via a frontend or another method for more realistic testing scenarios.

--- a/pkg/commands/call.go
+++ b/pkg/commands/call.go
@@ -25,8 +25,6 @@ var CallCommand = &cli.Command{
 		// Get logger
 		logger := common.LoggerFromContext(cCtx.Context)
 
-		logger.Debug("Testing AVS tasks...")
-
 		// Check for flagged contextName
 		contextName := cCtx.String("context")
 
@@ -34,12 +32,31 @@ var CallCommand = &cli.Command{
 		var err error
 		var contextJSON []byte
 		if contextName == "" {
-			contextJSON, _, err = common.LoadDefaultRawContext()
+			contextJSON, contextName, err = common.LoadDefaultRawContext()
 		} else {
-			contextJSON, _, err = common.LoadRawContext(contextName)
+			contextJSON, contextName, err = common.LoadRawContext(contextName)
 		}
 		if err != nil {
 			return fmt.Errorf("failed to load context: %w", err)
+		}
+
+		// Prevent runs when context is not devnet
+		if contextName != "devnet" {
+			cmdParams := reconstructCommandParams(cCtx.Args().Slice())
+
+			return fmt.Errorf(
+				"call failed: `devkit avs call` only available on devnet - please run `devkit avs call --context devnet %s`",
+				cmdParams,
+			)
+		}
+
+		// Print task if verbose
+		logger.Debug("Testing AVS tasks...")
+
+		// Check that args are provided
+		parts := cCtx.Args().Slice()
+		if len(parts) == 0 {
+			return fmt.Errorf("no parameters supplied")
 		}
 
 		// Run scriptPath from cwd
@@ -47,12 +64,6 @@ var CallCommand = &cli.Command{
 
 		// Set path for .devkit scripts
 		scriptPath := filepath.Join(".devkit", "scripts", "call")
-
-		// Check that args are provided
-		parts := cCtx.Args().Slice()
-		if len(parts) == 0 {
-			return fmt.Errorf("no parameters supplied")
-		}
 
 		// Parse the params from the provided args
 		paramsMap, err := parseParams(strings.Join(parts, " "))
@@ -89,4 +100,25 @@ func parseParams(input string) (map[string]string, error) {
 	}
 
 	return result, nil
+}
+
+func reconstructQuotes(val string) string {
+	if strings.Contains(val, `"`) {
+		return "'" + val + "'"
+	}
+	return `"` + val + `"`
+}
+
+func reconstructCommandParams(argv []string) string {
+	var out []string
+	for _, arg := range argv {
+		parts := strings.SplitN(arg, "=", 2)
+		if len(parts) == 2 {
+			k, v := parts[0], parts[1]
+			out = append(out, fmt.Sprintf("%s=%s", k, reconstructQuotes(v)))
+		} else {
+			out = append(out, arg)
+		}
+	}
+	return strings.Join(out, " ")
 }

--- a/pkg/commands/call.go
+++ b/pkg/commands/call.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/Layr-Labs/devkit-cli/pkg/common"
+	"github.com/Layr-Labs/devkit-cli/pkg/common/devnet"
 
 	"github.com/urfave/cli/v2"
 )
@@ -41,7 +42,7 @@ var CallCommand = &cli.Command{
 		}
 
 		// Prevent runs when context is not devnet
-		if contextName != "devnet" {
+		if contextName != devnet.DEVNET_CONTEXT {
 			cmdParams := reconstructCommandParams(cCtx.Args().Slice())
 
 			return fmt.Errorf(

--- a/pkg/commands/devnet.go
+++ b/pkg/commands/devnet.go
@@ -74,15 +74,24 @@ var DevnetCommand = &cli.Command{
 			Action: StartDevnetAction,
 		},
 		{
-			Name:   "deploy-contracts",
-			Usage:  "Deploy all L1/L2 and AVS contracts to devnet",
-			Flags:  []cli.Flag{},
+			Name:  "deploy-contracts",
+			Usage: "Deploy all L1/L2 and AVS contracts to devnet",
+			Flags: []cli.Flag{
+				&cli.StringFlag{
+					Name:  "context",
+					Usage: "Select the context to use in this command (devnet, testnet or mainnet)",
+				},
+			},
 			Action: DeployL1ContractsAction,
 		},
 		{
 			Name:  "stop",
 			Usage: "Stops and removes all containers and resources",
 			Flags: []cli.Flag{
+				&cli.StringFlag{
+					Name:  "context",
+					Usage: "Select the context to use in this command (devnet, testnet or mainnet)",
+				},
 				&cli.BoolFlag{
 					Name:  "all",
 					Usage: "Stop all running devnet containers",

--- a/pkg/commands/devnet_actions.go
+++ b/pkg/commands/devnet_actions.go
@@ -82,7 +82,7 @@ func StartDevnetAction(cCtx *cli.Context) error {
 	}
 
 	// Prevent runs when context is not devnet
-	if contextName != "devnet" {
+	if contextName != devnet.DEVNET_CONTEXT {
 		return fmt.Errorf("devnet start failed: `devkit avs devnet start` only available on devnet - please run `devkit avs devnet start --context devnet`")
 	}
 

--- a/pkg/commands/devnet_actions.go
+++ b/pkg/commands/devnet_actions.go
@@ -81,6 +81,11 @@ func StartDevnetAction(cCtx *cli.Context) error {
 		return fmt.Errorf("loading config and context failed: %w", err)
 	}
 
+	// Prevent runs when context is not devnet
+	if contextName != "devnet" {
+		return fmt.Errorf("devnet start failed: `devkit avs devnet start` only available on devnet - please run `devkit avs devnet start --context devnet`")
+	}
+
 	// Load the context nodes
 	yamlPath, rootNode, contextNode, contextName, err := common.LoadContext(contextName)
 	if err != nil {

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 
 	"github.com/Layr-Labs/devkit-cli/pkg/common"
+	"github.com/Layr-Labs/devkit-cli/pkg/common/devnet"
 
 	"github.com/urfave/cli/v2"
 )
@@ -45,7 +46,7 @@ func AVSRun(cCtx *cli.Context) error {
 	}
 
 	// Prevent runs when context is not devnet
-	if contextName != "devnet" {
+	if contextName != devnet.DEVNET_CONTEXT {
 		return fmt.Errorf("run failed: `devkit avs run` only available on devnet - please run `devkit avs run --context devnet`")
 	}
 

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -29,6 +29,26 @@ func AVSRun(cCtx *cli.Context) error {
 	// Get logger
 	logger := common.LoggerFromContext(cCtx.Context)
 
+	// Check for flagged contextName
+	contextName := cCtx.String("context")
+
+	// Set path for context yaml
+	var err error
+	var contextJSON []byte
+	if contextName == "" {
+		contextJSON, contextName, err = common.LoadDefaultRawContext()
+	} else {
+		contextJSON, contextName, err = common.LoadRawContext(contextName)
+	}
+	if err != nil {
+		return fmt.Errorf("failed to load context: %w", err)
+	}
+
+	// Prevent runs when context is not devnet
+	if contextName != "devnet" {
+		return fmt.Errorf("run failed: `devkit avs run` only available on devnet - please run `devkit avs run --context devnet`")
+	}
+
 	// Print task if verbose
 	logger.Debug("Starting offchain AVS components...")
 
@@ -38,21 +58,6 @@ func AVSRun(cCtx *cli.Context) error {
 
 	// Set path for .devkit scripts
 	scriptPath := filepath.Join(".devkit", "scripts", "run")
-
-	// Check for flagged contextName
-	contextName := cCtx.String("context")
-
-	// Set path for context yaml
-	var err error
-	var contextJSON []byte
-	if contextName == "" {
-		contextJSON, _, err = common.LoadDefaultRawContext()
-	} else {
-		contextJSON, _, err = common.LoadRawContext(contextName)
-	}
-	if err != nil {
-		return fmt.Errorf("failed to load context: %w", err)
-	}
 
 	// Run init on the template init script
 	if _, err := common.CallTemplateScript(cCtx.Context, logger, dir, scriptPath, common.ExpectNonJSONResponse, contextJSON); err != nil {


### PR DESCRIPTION
<!-- 
    🚨 ATTENTION! 🚨 
    
    This PR template is REQUIRED. PRs not following this format will be closed without review.
    
    Requirements:
    - PR title must follow commit conventions: https://www.conventionalcommits.org/en/v1.0.0/
    - Label your PR with the correct type (e.g., 🐛 Bug, ✨ Enhancement, 🧪 Test, etc.)
    - Provide clear and specific details in each section
-->

**Motivation:**
<!--
Explain here the context, and why you're making that change. What is the problem you're trying to solve.
-->
As an AVS developer, I want to be informed when I attempt to run a command that is not meant for testnet and beyond so that I am not surprised by any failures

**Modifications:**
<!--
Describe the modifications you've done from a high level. What are the key technical decisions and why were they made?
-->
- Restricts various commands to `devnet` context

**Result:**
<!--
*After your change, what will change.
-->
- `devnet start/deploy-contracts`, `run` and `call` can only be called when the selected context is `devnet`
