### PR TITLE
fix: export chainInfo into outputs artifacts

### DIFF
--- a/pkg/common/yaml.go
+++ b/pkg/common/yaml.go
@@ -163,17 +163,50 @@ func CleanYAML(v interface{}) interface{} {
 }
 
 // GetChildByKey returns the value node associated with the given key from a MappingNode
-func GetChildByKey(node *yaml.Node, key string) *yaml.Node {
-	if node == nil || node.Kind != yaml.MappingNode {
+func GetChildByKey(n *yaml.Node, path string) *yaml.Node {
+	if n == nil {
 		return nil
 	}
-	for i := 0; i < len(node.Content); i += 2 {
-		k := node.Content[i]
-		if k.Value == key {
-			return node.Content[i+1]
+	cur := n
+	for _, seg := range strings.Split(path, ".") {
+		// map lookup part before any index
+		key, idx := seg, -1
+		if i := strings.Index(seg, "["); i >= 0 {
+			key = seg[:i]
+			j := strings.Index(seg[i:], "]")
+			if j <= 1 {
+				return nil
+			}
+			v, err := strconv.Atoi(seg[i+1 : i+j])
+			if err != nil {
+				return nil
+			}
+			idx = v
+		}
+		if key != "" {
+			if cur.Kind != yaml.MappingNode {
+				return nil
+			}
+			found := false
+			for i := 0; i+1 < len(cur.Content); i += 2 {
+				if cur.Content[i].Value == key {
+					cur = cur.Content[i+1]
+					found = true
+					break
+				}
+			}
+			if !found {
+				return nil
+			}
+		}
+		if idx >= 0 {
+			if cur.Kind != yaml.SequenceNode || idx < 0 || idx >= len(cur.Content) {
+				return nil
+			}
+			cur = cur.Content[idx]
 		}
 	}
-	return nil
+	return cur
 }
 
 // CloneNode performs a deep copy of a *yaml.Node, including its content and comments

--- a/pkg/common/yaml.go
+++ b/pkg/common/yaml.go
@@ -163,34 +163,34 @@ func CleanYAML(v interface{}) interface{} {
 }
 
 // GetChildByKey returns the value node associated with the given key from a MappingNode
-func GetChildByKey(n *yaml.Node, path string) *yaml.Node {
-	if n == nil {
+func GetChildByKey(node *yaml.Node, path string) *yaml.Node {
+	if node == nil {
 		return nil
 	}
-	cur := n
+	currNode := node
 	for _, seg := range strings.Split(path, ".") {
 		// map lookup part before any index
-		key, idx := seg, -1
-		if i := strings.Index(seg, "["); i >= 0 {
-			key = seg[:i]
-			j := strings.Index(seg[i:], "]")
-			if j <= 1 {
+		key, segIdx := seg, -1
+		if idx := strings.Index(seg, "["); idx >= 0 {
+			key = seg[:idx]
+			closeIdxOffset := strings.Index(seg[idx:], "]")
+			if closeIdxOffset <= 1 {
 				return nil
 			}
-			v, err := strconv.Atoi(seg[i+1 : i+j])
+			idxVal, err := strconv.Atoi(seg[idx+1 : idx+closeIdxOffset])
 			if err != nil {
 				return nil
 			}
-			idx = v
+			segIdx = idxVal
 		}
 		if key != "" {
-			if cur.Kind != yaml.MappingNode {
+			if currNode.Kind != yaml.MappingNode {
 				return nil
 			}
 			found := false
-			for i := 0; i+1 < len(cur.Content); i += 2 {
-				if cur.Content[i].Value == key {
-					cur = cur.Content[i+1]
+			for idx := 0; idx+1 < len(currNode.Content); idx += 2 {
+				if currNode.Content[idx].Value == key {
+					currNode = currNode.Content[idx+1]
 					found = true
 					break
 				}
@@ -199,14 +199,14 @@ func GetChildByKey(n *yaml.Node, path string) *yaml.Node {
 				return nil
 			}
 		}
-		if idx >= 0 {
-			if cur.Kind != yaml.SequenceNode || idx < 0 || idx >= len(cur.Content) {
+		if segIdx >= 0 {
+			if currNode.Kind != yaml.SequenceNode || segIdx < 0 || segIdx >= len(currNode.Content) {
 				return nil
 			}
-			cur = cur.Content[idx]
+			currNode = currNode.Content[segIdx]
 		}
 	}
-	return cur
+	return currNode
 }
 
 // CloneNode performs a deep copy of a *yaml.Node, including its content and comments


### PR DESCRIPTION
<!-- 
    🚨 ATTENTION! 🚨 
    
    This PR template is REQUIRED. PRs not following this format will be closed without review.
    
    Requirements:
    - PR title must follow commit conventions: https://www.conventionalcommits.org/en/v1.0.0/
    - Label your PR with the correct type (e.g., 🐛 Bug, ✨ Enhancement, 🧪 Test, etc.)
    - Provide clear and specific details in each section
-->

**Motivation:**
<!--
Explain here the context, and why you're making that change. What is the problem you're trying to solve.
-->
As a devkit developer, I want consolidated outputs containing all information I would need to import into my app space, so that I do not need to pull details from multiple sources.

**Modifications:**
<!--
Describe the modifications you've done from a high level. What are the key technical decisions and why were they made?
-->
- Exports `chainInfo` into L1/L2 deployment outputs

**Result:**
<!--
*After your change, what will change.
-->
- Able to import contracts address, abi and chainId from a single output

**Testing:**
<!--
*List testing procedures taken and useful artifacts.
-->
- Tested against `hotdog-havoc`
