### PR TITLE
feat: allow operators to define keys for each operatorSet

### DIFF
--- a/config/contexts/migrations/v0.0.8-v0.0.9.go
+++ b/config/contexts/migrations/v0.0.8-v0.0.9.go
@@ -100,14 +100,6 @@ func Migration_0_0_8_to_0_0_9(user, old, new *yaml.Node) (*yaml.Node, error) {
 					return &yaml.Node{Kind: yaml.ScalarNode, Value: "0xaCB5DE6aa94a1908E6FA577C2ade65065333B450"}
 				},
 			},
-			// Add skip-setup flag to avs config
-			{
-				Path:      []string{"context", "avs", "skip_setup"},
-				Condition: migration.Always{},
-				Transform: func(_ *yaml.Node) *yaml.Node {
-					return &yaml.Node{Kind: yaml.ScalarNode, Value: "false"}
-				},
-			},
 		},
 	}
 

--- a/config/contexts/migrations/v0.0.9-v0.1.0.go
+++ b/config/contexts/migrations/v0.0.9-v0.1.0.go
@@ -1,0 +1,123 @@
+package contextMigrations
+
+import (
+	"fmt"
+
+	"github.com/Layr-Labs/devkit-cli/pkg/migration"
+
+	"gopkg.in/yaml.v3"
+)
+
+func Migration_0_0_9_to_0_1_0(user, old, new *yaml.Node) (*yaml.Node, error) {
+	engine := migration.PatchEngine{
+		Old:  old,
+		New:  new,
+		User: user,
+		Rules: []migration.PatchRule{
+			// Move Operators keystore to map
+			{
+				Path:      []string{"context", "operators"},
+				Condition: migration.Always{},
+				Transform: func(_ *yaml.Node) *yaml.Node {
+					avsNode := migration.ResolveNode(user, []string{"context", "avs", "address"})
+					avsAddr := ""
+					if avsNode != nil {
+						avsAddr = avsNode.Value
+					}
+
+					ops := migration.ResolveNode(user, []string{"context", "operators"})
+					if ops == nil || ops.Kind != yaml.SequenceNode {
+						return ops
+					}
+					out := migration.CloneNode(ops)
+
+					// Fixed operatorSet IDs
+					opsetIDs := []int{0, 1}
+
+					for _, op := range out.Content {
+						if op.Kind != yaml.MappingNode {
+							continue
+						}
+
+						ecdsaPath := ""
+						if n := migration.ResolveNode(op, []string{"ecdsa_keystore_path"}); n != nil {
+							ecdsaPath = n.Value
+						}
+						ecdsaPass := ""
+						if n := migration.ResolveNode(op, []string{"ecdsa_keystore_password"}); n != nil {
+							ecdsaPass = n.Value
+						}
+						blsPath := ""
+						if n := migration.ResolveNode(op, []string{"bls_keystore_path"}); n != nil {
+							blsPath = n.Value
+						}
+						blsPass := ""
+						if n := migration.ResolveNode(op, []string{"bls_keystore_password"}); n != nil {
+							blsPass = n.Value
+						}
+
+						// build keystores
+						keystoresSeq := &yaml.Node{Kind: yaml.SequenceNode, Tag: "!!seq"}
+
+						for _, setID := range opsetIDs {
+							ksMap := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+
+							ksMap.Content = append(ksMap.Content,
+								&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "avs"},
+								&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: avsAddr},
+
+								&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "operatorSet"},
+								&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!int", Value: fmt.Sprintf("%d", setID)},
+
+								&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "ecdsa_keystore_path"},
+								&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: ecdsaPath},
+								&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "ecdsa_keystore_password"},
+								&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: ecdsaPass},
+
+								&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "bls_keystore_path"},
+								&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: blsPath},
+								&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "bls_keystore_password"},
+								&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: blsPass},
+							)
+
+							keystoresSeq.Content = append(keystoresSeq.Content, ksMap)
+						}
+
+						// drop old flat fields and any preexisting keystore/keystores
+						c := op.Content[:0]
+						for j := 0; j < len(op.Content); j += 2 {
+							k := op.Content[j].Value
+							if k == "ecdsa_keystore_path" ||
+								k == "ecdsa_keystore_password" ||
+								k == "bls_keystore_path" ||
+								k == "bls_keystore_password" ||
+								k == "keystores" {
+								continue
+							}
+							c = append(c, op.Content[j], op.Content[j+1])
+						}
+						op.Content = c
+
+						// write new keystores
+						op.Content = append(op.Content,
+							&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "keystores"},
+							keystoresSeq,
+						)
+					}
+					return out
+				},
+			},
+		},
+	}
+
+	if err := engine.Apply(); err != nil {
+		return nil, err
+	}
+
+	// Upgrade the version
+	if v := migration.ResolveNode(user, []string{"version"}); v != nil {
+		v.Value = "0.1.0"
+	}
+
+	return user, nil
+}

--- a/config/contexts/registry.go
+++ b/config/contexts/registry.go
@@ -15,7 +15,7 @@ import (
 )
 
 // Set the latest version
