### PR TITLE
fix: take base of projectName for config

### DIFF
--- a/pkg/commands/create.go
+++ b/pkg/commands/create.go
@@ -281,7 +281,7 @@ func copyDefaultConfigToProject(logger iface.Logger, targetDir, projectName, pro
 	if err := yaml.Unmarshal([]byte(configContent), &cfg); err != nil {
 		return fmt.Errorf("failed to unmarshal config YAML: %w", err)
 	}
-	cfg.Config.Project.Name = projectName
+	cfg.Config.Project.Name = filepath.Base(projectName)
 	cfg.Config.Project.ProjectUUID = projectUUID
 	cfg.Config.Project.TelemetryEnabled = telemetryEnabled
 	cfg.Config.Project.TemplateBaseURL = templateBaseURL


### PR DESCRIPTION
<!-- 
    🚨 ATTENTION! 🚨 
    
    This PR template is REQUIRED. PRs not following this format will be closed without review.
    
    Requirements:
    - PR title must follow commit conventions: https://www.conventionalcommits.org/en/v1.0.0/
    - Label your PR with the correct type (e.g., 🐛 Bug, ✨ Enhancement, 🧪 Test, etc.)
    - Provide clear and specific details in each section
-->

**Motivation:**
<!--
Explain here the context, and why you're making that change. What is the problem you're trying to solve.
-->
As a devkit user, I want to be able to create a project relative to my current position and have the projectName be placed correctly to prevent later cmds from failing.

**Modifications:**
<!--
Describe the modifications you've done from a high level. What are the key technical decisions and why were they made?
-->
- Takes `filepath.Base(projectName)` for config project name 

**Result:**
<!--
*After your change, what will change.
-->
- No container naming problems after relative path creates