### PR TITLE
fix: updating the Hourglass binary digest for release command

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-v0.1.0-preview.4.rc
+v0.1.0-preview.5.rc

--- a/config/templates.yaml
+++ b/config/templates.yaml
@@ -1,7 +1,7 @@
 framework:
   hourglass:
     template: "https://github.com/Layr-Labs/hourglass-avs-template"
-    version: "v0.0.25"
+    version: "v0.0.26"
     languages:
       - go
       - ts

--- a/pkg/template/config_test.go
+++ b/pkg/template/config_test.go
@@ -17,7 +17,7 @@ func TestLoadConfig(t *testing.T) {
 	}
 
 	expectedBaseURL := "https://github.com/Layr-Labs/hourglass-avs-template"
-	expectedVersion := "v0.0.25"
+	expectedVersion := "v0.0.26"
 
 	if mainBaseURL != expectedBaseURL {
 		t.Errorf("Unexpected main template base URL: got %s, want %s", mainBaseURL, expectedBaseURL)


### PR DESCRIPTION
<!-- 
    🚨 ATTENTION! 🚨 
    
    This PR template is REQUIRED. PRs not following this format will be closed without review.
    
    Requirements:
    - PR title must follow commit conventions: https://www.conventionalcommits.org/en/v1.0.0/
    - Label your PR with the correct type (e.g., 🐛 Bug, ✨ Enhancement, 🧪 Test, etc.)
    - Provide clear and specific details in each section
-->

**Motivation:**
 - When a user uses the `release publish` command, this file is used to source the Hourglass binary. This is critical for users leveraging hgctl or any AVS generally distributing their application.

**Modifications:**
- SHA change

**Result:**
- Functional Aggregator & Executor distribution

**Testing:**

**Open questions:**
<!--
(optional) Any open questions or feedback on design desired?
-->