### PR TITLE
fix: load templateBaseUrl from config correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,7 +423,7 @@ This step is optional. The devkit `devkit avs devnet start` command already star
 devkit avs run
 ```
 
-### Deploy AVS Contracts (`devkit avs deploy-contract`)
+### Deploy AVS Contracts (`devkit avs devnet deploy-contracts`)
 
 Deploy your AVS's onchain contracts independently of the full devnet setup.
 
@@ -432,7 +432,7 @@ This step is **optional**. The `devkit avs devnet start` command already handles
 > Note: Testnet support is not yet implemented, but this command is structured to support such workflows in the future.
 
 ```bash
-devkit avs deploy-contract
+devkit avs devnet deploy-contracts
 ```
 
 ### Create Operator Keys (`devkit avs keystore`)

--- a/pkg/commands/template/template.go
+++ b/pkg/commands/template/template.go
@@ -41,7 +41,7 @@ func GetTemplateInfo() (string, string, string, string, error) {
 	if config, ok := configMap["config"].(map[string]interface{}); ok {
 		if project, ok := config["project"].(map[string]interface{}); ok {
 			projectName, _ = project["name"].(string)
-			templateBaseURL, _ = project["templateURL"].(string)
+			templateBaseURL, _ = project["templateBaseUrl"].(string)
 			templateVersion = getStringOrDefault(project, "templateVersion", templateVersion)
 			templateLanguage = getStringOrDefault(project, "templateLanguage", templateLanguage)
 		}
@@ -68,7 +68,7 @@ func GetTemplateInfoDefault() (string, string, string, string, error) {
 	// Default values
 	projectName := ""
 	templateBaseURL := ""
-	templateVersion := "https://github.com/Layr-Labs/hourglass-avs-template"
+	templateVersion := ""
 	templateLanguage := "go"
 
 	// Try to load templates configuration


### PR DESCRIPTION
<!-- 
    🚨 ATTENTION! 🚨 
    
    This PR template is REQUIRED. PRs not following this format will be closed without review.
    
    Requirements:
    - PR title must follow commit conventions: https://www.conventionalcommits.org/en/v1.0.0/
    - Label your PR with the correct type (e.g., 🐛 Bug, ✨ Enhancement, 🧪 Test, etc.)
    - Provide clear and specific details in each section
-->

**Motivation:**
<!--
Explain here the context, and why you're making that change. What is the problem you're trying to solve.
-->
As a devkit user, I want to be able to upgrade from a custom `templateBaseUrl` without flagging it on each upgrade.

**Modifications:**
<!--
Describe the modifications you've done from a high level. What are the key technical decisions and why were they made?
-->
- Ensures we're using the correct `templateBaseUrl` from config in the upgrade command.

**Result:**
<!--
*After your change, what will change.
-->
- Upgrades using the correct template url
