### PR TITLE
feat: use appropriate zeusEnv for contextName

### DIFF
--- a/pkg/common/zeus.go
+++ b/pkg/common/zeus.go
@@ -35,20 +35,30 @@ type L2ZeusAddressData struct {
 }
 
 // GetZeusAddresses runs the zeus env show commands and extracts core EigenLayer addresses.
-func GetZeusAddresses(ctx context.Context, logger iface.Logger) (*L1ZeusAddressData, *L2ZeusAddressData, error) {
+func GetZeusAddresses(ctx context.Context, logger iface.Logger, contextName string) (*L1ZeusAddressData, *L2ZeusAddressData, error) {
 	var (
 		l1Raw, l2Raw []byte
 		err          error
 	)
 
+	// Default zeus env to sepolia for testnet/devnet
+	l1ZeusEnv := "testnet-sepolia"
+	l2ZeusEnv := "testnet-base-sepolia"
+
+	// Overide with mainnet envs
+	if contextName == "mainnet" {
+		l1ZeusEnv = "mainnet"
+		l2ZeusEnv = "base"
+	}
+
 	// Run L1
-	l1Raw, err = runZeusJSON(ctx, "testnet-sepolia")
+	l1Raw, err = runZeusJSON(ctx, l1ZeusEnv)
 	if err != nil {
 		return nil, nil, fmt.Errorf("zeus L1: %w", err)
 	}
 
 	// Run L2
-	l2Raw, err = runZeusJSON(ctx, "testnet-base-sepolia")
+	l2Raw, err = runZeusJSON(ctx, l2ZeusEnv)
 	if err != nil {
 		return nil, nil, fmt.Errorf("zeus L2: %w", err)
 	}
@@ -126,7 +136,7 @@ func GetZeusAddresses(ctx context.Context, logger iface.Logger) (*L1ZeusAddressD
 // UpdateContextWithZeusAddresses updates the context configuration with addresses from Zeus
 func UpdateContextWithZeusAddresses(context context.Context, logger iface.Logger, contextMap *yaml.Node, contextName string) error {
 	logger.Title("Fetching EigenLayer core addresses for L1 and L2 from Zeus...")
-	l1Addresses, l2Addresses, err := GetZeusAddresses(context, logger)
+	l1Addresses, l2Addresses, err := GetZeusAddresses(context, logger, contextName)
 	if err != nil {
 		return err
 	}

--- a/pkg/common/zeus.go
+++ b/pkg/common/zeus.go
@@ -45,7 +45,7 @@ func GetZeusAddresses(ctx context.Context, logger iface.Logger, contextName stri
 	l1ZeusEnv := "testnet-sepolia"
 	l2ZeusEnv := "testnet-base-sepolia"
 
-	// Overide with mainnet envs
+	// Override with mainnet envs
 	if contextName == "mainnet" {
 		l1ZeusEnv = "mainnet"
 		l2ZeusEnv = "base"


### PR DESCRIPTION
<!-- 
    🚨 ATTENTION! 🚨 
    
    This PR template is REQUIRED. PRs not following this format will be closed without review.
    
    Requirements:
    - PR title must follow commit conventions: https://www.conventionalcommits.org/en/v1.0.0/
    - Label your PR with the correct type (e.g., 🐛 Bug, ✨ Enhancement, 🧪 Test, etc.)
    - Provide clear and specific details in each section
-->

**Motivation:**
<!--
Explain here the context, and why you're making that change. What is the problem you're trying to solve.
-->
As a devkit user, I want to be able to create and deploy to a mainnet environment and have addresses autopopulated from zeus.

**Modifications:**
<!--
Describe the modifications you've done from a high level. What are the key technical decisions and why were they made?
-->
- Defaults zeus env to `sepolia` except for `mainnet` context

**Result:**
<!--
*After your change, what will change.
-->
- Can deploy correctly to a `mainnet` env