-const LatestVersion = "0.0.9"
+const LatestVersion = "0.1.0"
 
 // Array of default contexts to create in project
 var DefaultContexts = [...]string{
@@ -53,6 +53,9 @@ var v0_0_8_default []byte
 //go:embed v0.0.9.yaml
 var v0_0_9_default []byte
 
+//go:embed v0.1.0.yaml
+var v0_1_0_default []byte
+
 // Map of context name -> content
 var ContextYamls = map[string][]byte{
 	"0.0.1": v0_0_1_default,
@@ -64,6 +67,7 @@ var ContextYamls = map[string][]byte{
 	"0.0.7": v0_0_7_default,
 	"0.0.8": v0_0_8_default,
 	"0.0.9": v0_0_9_default,
+	"0.1.0": v0_1_0_default,
 }
 
 // Map of sequential migrations
@@ -123,6 +127,13 @@ var MigrationChain = []migration.MigrationStep{
 		Apply:   contextMigrations.Migration_0_0_8_to_0_0_9,
 		OldYAML: v0_0_8_default,
 		NewYAML: v0_0_9_default,
+	},
+	{
+		From:    "0.0.9",
+		To:      "0.1.0",
+		Apply:   contextMigrations.Migration_0_0_9_to_0_1_0,
+		OldYAML: v0_0_9_default,
+		NewYAML: v0_1_0_default,
 	},
 }
 

--- a/config/contexts/v0.1.0.yaml
+++ b/config/contexts/v0.1.0.yaml
@@ -1,5 +1,5 @@
 # Devnet context to be used for local deployments against Anvil chain
-version: 0.0.9
+version: 0.1.0
 context:
   # Name of the context
   name: "devnet"
@@ -50,11 +50,20 @@ context:
   # List of Operators and their private keys / stake details
   operators:
     - address: "0x90F79bf6EB2c4f870365E785982E1f101E93b906"
-      ecdsa_key: "0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6" # Anvil Private Key 3
-      ecdsa_keystore_path: "keystores/operator1.ecdsa.keystore.json"
-      ecdsa_keystore_password: "testpass"
-      bls_keystore_path: "keystores/operator1.bls.keystore.json"
-      bls_keystore_password: "testpass"
+      ecdsa_key: "0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6"
+      keystores:
+        - avs: "0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
+          operatorSet: 0
+          ecdsa_keystore_path: "keystores/operator1.ecdsa.keystore.json"
+          ecdsa_keystore_password: "testpass"
+          bls_keystore_path: "keystores/operator1.bls.keystore.json"
+          bls_keystore_password: "testpass"
+        - avs: "0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
+          operatorSet: 1
+          ecdsa_keystore_path: "keystores/operator1.ecdsa.keystore.json"
+          ecdsa_keystore_password: "testpass"
+          bls_keystore_path: "keystores/operator1.bls.keystore.json"
+          bls_keystore_password: "testpass"
       allocations:
         - strategy_address: "0x8b29d91e67b013e855EaFe0ad704aC4Ab086a574"
           name: "stETH_Strategy"
@@ -66,10 +75,19 @@ context:
               allocation_in_wads: "500000000000000000" # 5e17 i.e 50% of max allocation
     - address: "0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65"
       ecdsa_key: "0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a" # Anvil Private Key 4
-      ecdsa_keystore_path: "keystores/operator2.ecdsa.keystore.json"
-      ecdsa_keystore_password: "testpass"
-      bls_keystore_path: "keystores/operator2.bls.keystore.json"
-      bls_keystore_password: "testpass"
+      keystores:
+        - avs: "0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
+          operatorSet: 0
+          ecdsa_keystore_path: "keystores/operator2.ecdsa.keystore.json"
+          ecdsa_keystore_password: "testpass"
+          bls_keystore_path: "keystores/operator2.bls.keystore.json"
+          bls_keystore_password: "testpass"
+        - avs: "0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
+          operatorSet: 1
+          ecdsa_keystore_path: "keystores/operator2.ecdsa.keystore.json"
+          ecdsa_keystore_password: "testpass"
+          bls_keystore_path: "keystores/operator2.bls.keystore.json"
+          bls_keystore_password: "testpass"
       allocations:
         - strategy_address: "0x8b29d91e67b013e855EaFe0ad704aC4Ab086a574"
           name: "stETH_Strategy"
@@ -81,22 +99,49 @@ context:
               allocation_in_wads: "500000000000000000" # 5e17 i.e 50% of max allocation
     - address: "0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc"
       ecdsa_key: "0x8b3a350cf5c34c9194ca85829a2df0ec3153be0318b5e2d3348e872092edffba" # Anvil Private Key 5
-      ecdsa_keystore_path: "keystores/operator3.ecdsa.keystore.json"
-      ecdsa_keystore_password: "testpass"
-      bls_keystore_path: "keystores/operator3.bls.keystore.json"
-      bls_keystore_password: "testpass"
+      keystores:
+        - avs: "0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
+          operatorSet: 0
+          ecdsa_keystore_path: "keystores/operator3.ecdsa.keystore.json"
+          ecdsa_keystore_password: "testpass"
+          bls_keystore_path: "keystores/operator3.bls.keystore.json"
+          bls_keystore_password: "testpass"
+        - avs: "0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
+          operatorSet: 1
+          ecdsa_keystore_path: "keystores/operator3.ecdsa.keystore.json"
+          ecdsa_keystore_password: "testpass"
+          bls_keystore_path: "keystores/operator3.bls.keystore.json"
+          bls_keystore_password: "testpass"
     - address: "0x976EA74026E726554dB657fA54763abd0C3a0aa9"
       ecdsa_key: "0x92db14e403b83dfe3df233f83dfa3a0d7096f21ca9b0d6d6b8d88b2b4ec1564e" # Anvil Private Key 6
-      ecdsa_keystore_path: "keystores/operator4.ecdsa.keystore.json"
-      ecdsa_keystore_password: "testpass"
-      bls_keystore_path: "keystores/operator4.bls.keystore.json"
-      bls_keystore_password: "testpass"
+      keystores:
+        - avs: "0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
+          operatorSet: 0
+          ecdsa_keystore_path: "keystores/operator4.ecdsa.keystore.json"
+          ecdsa_keystore_password: "testpass"
+          bls_keystore_path: "keystores/operator4.bls.keystore.json"
+          bls_keystore_password: "testpass"
+        - avs: "0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
+          operatorSet: 1
+          ecdsa_keystore_path: "keystores/operator4.ecdsa.keystore.json"
+          ecdsa_keystore_password: "testpass"
+          bls_keystore_path: "keystores/operator4.bls.keystore.json"
+          bls_keystore_password: "testpass"
     - address: "0x14dC79964da2C08b23698B3D3cc7Ca32193d9955"
       ecdsa_key: "0x4bbbf85ce3377467afe5d46f804f221813b2bb87f24d81f60f1fcdbf7cbf4356" # Anvil Private Key 7
-      ecdsa_keystore_path: "keystores/operator5.ecdsa.keystore.json"
-      ecdsa_keystore_password: "testpass"
-      bls_keystore_path: "keystores/operator5.bls.keystore.json"
-      bls_keystore_password: "testpass"
+      keystores:
+        - avs: "0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
+          operatorSet: 0
+          ecdsa_keystore_path: "keystores/operator5.ecdsa.keystore.json"
+          ecdsa_keystore_password: "testpass"
+          bls_keystore_path: "keystores/operator5.bls.keystore.json"
+          bls_keystore_password: "testpass"
+        - avs: "0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
+          operatorSet: 1
+          ecdsa_keystore_path: "keystores/operator5.ecdsa.keystore.json"
+          ecdsa_keystore_password: "testpass"
+          bls_keystore_path: "keystores/operator5.bls.keystore.json"
+          bls_keystore_password: "testpass"
   # AVS configuration
   avs:
     address: "0x70997970C51812dc3A010C7d01b50e0d17dc79C8"

--- a/config/templates.yaml
+++ b/config/templates.yaml
@@ -3,7 +3,7 @@ architectures:
     languages:
       go:
         baseUrl: "https://github.com/Layr-Labs/hourglass-avs-template"
-        version: "v0.0.17"
+        version: "99a5fa4273526cd5ab09267890fdd1d2c2774161"
       ts:
         baseUrl: ""
         version: ""

--- a/pkg/commands/devnet_actions.go
+++ b/pkg/commands/devnet_actions.go
@@ -338,7 +338,7 @@ func StartDevnetAction(cCtx *cli.Context) error {
 		time.Sleep(1 * time.Second)
 
 		logger.Title("Registering AVS with EigenLayer...")
-		if !(cCtx.Bool("skip-setup") || envCtx.Avs.SkipSetup) {
+		if !cCtx.Bool("skip-setup") {
 			if err := UpdateAVSMetadataAction(cCtx, logger); err != nil {
 				return fmt.Errorf("updating AVS metadata failed: %w", err)
 			}
@@ -1472,14 +1472,14 @@ func stopBothContainersByPort(cCtx *cli.Context, log iface.Logger, targetPort in
 // loadOperatorECDSAKey loads an operator's ECDSA private key from keystore or plaintext
 func loadOperatorECDSAKey(operator common.OperatorSpec) (string, error) {
 	// Check if ECDSA keystore is configured
-	if operator.ECDSAKeystorePath != "" && operator.ECDSAKeystorePassword != "" {
+	if len(operator.Keystores) > 0 && operator.Keystores[0].ECDSAKeystorePath != "" && operator.Keystores[0].ECDSAKeystorePassword != "" {
 		// Load from keystore
-		keystoreData, err := os.ReadFile(operator.ECDSAKeystorePath)
+		keystoreData, err := os.ReadFile(operator.Keystores[0].ECDSAKeystorePath)
 		if err != nil {
-			return "", fmt.Errorf("failed to read ECDSA keystore file %s: %w", operator.ECDSAKeystorePath, err)
+			return "", fmt.Errorf("failed to read ECDSA keystore file %s: %w", operator.Keystores[0].ECDSAKeystorePath, err)
 		}
 
-		key, err := ethkeystore.DecryptKey(keystoreData, operator.ECDSAKeystorePassword)
+		key, err := ethkeystore.DecryptKey(keystoreData, operator.Keystores[0].ECDSAKeystorePassword)
 		if err != nil {
 			return "", fmt.Errorf("failed to decrypt ECDSA keystore: %w", err)
 		}

--- a/pkg/commands/devnet_actions_test.go
+++ b/pkg/commands/devnet_actions_test.go
@@ -19,10 +19,14 @@ func TestLoadECDSAKeysFromKeystores(t *testing.T) {
 			// No keystore - use plaintext
 		},
 		{
-			Address:               "0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65",
-			ECDSAKey:              "0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a",
-			ECDSAKeystorePath:     "keystores/nonexistent.ecdsa.keystore.json",
-			ECDSAKeystorePassword: "testpass",
+			Address:  "0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65",
+			ECDSAKey: "0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a",
+			Keystores: []common.OperatorKeystores{
+				{
+					ECDSAKeystorePath:     "keystores/nonexistent.ecdsa.keystore.json",
+					ECDSAKeystorePassword: "testpass",
+				},
+			},
 		},
 		{
 			Address:  "0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc",
@@ -65,10 +69,14 @@ func TestLoadECDSAKeysFromKeystores(t *testing.T) {
 	t.Run("use plaintext key when keystore path without password", func(t *testing.T) {
 		// Test operator with keystore path but no password - should use plaintext
 		opWithPath := common.OperatorSpec{
-			Address:           "0x14dC79964da2C08b23698B3D3cc7Ca32193d9955",
-			ECDSAKey:          "0x4bbbf85ce3377467afe5d46f804f221813b2bb87f24d81f60f1fcdbf7cbf4356",
-			ECDSAKeystorePath: "keystores/operator5.ecdsa.keystore.json",
-			// No password provided
+			Address:  "0x14dC79964da2C08b23698B3D3cc7Ca32193d9955",
+			ECDSAKey: "0x4bbbf85ce3377467afe5d46f804f221813b2bb87f24d81f60f1fcdbf7cbf4356",
+			Keystores: []common.OperatorKeystores{
+				{
+					ECDSAKeystorePath: "keystores/operator5.ecdsa.keystore.json",
+					// No password provided
+				},
+			},
 		}
 		key, err := loadOperatorECDSAKey(opWithPath)
 		require.NoError(t, err)
@@ -99,18 +107,27 @@ func TestMixedBLSAndECDSAOperators(t *testing.T) {
 	// Test mixed operator configuration
 	operators := []common.OperatorSpec{
 		{
-			Address:               "0x90F79bf6EB2c4f870365E785982E1f101E93b906",
-			ECDSAKey:              "0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6",
-			ECDSAKeystorePath:     "keystores/operator1.ecdsa.keystore.json",
-			ECDSAKeystorePassword: "testpass",
-			BlsKeystorePath:       "keystores/operator1.bls.keystore.json",
-			BlsKeystorePassword:   "testpass",
+			Address:  "0x90F79bf6EB2c4f870365E785982E1f101E93b906",
+			ECDSAKey: "0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6",
+			Keystores: []common.OperatorKeystores{
+				{
+					ECDSAKeystorePath:     "keystores/operator1.ecdsa.keystore.json",
+					ECDSAKeystorePassword: "testpass",
+					BlsKeystorePath:       "keystores/operator1.bls.keystore.json",
+					BlsKeystorePassword:   "testpass",
+				},
+			},
 		},
 		{
-			Address:             "0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65",
-			ECDSAKey:            "0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a",
-			BlsKeystorePath:     "keystores/operator2.bls.keystore.json",
-			BlsKeystorePassword: "testpass",
+			Address:  "0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65",
+			ECDSAKey: "0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a",
+			Keystores: []common.OperatorKeystores{
+				{
+					BlsKeystorePath:     "keystores/operator2.bls.keystore.json",
+					BlsKeystorePassword: "testpass",
+				},
+			},
+
 			// No ECDSA keystore - uses plaintext
 		},
 	}

--- a/pkg/common/config.go
+++ b/pkg/common/config.go
@@ -35,14 +35,21 @@ type ForkConfig struct {
 }
 
 type OperatorSpec struct {
-	Address               string               `json:"address" yaml:"address"`
-	ECDSAKey              string               `json:"ecdsa_key,omitempty" yaml:"ecdsa_key,omitempty"`
-	ECDSAKeystorePath     string               `json:"ecdsa_keystore_path,omitempty" yaml:"ecdsa_keystore_path,omitempty"`
-	ECDSAKeystorePassword string               `json:"ecdsa_keystore_password,omitempty" yaml:"ecdsa_keystore_password,omitempty"`
-	BlsKeystorePath       string               `json:"bls_keystore_path" yaml:"bls_keystore_path"`
-	BlsKeystorePassword   string               `json:"bls_keystore_password" yaml:"bls_keystore_password"`
-	Stake                 string               `json:"stake,omitempty" yaml:"stake,omitempty"`
-	Allocations           []OperatorAllocation `json:"allocations,omitempty" yaml:"allocations,omitempty"`
+	Address     string               `json:"address" yaml:"address"`
+	ECDSAKey    string               `json:"ecdsa_key,omitempty" yaml:"ecdsa_key,omitempty"`
+	Stake       string               `json:"stake,omitempty" yaml:"stake,omitempty"`
+	Keystores   []OperatorKeystores  `json:"keystores,omitempty" yaml:"keystores,omitempty"`
+	Allocations []OperatorAllocation `json:"allocations,omitempty" yaml:"allocations,omitempty"`
+}
+
+// OperatorKeystore defines keystore data available to an operator
+type OperatorKeystores struct {
+	AVSAddress            string `json:"avs,omitempty" yaml:"avs,omitempty"`
+	OperatorSet           uint64 `json:"operatorSet,omitempty" yaml:"operatorSet,omitempty"`
+	ECDSAKeystorePath     string `json:"ecdsa_keystore_path,omitempty" yaml:"ecdsa_keystore_path,omitempty"`
+	ECDSAKeystorePassword string `json:"ecdsa_keystore_password,omitempty" yaml:"ecdsa_keystore_password,omitempty"`
+	BlsKeystorePath       string `json:"bls_keystore_path" yaml:"bls_keystore_path"`
+	BlsKeystorePassword   string `json:"bls_keystore_password" yaml:"bls_keystore_password"`
 }
 
 // OperatorAllocation defines strategy allocation for an operator
@@ -74,7 +81,6 @@ type StakerDeposits struct {
 }
 
 type AvsConfig struct {
-	SkipSetup        bool   `json:"skip_setup" yaml:"skip_setup"`
 	Address          string `json:"address" yaml:"address"`
 	MetadataUri      string `json:"metadata_url" yaml:"metadata_url"`
 	AVSPrivateKey    string `json:"avs_private_key" yaml:"avs_private_key"`

--- a/pkg/common/config_test.go
+++ b/pkg/common/config_test.go
@@ -42,10 +42,10 @@ func TestLoadConfigWithContextConfig_FromCopiedTempFile(t *testing.T) {
 	assert.Equal(t, "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80", cfg.Context["devnet"].DeployerPrivateKey)
 	assert.Equal(t, "0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a", cfg.Context["devnet"].AppDeployerPrivateKey)
 
-	assert.Equal(t, "keystores/operator1.bls.keystore.json", cfg.Context["devnet"].Operators[0].BlsKeystorePath)
-	assert.Equal(t, "keystores/operator2.bls.keystore.json", cfg.Context["devnet"].Operators[1].BlsKeystorePath)
-	assert.Equal(t, "testpass", cfg.Context["devnet"].Operators[0].BlsKeystorePassword)
-	assert.Equal(t, "testpass", cfg.Context["devnet"].Operators[0].BlsKeystorePassword)
+	assert.Equal(t, "keystores/operator1.bls.keystore.json", cfg.Context["devnet"].Operators[0].Keystores[0].BlsKeystorePath)
+	assert.Equal(t, "keystores/operator2.bls.keystore.json", cfg.Context["devnet"].Operators[1].Keystores[0].BlsKeystorePath)
+	assert.Equal(t, "testpass", cfg.Context["devnet"].Operators[0].Keystores[0].BlsKeystorePassword)
+	assert.Equal(t, "testpass", cfg.Context["devnet"].Operators[0].Keystores[0].BlsKeystorePassword)
 
 	// In v0.0.6, operators use allocations instead of stake
 	assert.NotEmpty(t, cfg.Context["devnet"].Operators[0].Allocations)

--- a/pkg/common/devnet/funding.go
+++ b/pkg/common/devnet/funding.go
@@ -307,14 +307,14 @@ func FundWalletsDevnet(cfg *devkitcommon.ConfigWithContextConfig, rpcURL string)
 		var privateKey *ecdsa.PrivateKey
 
 		// Check if ECDSA keystore is configured
-		if operator.ECDSAKeystorePath != "" && operator.ECDSAKeystorePassword != "" {
+		if len(operator.Keystores) > 0 && operator.Keystores[0].ECDSAKeystorePath != "" && operator.Keystores[0].ECDSAKeystorePassword != "" {
 			// Load from keystore
-			keystoreData, err := os.ReadFile(operator.ECDSAKeystorePath)
+			keystoreData, err := os.ReadFile(operator.Keystores[0].ECDSAKeystorePath)
 			if err != nil {
-				log.Fatalf("failed to read ECDSA keystore file %s: %v", operator.ECDSAKeystorePath, err)
+				log.Fatalf("failed to read ECDSA keystore file %s: %v", operator.Keystores[0].ECDSAKeystorePath, err)
 			}
 
-			key, err := keystore.DecryptKey(keystoreData, operator.ECDSAKeystorePassword)
+			key, err := keystore.DecryptKey(keystoreData, operator.Keystores[0].ECDSAKeystorePassword)
 			if err != nil {
 				log.Fatalf("failed to decrypt ECDSA keystore: %v", err)
 			}

--- a/pkg/template/config_test.go
+++ b/pkg/template/config_test.go
@@ -17,7 +17,7 @@ func TestLoadConfig(t *testing.T) {
 	}
 
 	expectedBaseURL := "https://github.com/Layr-Labs/hourglass-avs-template"
-	expectedVersion := "v0.0.17"
+	expectedVersion := "99a5fa4273526cd5ab09267890fdd1d2c2774161"
 
 	if mainBaseURL != expectedBaseURL {
 		t.Errorf("Unexpected main template base URL: got %s, want %s", mainBaseURL, expectedBaseURL)

--- a/test/integration/migration/avs_context_migration_test.go
+++ b/test/integration/migration/avs_context_migration_test.go
@@ -1063,6 +1063,297 @@ context:
 	})
 }
 
+func TestAVSContextMigration_0_0_8_to_0_0_9_PatchesAndAddsSkipSetup(t *testing.T) {
+	// v0.0.8 input with existing structure and old values
+	const in = `version: 0.0.8
+context:
+  name: "pre-009"
+  chains:
+    l1:
+      fork:
+        block: "11111111"
+    l2:
+      fork:
+        block: "22222222"
+  eigenlayer:
+    l1:
+      cross_chain_registry: "0xOLD_L1_CCR"
+      operator_table_updater: "0xOLD_L1_OTU"
+      key_registrar: "0xOLD_L1_KR"
+      bn254_table_calculator: "0xOLD_L1_BN254_TC"
+      ecdsa_table_calculator: "0xOLD_L1_ECDSA_TC"
+    l2:
+      task_mailbox: "0xOLD_L2_TM"
+      operator_table_updater: "0xOLD_L2_OTU"
+      bn254_certificate_verifier: "0xOLD_L2_BN254_CV"
+      ecdsa_certificate_verifier: "0xOLD_L2_ECDSA_CV"
+  avs:
+    address: "0xAVS"
+`
+
+	userNode := testNode(t, in)
+
+	// find the step 0.0.8 -> 0.0.9
+	var step migration.MigrationStep
+	for _, s := range contexts.MigrationChain {
+		if s.From == "0.0.8" && s.To == "0.0.9" {
+			step = s
+			break
+		}
+	}
+	if step.Apply == nil {
+		t.Fatalf("migration step 0.0.8 -> 0.0.9 not found")
+	}
+
+	out, err := migration.MigrateNode(userNode, "0.0.8", "0.0.9", []migration.MigrationStep{step})
+	if err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	// print migrated YAML for debugging
+	if b, err := yaml.Marshal(out); err == nil {
+		t.Log("\n" + string(b))
+	}
+
+	t.Run("version bumped", func(t *testing.T) {
+		v := migration.ResolveNode(out, []string{"version"})
+		if v == nil || v.Value != "0.0.9" {
+			t.Errorf("want version 0.0.9, got %v", v)
+		}
+	})
+
+	t.Run("fork blocks updated", func(t *testing.T) {
+		l1 := migration.ResolveNode(out, []string{"context", "chains", "l1", "fork", "block"})
+		l2 := migration.ResolveNode(out, []string{"context", "chains", "l2", "fork", "block"})
+		if l1 == nil || l1.Value != "8836193" {
+			t.Errorf("l1.fork.block want 8836193, got %v", l1)
+		}
+		if l2 == nil || l2.Value != "28820370" {
+			t.Errorf("l2.fork.block want 28820370, got %v", l2)
+		}
+	})
+
+	t.Run("L1 addresses updated", func(t *testing.T) {
+		CCR := migration.ResolveNode(out, []string{"context", "eigenlayer", "l1", "cross_chain_registry"})
+		OTU := migration.ResolveNode(out, []string{"context", "eigenlayer", "l1", "operator_table_updater"})
+		KR := migration.ResolveNode(out, []string{"context", "eigenlayer", "l1", "key_registrar"})
+		BN := migration.ResolveNode(out, []string{"context", "eigenlayer", "l1", "bn254_table_calculator"})
+		EC := migration.ResolveNode(out, []string{"context", "eigenlayer", "l1", "ecdsa_table_calculator"})
+
+		if CCR == nil || CCR.Value != "0x287381B1570d9048c4B4C7EC94d21dDb8Aa1352a" {
+			t.Errorf("l1.cross_chain_registry updated wrong, got %v", CCR)
+		}
+		if OTU == nil || OTU.Value != "0xB02A15c6Bd0882b35e9936A9579f35FB26E11476" {
+			t.Errorf("l1.operator_table_updater updated wrong, got %v", OTU)
+		}
+		if KR == nil || KR.Value != "0xA4dB30D08d8bbcA00D40600bee9F029984dB162a" {
+			t.Errorf("l1.key_registrar updated wrong, got %v", KR)
+		}
+		if BN == nil || BN.Value != "0xa19E3B00cf4aC46B5e6dc0Bbb0Fb0c86D0D65603" {
+			t.Errorf("l1.bn254_table_calculator updated wrong, got %v", BN)
+		}
+		if EC == nil || EC.Value != "0xaCB5DE6aa94a1908E6FA577C2ade65065333B450" {
+			t.Errorf("l1.ecdsa_table_calculator updated wrong, got %v", EC)
+		}
+	})
+
+	t.Run("L2 addresses updated", func(t *testing.T) {
+		TM := migration.ResolveNode(out, []string{"context", "eigenlayer", "l2", "task_mailbox"})
+		OTU := migration.ResolveNode(out, []string{"context", "eigenlayer", "l2", "operator_table_updater"})
+		BN := migration.ResolveNode(out, []string{"context", "eigenlayer", "l2", "bn254_certificate_verifier"})
+		EC := migration.ResolveNode(out, []string{"context", "eigenlayer", "l2", "ecdsa_certificate_verifier"})
+
+		if TM == nil || TM.Value != "0xB99CC53e8db7018f557606C2a5B066527bF96b26" {
+			t.Errorf("l2.task_mailbox updated wrong, got %v", TM)
+		}
+		if OTU == nil || OTU.Value != "0xB02A15c6Bd0882b35e9936A9579f35FB26E11476" {
+			t.Errorf("l2.operator_table_updater updated wrong, got %v", OTU)
+		}
+		if BN == nil || BN.Value != "0xff58A373c18268F483C1F5cA03Cf885c0C43373a" {
+			t.Errorf("l2.bn254_certificate_verifier updated wrong, got %v", BN)
+		}
+		if EC == nil || EC.Value != "0xb3Cd1A457dEa9A9A6F6406c6419B1c326670A96F" {
+			t.Errorf("l2.ecdsa_certificate_verifier updated wrong, got %v", EC)
+		}
+	})
+
+	t.Run("unrelated fields preserved", func(t *testing.T) {
+		name := migration.ResolveNode(out, []string{"context", "name"})
+		if name == nil || name.Value != "pre-009" {
+			t.Errorf("context.name mutated, got %v", name)
+		}
+	})
+}
+
+func TestAVSContextMigration_0_0_9_to_0_1_0_FixedOpSets(t *testing.T) {
+	// v0.0.9 input with flat keystore fields
+	customYAML := `version: 0.0.9
+context:
+  name: "custom-context"
+  avs:
+    address: "0xAVS_ADDR"
+  operators:
+    - address: "0xOP1"
+      ecdsa_key: "0xECDSAKEY1"
+      ecdsa_keystore_path: "keystores/operator1.ecdsa.keystore.json"
+      ecdsa_keystore_password: "pass1"
+      bls_keystore_path: "keystores/operator1.bls.keystore.json"
+      bls_keystore_password: "bpass1"
+      custom_field: "keepme1"
+    - address: "0xOP2"
+      ecdsa_key: "0xECDSAKEY2"
+      ecdsa_keystore_path: "keystores/operator2.ecdsa.keystore.json"
+      ecdsa_keystore_password: "pass2"
+      bls_keystore_path: "keystores/operator2.bls.keystore.json"
+      bls_keystore_password: "bpass2"
+  allocations:
+    - strategy_address: "0xSTRAT"
+      name: "stETH_Strategy"
+      operator_set_allocations:
+        - operator_set: "0"
+          allocation_in_wads: "500000000000000000"
+        - operator_set: "1"
+          allocation_in_wads: "500000000000000000"
+`
+
+	userNode := testNode(t, customYAML)
+
+	// locate the 0.0.9 -> 0.1.0 step from the chain
+	var step migration.MigrationStep
+	for _, s := range contexts.MigrationChain {
+		if s.From == "0.0.9" && s.To == "0.1.0" {
+			step = s
+			break
+		}
+	}
+	if step.Apply == nil {
+		t.Fatalf("migration step 0.0.9 -> 0.1.0 not found")
+	}
+
+	migrated, err := migration.MigrateNode(userNode, "0.0.9", "0.1.0", []migration.MigrationStep{step})
+	if err != nil {
+		t.Fatalf("Migration failed: %v", err)
+	}
+
+	t.Run("version bumped", func(t *testing.T) {
+		v := migration.ResolveNode(migrated, []string{"version"})
+		if v == nil || v.Value != "0.1.0" {
+			t.Errorf("expected version 0.1.0, got %v", v)
+		}
+	})
+
+	t.Run("operator 1 keystores created and fields preserved", func(t *testing.T) {
+		op := migration.ResolveNode(migrated, []string{"context", "operators", "0"})
+		if op == nil {
+			t.Fatal("operator[0] missing")
+		}
+
+		// preserved fields
+		if got := migration.ResolveNode(op, []string{"address"}); got == nil || got.Value != "0xOP1" {
+			t.Errorf("address not preserved, got %v", got)
+		}
+		if got := migration.ResolveNode(op, []string{"ecdsa_key"}); got == nil || got.Value != "0xECDSAKEY1" {
+			t.Errorf("ecdsa_key not preserved, got %v", got)
+		}
+		if got := migration.ResolveNode(op, []string{"custom_field"}); got == nil || got.Value != "keepme1" {
+			t.Errorf("custom_field not preserved, got %v", got)
+		}
+
+		// old flat fields removed
+		for _, k := range []string{"ecdsa_keystore_path", "ecdsa_keystore_password", "bls_keystore_path", "bls_keystore_password", "keystore"} {
+			if n := migration.ResolveNode(op, []string{k}); n != nil {
+				t.Errorf("expected %s to be removed, found %v", k, n)
+			}
+		}
+
+		// new keystores
+		ks := migration.ResolveNode(op, []string{"keystores"})
+		if ks == nil || ks.Kind != 2 /* yaml.SequenceNode */ || len(ks.Content) != 2 {
+			t.Fatalf("expected keystores sequence with 2 entries, got %#v", ks)
+		}
+
+		// entry 1: operatorSet 0
+		ks0 := ks.Content[0]
+		check := func(path []string, want string) {
+			n := migration.ResolveNode(ks0, path)
+			if n == nil || n.Value != want {
+				t.Errorf("expected %v == %q, got %v", path, want, n)
+			}
+		}
+		check([]string{"avs"}, "0xAVS_ADDR")
+		check([]string{"operatorSet"}, "0")
+		check([]string{"ecdsa_keystore_path"}, "keystores/operator1.ecdsa.keystore.json")
+		check([]string{"ecdsa_keystore_password"}, "pass1")
+		check([]string{"bls_keystore_path"}, "keystores/operator1.bls.keystore.json")
+		check([]string{"bls_keystore_password"}, "bpass1")
+
+		// entry 2: operatorSet 1, suffix .2
+		ks1 := ks.Content[1]
+		check2 := func(path []string, want string) {
+			n := migration.ResolveNode(ks1, path)
+			if n == nil || n.Value != want {
+				t.Errorf("expected %v == %q, got %v", path, want, n)
+			}
+		}
+		check2([]string{"avs"}, "0xAVS_ADDR")
+		check2([]string{"operatorSet"}, "1")
+		check2([]string{"ecdsa_keystore_path"}, "keystores/operator1.ecdsa.keystore.json")
+		check2([]string{"ecdsa_keystore_password"}, "pass1")
+		check2([]string{"bls_keystore_path"}, "keystores/operator1.bls.keystore.json")
+		check2([]string{"bls_keystore_password"}, "bpass1")
+	})
+
+	t.Run("operator 2 keystores created", func(t *testing.T) {
+		op := migration.ResolveNode(migrated, []string{"context", "operators", "1"})
+		if op == nil {
+			t.Fatal("operator[1] missing")
+		}
+		if got := migration.ResolveNode(op, []string{"address"}); got == nil || got.Value != "0xOP2" {
+			t.Errorf("address not preserved, got %v", got)
+		}
+
+		ks := migration.ResolveNode(op, []string{"keystores"})
+		if ks == nil || ks.Kind != 2 || len(ks.Content) != 2 {
+			t.Fatalf("expected keystores sequence with 2 entries, got %#v", ks)
+		}
+
+		ks0 := migration.ResolveNode(ks, []string{"0"})
+		ks1 := migration.ResolveNode(ks, []string{"1"})
+
+		if n := migration.ResolveNode(ks0, []string{"operatorSet"}); n == nil || n.Value != "0" {
+			t.Errorf("operatorSet[0] expected 0, got %v", n)
+		}
+		if n := migration.ResolveNode(ks1, []string{"operatorSet"}); n == nil || n.Value != "1" {
+			t.Errorf("operatorSet[1] expected 1, got %v", n)
+		}
+
+		// verify suffixing on operator2
+		if n := migration.ResolveNode(ks0, []string{"ecdsa_keystore_path"}); n == nil || n.Value != "keystores/operator2.ecdsa.keystore.json" {
+			t.Errorf("unexpected ecdsa path[0]: %v", n)
+		}
+		if n := migration.ResolveNode(ks1, []string{"ecdsa_keystore_path"}); n == nil || n.Value != "keystores/operator2.ecdsa.keystore.json" {
+			t.Errorf("unexpected ecdsa path[1]: %v", n)
+		}
+		if n := migration.ResolveNode(ks0, []string{"bls_keystore_path"}); n == nil || n.Value != "keystores/operator2.bls.keystore.json" {
+			t.Errorf("unexpected bls path[0]: %v", n)
+		}
+		if n := migration.ResolveNode(ks1, []string{"bls_keystore_path"}); n == nil || n.Value != "keystores/operator2.bls.keystore.json" {
+			t.Errorf("unexpected bls path[1]: %v", n)
+		}
+	})
+
+	t.Run("allocations and context name preserved", func(t *testing.T) {
+		name := migration.ResolveNode(migrated, []string{"context", "name"})
+		if name == nil || name.Value != "custom-context" {
+			t.Errorf("context name not preserved, got %v", name)
+		}
+		allocs := migration.ResolveNode(migrated, []string{"context", "allocations"})
+		if allocs == nil || allocs.Kind != 2 || len(allocs.Content) != 1 {
+			t.Errorf("allocations mutated, got %#v", allocs)
+		}
+	})
+}
+
 // TestAVSContextMigration_FullChain tests migrating through the entire chain from 0.0.1 to 0.0.8
 func TestAVSContextMigration_FullChain(t *testing.T) {
 	// Use the embedded v0.0.1 content as our starting point

--- a/test/integration/migration/avs_context_migration_test.go
+++ b/test/integration/migration/avs_context_migration_test.go
@@ -1077,16 +1077,16 @@ context:
         block: "22222222"
   eigenlayer:
     l1:
-      cross_chain_registry: "0xOLD_L1_CCR"
-      operator_table_updater: "0xOLD_L1_OTU"
-      key_registrar: "0xOLD_L1_KR"
-      bn254_table_calculator: "0xOLD_L1_BN254_TC"
-      ecdsa_table_calculator: "0xOLD_L1_ECDSA_TC"
+      cross_chain_registry: "0xOLD_L1_C_C_R"
+      operator_table_updater: "0xOLD_L1_O_T_U"
+      key_registrar: "0xOLD_L1_K_R"
+      bn254_table_calculator: "0xOLD_L1_BN254_T_C"
+      ecdsa_table_calculator: "0xOLD_L1_ECDSA_T_C"
     l2:
-      task_mailbox: "0xOLD_L2_TM"
-      operator_table_updater: "0xOLD_L2_OTU"
-      bn254_certificate_verifier: "0xOLD_L2_BN254_CV"
-      ecdsa_certificate_verifier: "0xOLD_L2_ECDSA_CV"
+      task_mailbox: "0xOLD_L2_T_M"
+      operator_table_updater: "0xOLD_L2_O_T_U"
+      bn254_certificate_verifier: "0xOLD_L2_BN254_C_V"
+      ecdsa_certificate_verifier: "0xOLD_L2_ECDSA_C_V"
   avs:
     address: "0xAVS"
 `
@@ -1134,46 +1134,46 @@ context:
 	})
 
 	t.Run("L1 addresses updated", func(t *testing.T) {
-		CCR := migration.ResolveNode(out, []string{"context", "eigenlayer", "l1", "cross_chain_registry"})
-		OTU := migration.ResolveNode(out, []string{"context", "eigenlayer", "l1", "operator_table_updater"})
-		KR := migration.ResolveNode(out, []string{"context", "eigenlayer", "l1", "key_registrar"})
-		BN := migration.ResolveNode(out, []string{"context", "eigenlayer", "l1", "bn254_table_calculator"})
-		EC := migration.ResolveNode(out, []string{"context", "eigenlayer", "l1", "ecdsa_table_calculator"})
+		C_C_R := migration.ResolveNode(out, []string{"context", "eigenlayer", "l1", "cross_chain_registry"})
+		O_T_U := migration.ResolveNode(out, []string{"context", "eigenlayer", "l1", "operator_table_updater"})
+		K_R := migration.ResolveNode(out, []string{"context", "eigenlayer", "l1", "key_registrar"})
+		B_N := migration.ResolveNode(out, []string{"context", "eigenlayer", "l1", "bn254_table_calculator"})
+		E_C := migration.ResolveNode(out, []string{"context", "eigenlayer", "l1", "ecdsa_table_calculator"})
 
-		if CCR == nil || CCR.Value != "0x287381B1570d9048c4B4C7EC94d21dDb8Aa1352a" {
-			t.Errorf("l1.cross_chain_registry updated wrong, got %v", CCR)
+		if C_C_R == nil || C_C_R.Value != "0x287381B1570d9048c4B4C7EC94d21dDb8Aa1352a" {
+			t.Errorf("l1.cross_chain_registry updated wrong, got %v", C_C_R)
 		}
-		if OTU == nil || OTU.Value != "0xB02A15c6Bd0882b35e9936A9579f35FB26E11476" {
-			t.Errorf("l1.operator_table_updater updated wrong, got %v", OTU)
+		if O_T_U == nil || O_T_U.Value != "0xB02A15c6Bd0882b35e9936A9579f35FB26E11476" {
+			t.Errorf("l1.operator_table_updater updated wrong, got %v", O_T_U)
 		}
-		if KR == nil || KR.Value != "0xA4dB30D08d8bbcA00D40600bee9F029984dB162a" {
-			t.Errorf("l1.key_registrar updated wrong, got %v", KR)
+		if K_R == nil || K_R.Value != "0xA4dB30D08d8bbcA00D40600bee9F029984dB162a" {
+			t.Errorf("l1.key_registrar updated wrong, got %v", K_R)
 		}
-		if BN == nil || BN.Value != "0xa19E3B00cf4aC46B5e6dc0Bbb0Fb0c86D0D65603" {
-			t.Errorf("l1.bn254_table_calculator updated wrong, got %v", BN)
+		if B_N == nil || B_N.Value != "0xa19E3B00cf4aC46B5e6dc0Bbb0Fb0c86D0D65603" {
+			t.Errorf("l1.bn254_table_calculator updated wrong, got %v", B_N)
 		}
-		if EC == nil || EC.Value != "0xaCB5DE6aa94a1908E6FA577C2ade65065333B450" {
-			t.Errorf("l1.ecdsa_table_calculator updated wrong, got %v", EC)
+		if E_C == nil || E_C.Value != "0xaCB5DE6aa94a1908E6FA577C2ade65065333B450" {
+			t.Errorf("l1.ecdsa_table_calculator updated wrong, got %v", E_C)
 		}
 	})
 
 	t.Run("L2 addresses updated", func(t *testing.T) {
-		TM := migration.ResolveNode(out, []string{"context", "eigenlayer", "l2", "task_mailbox"})
-		OTU := migration.ResolveNode(out, []string{"context", "eigenlayer", "l2", "operator_table_updater"})
-		BN := migration.ResolveNode(out, []string{"context", "eigenlayer", "l2", "bn254_certificate_verifier"})
-		EC := migration.ResolveNode(out, []string{"context", "eigenlayer", "l2", "ecdsa_certificate_verifier"})
+		T_M := migration.ResolveNode(out, []string{"context", "eigenlayer", "l2", "task_mailbox"})
+		O_T_U := migration.ResolveNode(out, []string{"context", "eigenlayer", "l2", "operator_table_updater"})
+		B_N := migration.ResolveNode(out, []string{"context", "eigenlayer", "l2", "bn254_certificate_verifier"})
+		E_C := migration.ResolveNode(out, []string{"context", "eigenlayer", "l2", "ecdsa_certificate_verifier"})
 
-		if TM == nil || TM.Value != "0xB99CC53e8db7018f557606C2a5B066527bF96b26" {
-			t.Errorf("l2.task_mailbox updated wrong, got %v", TM)
+		if T_M == nil || T_M.Value != "0xB99CC53e8db7018f557606C2a5B066527bF96b26" {
+			t.Errorf("l2.task_mailbox updated wrong, got %v", T_M)
 		}
-		if OTU == nil || OTU.Value != "0xB02A15c6Bd0882b35e9936A9579f35FB26E11476" {
-			t.Errorf("l2.operator_table_updater updated wrong, got %v", OTU)
+		if O_T_U == nil || O_T_U.Value != "0xB02A15c6Bd0882b35e9936A9579f35FB26E11476" {
+			t.Errorf("l2.operator_table_updater updated wrong, got %v", O_T_U)
 		}
-		if BN == nil || BN.Value != "0xff58A373c18268F483C1F5cA03Cf885c0C43373a" {
-			t.Errorf("l2.bn254_certificate_verifier updated wrong, got %v", BN)
+		if B_N == nil || B_N.Value != "0xff58A373c18268F483C1F5cA03Cf885c0C43373a" {
+			t.Errorf("l2.bn254_certificate_verifier updated wrong, got %v", B_N)
 		}
-		if EC == nil || EC.Value != "0xb3Cd1A457dEa9A9A6F6406c6419B1c326670A96F" {
-			t.Errorf("l2.ecdsa_certificate_verifier updated wrong, got %v", EC)
+		if E_C == nil || E_C.Value != "0xb3Cd1A457dEa9A9A6F6406c6419B1c326670A96F" {
+			t.Errorf("l2.ecdsa_certificate_verifier updated wrong, got %v", E_C)
 		}
 	})
 


### PR DESCRIPTION
<!-- 
    🚨 ATTENTION! 🚨 
    
    This PR template is REQUIRED. PRs not following this format will be closed without review.
    
    Requirements:
    - PR title must follow commit conventions: https://www.conventionalcommits.org/en/v1.0.0/
    - Label your PR with the correct type (e.g., 🐛 Bug, ✨ Enhancement, 🧪 Test, etc.)
    - Provide clear and specific details in each section
-->

**Motivation:**
<!--
Explain here the context, and why you're making that change. What is the problem you're trying to solve.
-->
As a user of Devkit, I need to be able to define multiple keys for my Operators so that I can assign the same operator to multiple operatorSets.

**Modifications:**
<!--
Describe the modifications you've done from a high level. What are the key technical decisions and why were they made?
-->
- Adds a `keystores` entry to the `operators` to list out all available keys
- Adds a migration to move us to context version `v0.1.0`
- Removes remnant `skip-setup` context entry
- Adds tests for `v0.0.9` and `v0.1.0` context migrations

**Result:**
<!--
*After your change, what will change.
-->
- Users can assign multiple keys to their operators for different operatorSets

**Testing:**
<!--
*List testing procedures taken and useful artifacts.
-->
- Migration tests have been added and other tests updated

**Open questions:**
<!--
(optional) Any open questions or feedback on design desired?
-->
- depends on: https://github.com/Layr-Labs/hourglass-avs-template/pull/96