### PR TITLE
chore: bump devkit version

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,16 +27,16 @@ curl -fsSL https://raw.githubusercontent.com/Layr-Labs/devkit-cli/main/install-d
 Download the binary for your platform:
 ```bash
 # macOS (Apple Silicon)
-mkdir -p $HOME/bin && curl -sL https://s3.amazonaws.com/eigenlayer-devkit-releases/v0.1.0-preview.2.rc/devkit-darwin-arm64-v0.1.0-preview.2.rc.tar.gz | tar xz -C "$HOME/bin"
+mkdir -p $HOME/bin && curl -sL https://s3.amazonaws.com/eigenlayer-devkit-releases/v0.1.0-preview.4.rc/devkit-darwin-arm64-v0.1.0-preview.4.rc.tar.gz | tar xz -C "$HOME/bin"
 
 # macOS (Intel)
-mkdir -p $HOME/bin && curl -sL https://s3.amazonaws.com/eigenlayer-devkit-releases/v0.1.0-preview.2.rc/devkit-darwin-amd64-v0.1.0-preview.2.rc.tar.gz | tar xz -C "$HOME/bin"
+mkdir -p $HOME/bin && curl -sL https://s3.amazonaws.com/eigenlayer-devkit-releases/v0.1.0-preview.4.rc/devkit-darwin-amd64-v0.1.0-preview.4.rc.tar.gz | tar xz -C "$HOME/bin"
 
 # Linux (x86_64 / AMD64)
-mkdir -p $HOME/bin && curl -sL https://s3.amazonaws.com/eigenlayer-devkit-releases/v0.1.0-preview.2.rc/devkit-linux-amd64-v0.1.0-preview.2.rc.tar.gz | tar xz -C "$HOME/bin"
+mkdir -p $HOME/bin && curl -sL https://s3.amazonaws.com/eigenlayer-devkit-releases/v0.1.0-preview.4.rc/devkit-linux-amd64-v0.1.0-preview.4.rc.tar.gz | tar xz -C "$HOME/bin"
 
 # Linux (ARM64 / aarch64)
-mkdir -p $HOME/bin && curl -sL https://s3.amazonaws.com/eigenlayer-devkit-releases/v0.1.0-preview.2.rc/devkit-linux-arm64-v0.1.0-preview.2.rc.tar.gz | tar xz -C "$HOME/bin"
+mkdir -p $HOME/bin && curl -sL https://s3.amazonaws.com/eigenlayer-devkit-releases/v0.1.0-preview.4.rc/devkit-linux-arm64-v0.1.0-preview.4.rc.tar.gz | tar xz -C "$HOME/bin"
 ```
 
 Add to your PATH:

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-v0.1.0-preview.3.rc
+v0.1.0-preview.4.rc


### PR DESCRIPTION
## Summary
`v0.1.0` elevates DevKit from local experiments to public `testnet` deployments introducing ECDSA keys for signing.

##  ⚠️ Important
- `v0.1.0` brings `testnet` deployments to `devkit` adding the following commands:
  - `devkit avs deploy contracts l1` 
  - `devkit avs deploy contracts l2`
  
- To deploy to `testnet` you must first configure a `testnet` context using:
  - `devkit avs context create testnet` 

## Breaking changes for template migration (to `v0.0.25`)

- In your projects `contracts/src/l2-contracts/AVSTaskHook.sol`, implement the following method:

```
    function handlePostTaskResultSubmission(address caller, bytes32 taskHash) external {
        //TODO: Implement
    }
```

- Upgrade go dependencies (go.mod):
```
    -- github.com/Layr-Labs/hourglass-monorepo/ponos v0.0.0-20250516160557-195c62a908e3	
    ++ github.com/Layr-Labs/hourglass-monorepo/ponos v0.0.0-20250819223025-195764c9457a

	-- github.com/Layr-Labs/protocol-apis v1.12.1
	++ github.com/Layr-Labs/protocol-apis v1.17.0
```
> then run `go mod tidy` && `devkit avs build`

## Changes

