### PR TITLE
feat: pass config+context json to run command

### DIFF
--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -37,9 +37,9 @@ func AVSRun(cCtx *cli.Context) error {
 	var err error
 	var contextJSON []byte
 	if contextName == "" {
-		contextJSON, contextName, err = common.LoadDefaultRawContext()
+		contextJSON, contextName, err = common.LoadDefaultRawConfigWithContext()
 	} else {
-		contextJSON, contextName, err = common.LoadRawContext(contextName)
+		contextJSON, contextName, err = common.LoadRawConfigWithContext(contextName)
 	}
 	if err != nil {
 		return fmt.Errorf("failed to load context: %w", err)


### PR DESCRIPTION
<!-- 
    🚨 ATTENTION! 🚨 
    
    This PR template is REQUIRED. PRs not following this format will be closed without review.
    
    Requirements:
    - PR title must follow commit conventions: https://www.conventionalcommits.org/en/v1.0.0/
    - Label your PR with the correct type (e.g., 🐛 Bug, ✨ Enhancement, 🧪 Test, etc.)
    - Provide clear and specific details in each section
-->

**Motivation:**
<!--
Explain here the context, and why you're making that change. What is the problem you're trying to solve.
-->
As a devkit user, I need my config + context to be passed through to the run command so that my project name can be used in my executor.yaml config

**Modifications:**
<!--
Describe the modifications you've done from a high level. What are the key technical decisions and why were they made?
-->
- Adds methods to produce config+context JSON
- Alters the run command to pass both config+context as JSON to run script

**Result:**
<!--
*After your change, what will change.
-->
- Run script can use both config+context to construct hourglass configs
