### PR TITLE
fix: allow AVS setup to be skipped from context "flag"

### DIFF
--- a/config/contexts/migrations/v0.0.8-v0.0.9.go
+++ b/config/contexts/migrations/v0.0.8-v0.0.9.go
@@ -92,6 +92,14 @@ func Migration_0_0_8_to_0_0_9(user, old, new *yaml.Node) (*yaml.Node, error) {
 					return &yaml.Node{Kind: yaml.ScalarNode, Value: "0xaCB5DE6aa94a1908E6FA577C2ade65065333B450"}
 				},
 			},
+			// Add skip-setup flag to avs config
+			{
+				Path:      []string{"context", "avs", "skip_setup"},
+				Condition: migration.Always{},
+				Transform: func(_ *yaml.Node) *yaml.Node {
+					return &yaml.Node{Kind: yaml.ScalarNode, Value: "false"}
+				},
+			},
 		},
 	}
 

--- a/config/contexts/migrations/v0.0.8-v0.0.9.go
+++ b/config/contexts/migrations/v0.0.8-v0.0.9.go
@@ -52,6 +52,14 @@ func Migration_0_0_8_to_0_0_9(user, old, new *yaml.Node) (*yaml.Node, error) {
 					return &yaml.Node{Kind: yaml.ScalarNode, Value: "0xA4dB30D08d8bbcA00D40600bee9F029984dB162a"}
 				},
 			},
+			// Update L2 TaskMailbox address
+			{
+				Path:      []string{"context", "eigenlayer", "l2", "task_mailbox"},
+				Condition: migration.Always{},
+				Transform: func(_ *yaml.Node) *yaml.Node {
+					return &yaml.Node{Kind: yaml.ScalarNode, Value: "0xB99CC53e8db7018f557606C2a5B066527bF96b26"}
+				},
+			},
 			// Update L2 OperatorTableUpdater address
 			{
 				Path:      []string{"context", "eigenlayer", "l2", "operator_table_updater"},


### PR DESCRIPTION
<!-- 
    🚨 ATTENTION! 🚨 
    
    This PR template is REQUIRED. PRs not following this format will be closed without review.
    
    Requirements:
    - PR title must follow commit conventions: https://www.conventionalcommits.org/en/v1.0.0/
    - Label your PR with the correct type (e.g., 🐛 Bug, ✨ Enhancement, 🧪 Test, etc.)
    - Provide clear and specific details in each section
-->

**Motivation:**
<!--
Explain here the context, and why you're making that change. What is the problem you're trying to solve.
-->
As a devkit user, I need to be able to `skip-setup` on AVS deployment to allow custom templates to handle this for me

**Modifications:**
<!--
Describe the modifications you've done from a high level. What are the key technical decisions and why were they made?
-->
- Reverts the removal of `avs.skip-setup` context migration following accidental removal
- Adds the same `skip-setup` procedure to `devnet start`

**Result:**
<!--
*After your change, what will change.
-->
- User can configure the `skip-setup` "flag" from their context to avoid having to do this in `devnet start`/`deploy l1`

**Testing:**
<!--
*List testing procedures taken and useful artifacts.
-->
- Tested locally