0904c13ed52a8cbc3742bec91ccdaa9677c496a5: feat: eigen runtime spec support for devkit driven by avs template by @bdchatham (https://github.com/Layr-Labs/devkit-cli/pull/235)
6a071b9c4d4c661e2ad48b77ae265c6167c36626: feat: allow any context to feed core commands by @grezle (https://github.com/Layr-Labs/devkit-cli/pull/233)
f3af4b9877600afe86decdfb1226038a66e27281: fix: arbitrary file access during archive extraction ("Zip Slip") by @grezle (https://github.com/Layr-Labs/devkit-cli/pull/239)
0894887f3c0786dd53b637240ddd1741d1984d28: feat: l1/l2 deploy commands for testnet/mainnet by @grezle (https://github.com/Layr-Labs/devkit-cli/pull/234)
33f090482e5a405efe56ba8edf991ef0948c995a: feat: restrict devnet only cmds by @grezle (https://github.com/Layr-Labs/devkit-cli/pull/238)
c514bed9b3da34ef659def6ff90cec3b54d696f6: feat: update TableCalculator addresses by @grezle (https://github.com/Layr-Labs/devkit-cli/pull/241)
962cf2ecdb15a490b4d11541f1c0262574574c10: fix: allow AVS setup to be skipped from context "flag" by @grezle (https://github.com/Layr-Labs/devkit-cli/pull/242)
51c333d023e7c3e3f3338d4bbb2031890bcf5625: fix: disable rpc rate limiting by @grezle (https://github.com/Layr-Labs/devkit-cli/pull/243)
8f080030d93f6ae4e83fcc7f4b1f31089b954123: fix: fixing workflow permissions by @anupsv (https://github.com/Layr-Labs/devkit-cli/pull/236)
eee71f8f04ce112b22743c118479e8f37988fe58: fix: ensure we're consistently using v6.5.2 of golangci/golangci-lint-action by @grezle (https://github.com/Layr-Labs/devkit-cli/pull/244)
65c122123696e3fad714f5b250785333794e02ac: feat: allow operators to define keys for each operatorSet by @grezle (https://github.com/Layr-Labs/devkit-cli/pull/245/)
5a05c46d75a1966d851d697091ef0a5713a880a0: fix: add missing migration details by @grezle (https://github.com/Layr-Labs/devkit-cli/pull/247)
3810bd63de6e820097ede99e6fd571b1525c3fe9: feat: expose language selection to relevant template scripts by @grezle (https://github.com/Layr-Labs/devkit-cli/pull/224)
89f4abca96a9790bceb96268a2deb3d8e69f066d: fix: export chainInfo into outputs artifacts by @grezle (https://github.com/Layr-Labs/devkit-cli/pull/248)
93999c79ff1e291a3578304153a7c47162f61860: fix: load templateBaseUrl from config correctly by @grezle (https://github.com/Layr-Labs/devkit-cli/pull/251)
a8a651f3d96c1c0b986dbe433810138e5bf7667d: feat: upgrading the hourglass avs template version by @bdchatham (https://github.com/Layr-Labs/devkit-cli/pull/252)
424de415b5c1f3c0edded1d385ff0a0e18b1d9c2: fix: set PermissionController in context by @grezle (https://github.com/Layr-Labs/devkit-cli/pull/254)
19af8ff807b19100ce0129345a72b16badfdcd7c: feat: implement wizard for context creation by @grezle (https://github.com/Layr-Labs/devkit-cli/pull/255)
32b4c44efa72d974ddd9759abf947de005844977: feat: allow operatorSets to be registered from context by @grezle (https://github.com/Layr-Labs/devkit-cli/pull/253)
127930b848ed14ea95570b2a4d79aadffb9f9f8c: feat: set context_name in posthog metrics by @grezle (https://github.com/Layr-Labs/devkit-cli/pull/259)
3a62a56113f8cec6984e76156c1f4671132e5376: fix: take ownership of multichain contracts and register transporters BLS key by @grezle (https://github.com/Layr-Labs/devkit-cli/pull/261)
9ced76ad3cc5edb65f46fd9cfaf900f52bdaa240: fix: use BN254CertificateVerifier for calcOperatorInfoLeaf call by @grezle (https://github.com/Layr-Labs/devkit-cli/pull/262)
2175ab698b60a8158457bdae223560743449b2bd: refactor: tidy up transporter flow by @grezle (https://github.com/Layr-Labs/devkit-cli/pull/263)
d99dd09ef0a9520d4bf9c935f66b21eb453c24dd: feat: pass config+context json to run command by @grezle (https://github.com/Layr-Labs/devkit-cli/pull/264)
223eb18b95b6fe3e097d02bc7d9109324a060d24: fix: only update generator on initial Transporter run by @grezle (https://github.com/Layr-Labs/devkit-cli/pull/266)
23a70ffa948c3a66f97dd6aecc656af68da7f439: chore: bumping hourglass template version to use latest binary by @bdchatham (https://github.com/Layr-Labs/devkit-cli/pull/265)
4dca543936c7bfcbc6b25c6aa76a0c45d8a9d01d: fix: default baseUrl/version if omitted by @grezle (https://github.com/Layr-Labs/devkit-cli/pull/267)
678e1cf9a272250010c013f318111a20fa2dc5a8: fix: use newNode for untouched prop migrations by @grezle (https://github.com/Layr-Labs/devkit-cli/pull/268)
d4735fe01321869a580c5a32c358eba5ce7e14df: feat: integrate ECDSA registration for KeyRegistrar by @grezle https://github.com/Layr-Labs/devkit-cli/pull/269)
e880d087d2d7f4e2d03ef81cdc0ad695687a1f5e: feat: check task result is produced after avs call by @grezle (https://github.com/Layr-Labs/devkit-cli/pull/258)
ae3211574ff23c3671e407743ab88aa206bc8c8f: chore: bumping base template version to default to ECDSA curveType by @grezle (https://github.com/Layr-Labs/devkit-cli/pull/270)

**Full Changelog**: https://github.com/Layr-Labs/devkit-cli/compare/v0.0.10...v0.1.0-preview.4.rc

### **Pre-Release Preparation**

- [x] **Versioning**
    - Update version number consistently across:
        - `README.md`
        - Codebase
        - Release notes
- [x] **Release Notes**
    - Clearly document all user-facing changes, fixes, and known issues.
- [ ] **Prerelease Artifacts**
    - Ensure release pipeline generates binaries/packages for each target architecture:
        - [ ]  Linux (`amd64`, `arm64`)
        - [ ]  macOS (`amd64`, `arm64`)
        

### **Communication**

- [ ]  Announce new release internally (Slack, email, etc.) and externally as appropriate.

