### PR TITLE
feat: set context_name in posthog metrics

### DIFF
--- a/pkg/hooks/hooks.go
+++ b/pkg/hooks/hooks.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/Layr-Labs/devkit-cli/pkg/common"
+	"github.com/Layr-Labs/devkit-cli/pkg/common/devnet"
 	"github.com/Layr-Labs/devkit-cli/pkg/common/logger"
 	"github.com/Layr-Labs/devkit-cli/pkg/telemetry"
 
@@ -255,8 +256,9 @@ func WithCommandMetricsContext(ctx *cli.Context) error {
 	if contextName == "" {
 		_, contextName, err = common.LoadDefaultRawContext()
 	}
+	// If there is an error pulling the context, assume we're in devnet
 	if err != nil {
-		return fmt.Errorf("failed to load context: %w", err)
+		contextName = devnet.DEVNET_CONTEXT
 	}
 
 	// Set context_name in metrics

--- a/pkg/hooks/hooks.go
+++ b/pkg/hooks/hooks.go
@@ -247,6 +247,22 @@ func WithCommandMetricsContext(ctx *cli.Context) error {
 	metrics := telemetry.NewMetricsContext()
 	ctx.Context = telemetry.WithMetricsContext(ctx.Context, metrics)
 
+	// Check for flagged contextName
+	contextName := ctx.String("context")
+
+	// Check config for contextName
+	var err error
+	if contextName == "" {
+		_, contextName, err = common.LoadDefaultRawContext()
+	}
+	if err != nil {
+		return fmt.Errorf("failed to load context: %w", err)
+	}
+
+	// Set context_name in metrics
+	metrics.Properties["context_name"] = contextName
+
+	// Set appEnv details in metrics
 	if appEnv, ok := common.AppEnvironmentFromContext(ctx.Context); ok {
 		metrics.Properties["cli_version"] = appEnv.CLIVersion
 		metrics.Properties["os"] = appEnv.OS
@@ -255,6 +271,7 @@ func WithCommandMetricsContext(ctx *cli.Context) error {
 		metrics.Properties["user_uuid"] = appEnv.UserUUID
 	}
 
+	// Set flags in metrics
 	for k, v := range collectFlagValues(ctx) {
 		metrics.Properties[k] = fmt.Sprintf("%v", v)
 	}

--- a/pkg/hooks/hooks_test.go
+++ b/pkg/hooks/hooks_test.go
@@ -42,6 +42,7 @@ func MockWithTelemetry(action cli.ActionFunc, mockClient telemetry.Client) cli.A
 		metrics.Properties["arch"] = runtime.GOARCH
 		metrics.Properties["project_uuid"] = "test-uuid"
 		metrics.Properties["user_uuid"] = "user-uuid"
+		metrics.Properties["context_name"] = "devnet"
 
 		// Add command flags as properties
 		flags := collectFlagValues(ctx)


### PR DESCRIPTION
<!-- 
    🚨 ATTENTION! 🚨 
    
    This PR template is REQUIRED. PRs not following this format will be closed without review.
    
    Requirements:
    - PR title must follow commit conventions: https://www.conventionalcommits.org/en/v1.0.0/
    - Label your PR with the correct type (e.g., 🐛 Bug, ✨ Enhancement, 🧪 Test, etc.)
    - Provide clear and specific details in each section
-->

**Motivation:**
<!--
Explain here the context, and why you're making that change. What is the problem you're trying to solve.
-->
As a devkit maintainer, I want to see which context commands have been ran against in our telemetry dashboard

**Modifications:**
<!--
Describe the modifications you've done from a high level. What are the key technical decisions and why were they made?
-->
- Pulls `context_name` from flag or config to feed posthog metrics

**Result:**
<!--
*After your change, what will change.
-->
- Can see which context was selected for a given cmd run
