### PR TITLE
fix: only update generator on initial Transporter run

### DIFF
--- a/pkg/commands/devnet_actions.go
+++ b/pkg/commands/devnet_actions.go
@@ -402,7 +402,7 @@ func StartDevnetAction(cCtx *cli.Context) error {
 	// Run Transport against schedule - exit when AVSRun exits
 	if !skipTransporter {
 		// Post initial stake roots to L1
-		if err := Transport(cCtx); err != nil && !errors.Is(err, context.Canceled) {
+		if err := Transport(cCtx, true); err != nil && !errors.Is(err, context.Canceled) {
 			return fmt.Errorf("transport run failed: %w", err)
 		}
 


### PR DESCRIPTION
<!-- 
    🚨 ATTENTION! 🚨 
    
    This PR template is REQUIRED. PRs not following this format will be closed without review.
    
    Requirements:
    - PR title must follow commit conventions: https://www.conventionalcommits.org/en/v1.0.0/
    - Label your PR with the correct type (e.g., 🐛 Bug, ✨ Enhancement, 🧪 Test, etc.)
    - Provide clear and specific details in each section
-->

**Motivation:**
<!--
Explain here the context, and why you're making that change. What is the problem you're trying to solve.
-->
As a devkit user, I want runs of the Transporter to omit updating the generator after the initial run

**Modifications:**
<!--
Describe the modifications you've done from a high level. What are the key technical decisions and why were they made?
-->
- Prevents scheduled runs of the Transport from updating the Generator state

**Result:**
<!--
*After your change, what will change.
-->
- Only takes ownership and updates Generator on initial run
