### PR TITLE
feat: add rust option for TEE template

### DIFF
--- a/config/templates.yaml
+++ b/config/templates.yaml
@@ -12,6 +12,12 @@ architectures:
         version: ""
   tee:
     languages:
+      rs:
+        baseUrl: "https://github.com/Layr-Labs/tee-avs-template"
+        version: "rust-app"
+      rust:
+        baseUrl: "https://github.com/Layr-Labs/tee-avs-template"
+        version: "rust-app"
       ts:
         baseUrl: "https://github.com/Layr-Labs/tee-avs-template"
         version: "master"


### PR DESCRIPTION
This PR updates TEE template creation config to point to [tee-avs-template/rust-app](https://github.com/Layr-Labs/tee-avs-template/tree/rust-app)