### PR TITLE
fix: default baseUrl/version if omitted

### DIFF
--- a/pkg/commands/create.go
+++ b/pkg/commands/create.go
@@ -215,21 +215,29 @@ func getTemplateURLs(cCtx *cli.Context) (string, string, string, error) {
 	version := cCtx.String("template-version")
 	lang := cCtx.String("lang")
 
-	// If no overrides provided, get from config
-	if baseURL == "" && version == "" {
+	// If overrides are omitted, get from config
+	if baseURL == "" || version == "" {
 		cfg, err := template.LoadConfig()
 		if err != nil {
 			return "", "", "", fmt.Errorf("failed to load templates cfg: %w", err)
 		}
 
 		selectedTemplate := cCtx.String("template")
-		baseURL, version, err = template.GetTemplateURLs(cfg, selectedTemplate, lang)
+		defaultBaseURL, defaultVersion, err := template.GetTemplateURLs(cfg, selectedTemplate, lang)
 		if err != nil {
 			return "", "", "", fmt.Errorf("failed to get template URLs: %w", err)
 		}
 
-		if baseURL == "" {
+		if defaultBaseURL == "" {
 			return "", "", "", fmt.Errorf("no template found for template %s and language %s", selectedTemplate, lang)
+		}
+
+		// If no baseUrl/version is provided use template defaults
+		if baseURL == "" {
+			baseURL = defaultBaseURL
+		}
+		if version == "" {
+			version = defaultVersion
 		}
 	}
 


### PR DESCRIPTION
<!-- 
    🚨 ATTENTION! 🚨 
    
    This PR template is REQUIRED. PRs not following this format will be closed without review.
    
    Requirements:
    - PR title must follow commit conventions: https://www.conventionalcommits.org/en/v1.0.0/
    - Label your PR with the correct type (e.g., 🐛 Bug, ✨ Enhancement, 🧪 Test, etc.)
    - Provide clear and specific details in each section
-->

**Motivation:**
<!--
Explain here the context, and why you're making that change. What is the problem you're trying to solve.
-->
As a devkit user, I want to be able to select a new template version without selecting a new template baseUrl

**Modifications:**
<!--
Describe the modifications you've done from a high level. What are the key technical decisions and why were they made?
-->
- Defaults `baseUrl`/`version` if either are missing

**Result:**
<!--
*After your change, what will change.
-->
- `devkit avs create --template-version="v0.0.24" ./` works as expected
