### PR TITLE
fix: use newNode for untouched prop migrations

### DIFF
--- a/config/contexts/migrations/v0.0.9-v0.1.0.go
+++ b/config/contexts/migrations/v0.0.9-v0.1.0.go
@@ -174,7 +174,6 @@ func Migration_0_0_9_to_0_1_0(user, old, new *yaml.Node) (*yaml.Node, error) {
 			{
 				Path:      []string{"context", "eigenlayer", "l1", "permission_controller"},
 				Condition: migration.Always{},
-				Base:      migration.BaseUser,
 				Transform: func(_ *yaml.Node) *yaml.Node {
 					return &yaml.Node{Kind: yaml.ScalarNode, Value: "0x44632dfBdCb6D3E21EF613B0ca8A6A0c618F5a37"}
 				},
@@ -183,7 +182,6 @@ func Migration_0_0_9_to_0_1_0(user, old, new *yaml.Node) (*yaml.Node, error) {
 			{
 				Path:      []string{"context", "chains", "l1", "fork", "block"},
 				Condition: migration.Always{},
-				Base:      migration.BaseUser,
 				Transform: func(_ *yaml.Node) *yaml.Node {
 					return &yaml.Node{Kind: yaml.ScalarNode, Value: "9085290"}
 				},
@@ -192,7 +190,6 @@ func Migration_0_0_9_to_0_1_0(user, old, new *yaml.Node) (*yaml.Node, error) {
 			{
 				Path:      []string{"context", "chains", "l2", "fork", "block"},
 				Condition: migration.Always{},
-				Base:      migration.BaseUser,
 				Transform: func(_ *yaml.Node) *yaml.Node {
 					return &yaml.Node{Kind: yaml.ScalarNode, Value: "30327360"}
 				},


### PR DESCRIPTION
<!-- 
    🚨 ATTENTION! 🚨 
    
    This PR template is REQUIRED. PRs not following this format will be closed without review.
    
    Requirements:
    - PR title must follow commit conventions: https://www.conventionalcommits.org/en/v1.0.0/
    - Label your PR with the correct type (e.g., 🐛 Bug, ✨ Enhancement, 🧪 Test, etc.)
    - Provide clear and specific details in each section
-->

**Motivation:**
<!--
Explain here the context, and why you're making that change. What is the problem you're trying to solve.
-->
As a devkit user, I need migrations to properly write all new values to my contexts

**Modifications:**
<!--
Describe the modifications you've done from a high level. What are the key technical decisions and why were they made?
-->
- Uses default `newNode` base for prop migrations that haven't been previously altered in this run

**Result:**
<!--
*After your change, what will change.
-->
- Migrations properly write new keys to updated context