### PR TITLE
fix: add missing migration details

### DIFF
--- a/config/contexts/migrations/v0.0.9-v0.1.0.go
+++ b/config/contexts/migrations/v0.0.9-v0.1.0.go
@@ -26,6 +26,7 @@ func Migration_0_0_9_to_0_1_0(user, old, new *yaml.Node) (*yaml.Node, error) {
 			{
 				Path:      []string{"context", "operators"},
 				Condition: migration.Always{},
+				Base:      migration.BaseUser,
 				Transform: func(_ *yaml.Node) *yaml.Node {
 					avsNode := migration.ResolveNode(user, []string{"context", "avs", "address"})
 					avsAddr := ""
@@ -119,6 +120,7 @@ func Migration_0_0_9_to_0_1_0(user, old, new *yaml.Node) (*yaml.Node, error) {
 			{
 				Path:      []string{"context", "stakers"},
 				Condition: migration.Exists{},
+				Base:      migration.BaseUser,
 				Transform: func(node *yaml.Node) *yaml.Node {
 					// node is a seq of stakers
 					for _, staker := range node.Content {
@@ -145,6 +147,7 @@ func Migration_0_0_9_to_0_1_0(user, old, new *yaml.Node) (*yaml.Node, error) {
 			{
 				Path:      []string{"context", "operators"},
 				Condition: migration.Exists{},
+				Base:      migration.BaseUser,
 				Transform: func(node *yaml.Node) *yaml.Node {
 					// node is a seq of operators
 					for _, op := range node.Content {

--- a/config/contexts/migrations/v0.0.9-v0.1.0.go
+++ b/config/contexts/migrations/v0.0.9-v0.1.0.go
@@ -2,6 +2,7 @@ package contextMigrations
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/Layr-Labs/devkit-cli/pkg/migration"
 
@@ -9,6 +10,13 @@ import (
 )
 
 func Migration_0_0_9_to_0_1_0(user, old, new *yaml.Node) (*yaml.Node, error) {
+	// Add missing strategy upgrade to move stETH from holesky to sepolia
+	const (
+		oldStrat = "0x7D704507b76571a51d9caE8AdDAbBFd0ba0e63d3"
+		newStrat = "0x8b29d91e67b013e855EaFe0ad704aC4Ab086a574"
+	)
+
+	// Patch all changes in context
 	engine := migration.PatchEngine{
 		Old:  old,
 		New:  new,
@@ -105,6 +113,58 @@ func Migration_0_0_9_to_0_1_0(user, old, new *yaml.Node) (*yaml.Node, error) {
 						)
 					}
 					return out
+				},
+			},
+			// Rewrite strategy_address in stakers[].deposits[]
+			{
+				Path:      []string{"context", "stakers"},
+				Condition: migration.Exists{},
+				Transform: func(node *yaml.Node) *yaml.Node {
+					// node is a seq of stakers
+					for _, staker := range node.Content {
+						if staker.Kind != yaml.MappingNode {
+							continue
+						}
+						deposits := migration.ResolveNode(staker, []string{"deposits"})
+						if deposits == nil || deposits.Kind != yaml.SequenceNode {
+							continue
+						}
+						for _, dep := range deposits.Content {
+							if dep.Kind != yaml.MappingNode {
+								continue
+							}
+							if sa := migration.ResolveNode(dep, []string{"strategy_address"}); sa != nil && strings.EqualFold(sa.Value, oldStrat) {
+								sa.Value = newStrat
+							}
+						}
+					}
+					return node
+				},
+			},
+			// Rewrite strategy_address in operators[].allocations[]
+			{
+				Path:      []string{"context", "operators"},
+				Condition: migration.Exists{},
+				Transform: func(node *yaml.Node) *yaml.Node {
+					// node is a seq of operators
+					for _, op := range node.Content {
+						if op.Kind != yaml.MappingNode {
+							continue
+						}
+						allocs := migration.ResolveNode(op, []string{"allocations"})
+						if allocs == nil || allocs.Kind != yaml.SequenceNode {
+							continue
+						}
+						for _, alloc := range allocs.Content {
+							if alloc.Kind != yaml.MappingNode {
+								continue
+							}
+							if sa := migration.ResolveNode(alloc, []string{"strategy_address"}); sa != nil && strings.EqualFold(sa.Value, oldStrat) {
+								sa.Value = newStrat
+							}
+						}
+					}
+					return node
 				},
 			},
 		},

--- a/pkg/migration/migrator.go
+++ b/pkg/migration/migrator.go
@@ -20,10 +20,14 @@ type PatchCondition interface {
 
 // Available conditions
 type Always struct{}
+type Exists struct{}
 type IfUnchanged struct{}
 
 // Always applies unconditionally
 func (Always) ShouldApply(_, _ *yaml.Node) bool { return true }
+
+// Exists applies only if the userNode is present
+func (Exists) ShouldApply(userNode, _ *yaml.Node) bool { return userNode != nil }
 
 // IfUnchanged applies only if userNode equals oldNode
 func (IfUnchanged) ShouldApply(userNode, oldNode *yaml.Node) bool {

--- a/pkg/migration/migrator.go
+++ b/pkg/migration/migrator.go
@@ -36,6 +36,17 @@ func (IfUnchanged) ShouldApply(userNode, oldNode *yaml.Node) bool {
 	return bytes.Equal(ub, ob)
 }
 
+// Which node to use as the starting point for a replacement
+type Base int
+
+// Enum for available Base options
+const (
+	BaseAuto Base = iota // default when omitted
+	BaseNew
+	BaseUser
+	BaseOld
+)
+
 // PatchRule defines a YAML node patch rule
 type PatchRule struct {
 	// Path: sequence of map keys or sequence indices (as strings)
@@ -46,6 +57,8 @@ type PatchRule struct {
 	Transform func(newNode *yaml.Node) *yaml.Node
 	// Remove: if true, delete the node instead of patching
 	Remove bool
+	// Which node to base the patch on
+	Base Base
 }
 
 // MigrationStep represents one version-to-version migration
@@ -78,18 +91,41 @@ func (e *PatchEngine) Apply() error {
 		oldNode := ResolveNode(e.Old, rule.Path)
 		newNode := ResolveNode(e.New, rule.Path)
 
-		// insert new node if missing
+		// chose the base node to use for patch operation
+		choose := func(exists bool) *yaml.Node {
+			switch rule.Base {
+			case BaseNew:
+				return newNode
+			case BaseUser:
+				return userNode
+			case BaseOld:
+				return oldNode
+			default:
+				if !exists {
+					// insert uses New by default
+					return newNode
+				}
+				if rule.Transform == nil {
+					// legacy behavior picks newNode
+					return newNode
+				}
+				// transforms default to User
+				return userNode
+			}
+		}
+
 		if userNode == nil {
 			parent, _ := findParent(e.User, rule.Path)
 			if parent == nil {
 				continue
 			}
-			repl := ResolveNode(e.New, rule.Path)
-			if repl == nil {
+			base := choose(false)
+			if base == nil {
 				continue
 			}
+			repl := CloneNode(base)
 			if rule.Transform != nil {
-				repl = rule.Transform(CloneNode(repl))
+				repl = rule.Transform(repl)
 			}
 			insertNode(parent, len(parent.Content), rule.Path[len(rule.Path)-1], CloneNode(repl))
 			continue
@@ -106,9 +142,13 @@ func (e *PatchEngine) Apply() error {
 				continue
 			}
 			// choose replacement
-			repl := newNode
+			base := choose(true)
+			if base == nil {
+				base = userNode
+			}
+			repl := CloneNode(base)
 			if rule.Transform != nil {
-				repl = rule.Transform(CloneNode(newNode))
+				repl = rule.Transform(repl)
 			}
 			// overwrite in place
 			*userNode = *CloneNode(repl)


### PR DESCRIPTION
<!-- 
    🚨 ATTENTION! 🚨 
    
    This PR template is REQUIRED. PRs not following this format will be closed without review.
    
    Requirements:
    - PR title must follow commit conventions: https://www.conventionalcommits.org/en/v1.0.0/
    - Label your PR with the correct type (e.g., 🐛 Bug, ✨ Enhancement, 🧪 Test, etc.)
    - Provide clear and specific details in each section
-->

**Motivation:**
<!--
Explain here the context, and why you're making that change. What is the problem you're trying to solve.
-->
As a devkit user, I want all required context changes to be applied for me when I migrate my context so that I do not have to manually change anything.

**Modifications:**
<!--
Describe the modifications you've done from a high level. What are the key technical decisions and why were they made?
-->
- Adds missing updates to `v0.1.0` context migration (holesky -> sepolia stETH address)

**Result:**
<!--
*After your change, what will change.
-->
- All context details are correct for sepolia deployment

**Testing:**
<!--
*List testing procedures taken and useful artifacts.
-->
- Tested against `hotdog-havoc`
- Added unit tests for new patch stages
