### PR TITLE
fix: disable rpc rate limiting

### DIFF
--- a/pkg/common/devnet/constants.go
+++ b/pkg/common/devnet/constants.go
@@ -2,8 +2,8 @@ package devnet
 
 // Foundry Image Date : 21 April 2025
 const FOUNDRY_IMAGE = "ghcr.io/foundry-rs/foundry:stable"
-const L1_CHAIN_ARGS = "--gas-limit 140000000 --base-fee 0 --gas-price 1000000"
-const L2_CHAIN_ARGS = "--gas-limit 140000000 --base-fee 0 --gas-price 1000000"
+const L1_CHAIN_ARGS = "--gas-limit 140000000 --base-fee 0 --gas-price 1000000 --no-rate-limit"
+const L2_CHAIN_ARGS = "--gas-limit 140000000 --base-fee 0 --gas-price 1000000 --no-rate-limit"
 
 const FUND_VALUE = "1000000000000000000"
 const DEVNET_CONTEXT = "devnet"


### PR DESCRIPTION
<!-- 
    🚨 ATTENTION! 🚨 
    
    This PR template is REQUIRED. PRs not following this format will be closed without review.
    
    Requirements:
    - PR title must follow commit conventions: https://www.conventionalcommits.org/en/v1.0.0/
    - Label your PR with the correct type (e.g., 🐛 Bug, ✨ Enhancement, 🧪 Test, etc.)
    - Provide clear and specific details in each section
-->

**Motivation:**
<!--
Explain here the context, and why you're making that change. What is the problem you're trying to solve.
-->
As a devkit user, I need `devnet start` to reliably fork sepolia chains and keep nonces in sync at all times so that I do not encounter unexpected intermittent failures.

**Modifications:**
<!--
Describe the modifications you've done from a high level. What are the key technical decisions and why were they made?
-->
- Ensures Anvil is started with `--no-rate-limit` to eliminate artificial RPC throttling and allow high-throughput transaction scripts without nonce drift

**Result:**
<!--
*After your change, what will change.
-->
- Scripts using multiple signers or rapid `vm.startBroadcast` calls no longer encounter `Failed to send transaction` or `nonce too high/low` errors

**Testing:**
<!--
*List testing procedures taken and useful artifacts.
-->
- Manually tested `devnet start` flow that previously failed due to nonce mismatches
