### PR TITLE
chore: bumping hourglass avs template tag to v0.0.22

### DIFF
--- a/config/templates.yaml
+++ b/config/templates.yaml
@@ -1,7 +1,7 @@
 framework:
   hourglass:
     template: "https://github.com/Layr-Labs/hourglass-avs-template"
-    version: "v0.0.20"
+    version: "v0.0.22"
     languages:
       - go
       - ts

--- a/pkg/template/config_test.go
+++ b/pkg/template/config_test.go
@@ -17,7 +17,7 @@ func TestLoadConfig(t *testing.T) {
 	}
 
 	expectedBaseURL := "https://github.com/Layr-Labs/hourglass-avs-template"
-	expectedVersion := "v0.0.20"
+	expectedVersion := "v0.0.22"
 
 	if mainBaseURL != expectedBaseURL {
 		t.Errorf("Unexpected main template base URL: got %s, want %s", mainBaseURL, expectedBaseURL)


### PR DESCRIPTION
<!-- 
    🚨 ATTENTION! 🚨 
    
    This PR template is REQUIRED. PRs not following this format will be closed without review.
    
    Requirements:
    - PR title must follow commit conventions: https://www.conventionalcommits.org/en/v1.0.0/
    - Label your PR with the correct type (e.g., 🐛 Bug, ✨ Enhancement, 🧪 Test, etc.)
    - Provide clear and specific details in each section
-->

**Motivation:**
 - Updating Devkit to use the latest release candidate of the Hourglass off-chain software.

**Modifications:**
 - template tag

**Result:**
 - Runs latest HG software during devnet operations

**Testing:**
 - Addressed all Certora & SigP On-Chain audit findings

**Open questions:**
