### PR TITLE
fix: set PermissionController in context

### DIFF
--- a/config/contexts/migrations/v0.0.9-v0.1.0.go
+++ b/config/contexts/migrations/v0.0.9-v0.1.0.go
@@ -170,6 +170,15 @@ func Migration_0_0_9_to_0_1_0(user, old, new *yaml.Node) (*yaml.Node, error) {
 					return node
 				},
 			},
+			// Update L1 PermissionController address
+			{
+				Path:      []string{"context", "eigenlayer", "l1", "permission_controller"},
+				Condition: migration.Always{},
+				Base:      migration.BaseUser,
+				Transform: func(_ *yaml.Node) *yaml.Node {
+					return &yaml.Node{Kind: yaml.ScalarNode, Value: "0x44632dfBdCb6D3E21EF613B0ca8A6A0c618F5a37"}
+				},
+			},
 		},
 	}
 

--- a/config/contexts/v0.1.0.yaml
+++ b/config/contexts/v0.1.0.yaml
@@ -161,6 +161,7 @@ context:
       release_manager: "0xd9Cb89F1993292dEC2F973934bC63B0f2A702776"
       operator_table_updater: "0xB02A15c6Bd0882b35e9936A9579f35FB26E11476"
       task_mailbox: "0xB99CC53e8db7018f557606C2a5B066527bF96b26"
+      permission_controller: "0x44632dfBdCb6D3E21EF613B0ca8A6A0c618F5a37"
     l2:
       bn254_certificate_verifier: "0xff58A373c18268F483C1F5cA03Cf885c0C43373a"
       operator_table_updater: "0xB02A15c6Bd0882b35e9936A9579f35FB26E11476"

--- a/config/templates.yaml
+++ b/config/templates.yaml
@@ -1,7 +1,7 @@
 framework:
   hourglass:
     template: "https://github.com/Layr-Labs/hourglass-avs-template"
-    version: "v0.0.19"
+    version: "v0.0.20"
     languages:
       - go
       - ts

--- a/pkg/common/config.go
+++ b/pkg/common/config.go
@@ -104,6 +104,7 @@ type EigenLayerL1Config struct {
 	ReleaseManager       string `json:"release_manager" yaml:"release_manager"`
 	OperatorTableUpdater string `json:"operator_table_updater" yaml:"operator_table_updater"`
 	TaskMailbox          string `json:"task_mailbox" yaml:"task_mailbox"`
+	PermissionController string `json:"permission_controller" yaml:"permission_controller"`
 }
 
 type EigenLayerL2Config struct {

--- a/pkg/common/zeus.go
+++ b/pkg/common/zeus.go
@@ -20,6 +20,7 @@ type L1ZeusAddressData struct {
 	ReleaseManager       string `json:"releaseManager"`
 	OperatorTableUpdater string `json:"operatorTableUpdater"`
 	TaskMailbox          string `json:"taskMailbox"`
+	PermissionController string `json:"permissionController"`
 }
 
 type L2ZeusAddressData struct {
@@ -116,6 +117,13 @@ func GetZeusAddresses(ctx context.Context, logger iface.Logger) (*L1ZeusAddressD
 	if val, ok := l1ZeusData["ZEUS_DEPLOYED_TaskMailbox_Proxy"]; ok {
 		if strVal, ok := val.(string); ok {
 			l1Addresses.TaskMailbox = strVal
+		}
+	}
+
+	// Get PermissionController address
+	if val, ok := l1ZeusData["ZEUS_DEPLOYED_PermissionController_Proxy"]; ok {
+		if strVal, ok := val.(string); ok {
+			l1Addresses.PermissionController = strVal
 		}
 	}
 
@@ -230,6 +238,8 @@ func UpdateContextWithZeusAddresses(context context.Context, logger iface.Logger
 	operatorTableUpdaterVal := &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: l1Addresses.OperatorTableUpdater}
 	taskMailboxKey := &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "task_mailbox"}
 	taskMailboxVal := &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: l1Addresses.TaskMailbox}
+	permissionControllerKey := &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "permission_controller"}
+	permissionControllerVal := &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: l1Addresses.PermissionController}
 
 	// Replace existing or append new entries in l1 section
 	SetMappingValue(l1Map, allocationManagerKey, allocationManagerVal)
@@ -240,6 +250,7 @@ func UpdateContextWithZeusAddresses(context context.Context, logger iface.Logger
 	SetMappingValue(l1Map, releaseManagerKey, releaseManagerVal)
 	SetMappingValue(l1Map, operatorTableUpdaterKey, operatorTableUpdaterVal)
 	SetMappingValue(l1Map, taskMailboxKey, taskMailboxVal)
+	SetMappingValue(l1Map, permissionControllerKey, permissionControllerVal)
 
 	// Find or create "l2" mapping entry under eigenlayer
 	l2Map := GetChildByKey(parentMap, "l2")

--- a/pkg/template/config_test.go
+++ b/pkg/template/config_test.go
@@ -17,7 +17,7 @@ func TestLoadConfig(t *testing.T) {
 	}
 
 	expectedBaseURL := "https://github.com/Layr-Labs/hourglass-avs-template"
-	expectedVersion := "v0.0.19"
+	expectedVersion := "v0.0.20"
 
 	if mainBaseURL != expectedBaseURL {
 		t.Errorf("Unexpected main template base URL: got %s, want %s", mainBaseURL, expectedBaseURL)


### PR DESCRIPTION
<!-- 
    🚨 ATTENTION! 🚨 
    
    This PR template is REQUIRED. PRs not following this format will be closed without review.
    
    Requirements:
    - PR title must follow commit conventions: https://www.conventionalcommits.org/en/v1.0.0/
    - Label your PR with the correct type (e.g., 🐛 Bug, ✨ Enhancement, 🧪 Test, etc.)
    - Provide clear and specific details in each section
-->

**Motivation:**
<!--
Explain here the context, and why you're making that change. What is the problem you're trying to solve.
-->
As a devkit user, I need to have the  L1 `permissionController` address defined in my context so that I can correctly deploy a `TaskAVSRegistrar` contract

**Modifications:**
<!--
Describe the modifications you've done from a high level. What are the key technical decisions and why were they made?
-->
- defines `permissionController` in context
- pulls `permissionController` from zeus to get correct address for current context

**Result:**
<!--
*After your change, what will change.
-->
- correctly deploys L1 contracts
