### PR TITLE
fix: create tmp directory in working directory

### DIFF
--- a/config/.gitignore
+++ b/config/.gitignore
@@ -29,6 +29,9 @@ Thumbs.db
 # Release outputs
 temp_external/
 
+# Internal upgrade directory
+temp_internal/
+
 # DevKit context configurations (only devnet.yaml is indexed)
 config/contexts/**/*
 !config/contexts/devnet.yaml

--- a/pkg/commands/template/upgrade.go
+++ b/pkg/commands/template/upgrade.go
@@ -157,14 +157,14 @@ func createUpgradeCommand(
 				return fmt.Errorf("uncommitted changes found, please commit or stash them before upgrading")
 			}
 
-			// Ensure .gitignore entry is present for tempExternal
-			tempExternal := "temp_external"
-			if err := gitClient.EnsureGitignoreEntry(".gitignore", tempExternal); err != nil {
-				return fmt.Errorf("failed to add entry to .gitignore %s: %w", tempExternal, err)
+			// Ensure .gitignore entry is present for tempInternal
+			tempInternal := "temp_internal"
+			if err := gitClient.EnsureGitignoreEntry(".gitignore", fmt.Sprintf("%s/", tempInternal)); err != nil {
+				return fmt.Errorf("failed to add entry to .gitignore %s: %w", tempInternal, err)
 			}
 
 			// Ensure parent exists
-			tempParent := filepath.Join(absProjectPath, tempExternal)
+			tempParent := filepath.Join(absProjectPath, tempInternal)
 			if err := os.MkdirAll(tempParent, 0o755); err != nil {
 				return fmt.Errorf("failed to create %s: %w", tempParent, err)
 			}

--- a/pkg/commands/template/upgrade.go
+++ b/pkg/commands/template/upgrade.go
@@ -148,13 +148,19 @@ func createUpgradeCommand(
 			// Create a gitClient for upgrade process
 			gitClient := template.NewGitClient()
 
+			// Check if working tree is clean before upgrading
+			clean, err := gitClient.GitIsClean()
+			if err != nil {
+				return fmt.Errorf("failed to check .git working tree state: %w", err)
+			}
+			if !clean {
+				return fmt.Errorf("uncommitted changes found, please commit or stash them before upgrading")
+			}
+
 			// Ensure .gitignore entry is present for tempExternal
 			tempExternal := "temp_external"
 			if err := gitClient.EnsureGitignoreEntry(".gitignore", tempExternal); err != nil {
 				return fmt.Errorf("failed to add entry to .gitignore %s: %w", tempExternal, err)
-			}
-			if err := gitClient.Commit(".gitignore", fmt.Sprintf("chore: ensure %s is in .gitignore", tempExternal)); err != nil {
-				return fmt.Errorf("failed to commit entry to .gitignore %s: %w", tempExternal, err)
 			}
 
 			// Ensure parent exists

--- a/pkg/commands/template/upgrade.go
+++ b/pkg/commands/template/upgrade.go
@@ -145,18 +145,34 @@ func createUpgradeCommand(
 				return fmt.Errorf("failed to get current working directory: %w", err)
 			}
 
-			// Create temporary directory for cloning the template
-			tempDir, err := os.MkdirTemp("", "devkit-template-upgrade-*")
+			// Ensure parent exists
+			tempParent := filepath.Join(absProjectPath, "temp_external")
+			if err := os.MkdirAll(tempParent, 0o755); err != nil {
+				return fmt.Errorf("failed to create %s: %w", tempParent, err)
+			}
+
+			// Create run-specific temp dir inside tempParent
+			tempDir, err := os.MkdirTemp(tempParent, ".tmp-devkit-template-upgrade-*")
 			if err != nil {
 				return fmt.Errorf("failed to create temporary directory: %w", err)
 			}
-			defer os.RemoveAll(tempDir) // Clean up on exit
 
-			tempCacheDir, err := os.MkdirTemp("", "devkit-template-cache-*")
-			if err != nil {
-				return fmt.Errorf("failed to create temporary cache directory: %w", err)
-			}
-			defer os.RemoveAll(tempCacheDir) // Clean up on exit
+			// Remove tempParent if it is empty after tempDir cleanup
+			defer func() {
+				err = os.RemoveAll(tempDir)
+				if err != nil {
+					logger.Warn("failed to remove %s: %v\n", tempDir, err)
+				}
+				entries, err := os.ReadDir(tempParent)
+				if err != nil {
+					logger.Warn("could not read %s: %v\n", tempParent, err)
+				}
+				if len(entries) == 0 {
+					if err := os.Remove(tempParent); err != nil {
+						logger.Warn("failed to remove %s: %v\n", tempParent, err)
+					}
+				}
+			}()
 
 			logger.Info("Upgrading project template:")
 			logger.Info("  Project: %s", projectName)

--- a/pkg/commands/template/upgrade.go
+++ b/pkg/commands/template/upgrade.go
@@ -145,8 +145,20 @@ func createUpgradeCommand(
 				return fmt.Errorf("failed to get current working directory: %w", err)
 			}
 
+			// Create a gitClient for upgrade process
+			gitClient := template.NewGitClient()
+
+			// Ensure .gitignore entry is present for tempExternal
+			tempExternal := "temp_external"
+			if err := gitClient.EnsureGitignoreEntry(".gitignore", tempExternal); err != nil {
+				return fmt.Errorf("failed to add entry to .gitignore %s: %w", tempExternal, err)
+			}
+			if err := gitClient.Commit(".gitignore", fmt.Sprintf("chore: ensure %s is in .gitignore", tempExternal)); err != nil {
+				return fmt.Errorf("failed to commit entry to .gitignore %s: %w", tempExternal, err)
+			}
+
 			// Ensure parent exists
-			tempParent := filepath.Join(absProjectPath, "temp_external")
+			tempParent := filepath.Join(absProjectPath, tempExternal)
 			if err := os.MkdirAll(tempParent, 0o755); err != nil {
 				return fmt.Errorf("failed to create %s: %w", tempParent, err)
 			}
@@ -187,7 +199,7 @@ func createUpgradeCommand(
 
 			// Fetch main template
 			fetcher := &template.GitFetcher{
-				Client: template.NewGitClient(),
+				Client: gitClient,
 				Logger: *progresslogger.NewProgressLogger(
 					logger,
 					tracker,

--- a/pkg/commands/template/upgrade_test.go
+++ b/pkg/commands/template/upgrade_test.go
@@ -103,6 +103,11 @@ func TestUpgradeCommand(t *testing.T) {
 		t.Fatalf("Failed to write config file: %v", err)
 	}
 
+	// Create git repo in temp dir
+	if err := testutils.TestGitInit(testProjectsDir); err != nil {
+		t.Fatalf("Failed init git repo: %v", err)
+	}
+
 	// Create mock template info getter
 	mockTemplateInfoGetter := &MockTemplateInfoGetter{
 		projectName:      "template-upgrade-test",
@@ -137,6 +142,11 @@ func TestUpgradeCommand(t *testing.T) {
 
 	// Test upgrade command with version flag
 	t.Run("Upgrade command with version", func(t *testing.T) {
+		// Discard changes between runs
+		if err := testutils.TestGitDiscardChanges(testProjectsDir); err != nil {
+			t.Fatalf("Failed to clean working tree: %v", err)
+		}
+
 		// Create a flag set and context with no-op logger
 		set := flag.NewFlagSet("test", 0)
 		set.String("version", "v0.0.4", "")
@@ -186,6 +196,11 @@ func TestUpgradeCommand(t *testing.T) {
 
 	// Test upgrade command without version flag
 	t.Run("Upgrade command without version", func(t *testing.T) {
+		// Discard changes between runs
+		if err := testutils.TestGitDiscardChanges(testProjectsDir); err != nil {
+			t.Fatalf("Failed to clean working tree: %v", err)
+		}
+
 		// Create a flag set and context without version flag, with no-op logger
 		set := flag.NewFlagSet("test", 0)
 
@@ -233,6 +248,11 @@ func TestUpgradeCommand(t *testing.T) {
 
 	// Test upgrade command with incompatible to devkit version
 	t.Run("Upgrade command with incompatible version", func(t *testing.T) {
+		// Discard changes between runs
+		if err := testutils.TestGitDiscardChanges(testProjectsDir); err != nil {
+			t.Fatalf("Failed to clean working tree: %v", err)
+		}
+
 		// Create a flag set and context with no-op logger
 		set := flag.NewFlagSet("test", 0)
 		set.String("version", "v0.0.5", "")
@@ -258,6 +278,11 @@ func TestUpgradeCommand(t *testing.T) {
 
 	// Test with missing config file
 	t.Run("No config file", func(t *testing.T) {
+		// Discard changes between runs
+		if err := testutils.TestGitDiscardChanges(testProjectsDir); err != nil {
+			t.Fatalf("Failed to clean working tree: %v", err)
+		}
+
 		// Create a separate directory without a config file
 		noConfigDir := filepath.Join(testProjectsDir, "no-config")
 		err = os.MkdirAll(noConfigDir, 0755)

--- a/pkg/template/git_client.go
+++ b/pkg/template/git_client.go
@@ -2,6 +2,7 @@ package template
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -240,6 +241,17 @@ func (g *GitClient) ParseCloneOutput(r io.Reader, rep Reporter, dest string, ref
 	return nil
 }
 
+func (g *GitClient) GitIsClean() (bool, error) {
+	cmd := exec.Command("git", "status", "--porcelain")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return false, fmt.Errorf("git status failed: %w\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()) == "", nil
+}
+
 func (g *GitClient) EnsureGitignoreEntry(path, entry string) error {
 	// Create .gitignore if missing
 	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0o644)
@@ -263,6 +275,11 @@ func (g *GitClient) EnsureGitignoreEntry(path, entry string) error {
 	if _, err := f.WriteString("\n" + entry + "\n"); err != nil {
 		return fmt.Errorf("write %s: %w", path, err)
 	}
+
+	if err := g.Commit(".gitignore", fmt.Sprintf("chore: ensure %s is in .gitignore", entry)); err != nil {
+		return fmt.Errorf("failed to commit entry to .gitignore %s: %w", entry, err)
+	}
+
 	return nil
 }
 

--- a/pkg/template/git_client.go
+++ b/pkg/template/git_client.go
@@ -239,3 +239,45 @@ func (g *GitClient) ParseCloneOutput(r io.Reader, rep Reporter, dest string, ref
 	}
 	return nil
 }
+
+func (g *GitClient) EnsureGitignoreEntry(path, entry string) error {
+	// Create .gitignore if missing
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0o644)
+	if err != nil {
+		return fmt.Errorf("open %s: %w", path, err)
+	}
+	defer f.Close()
+
+	// Check if entry exists
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		if strings.TrimSpace(scanner.Text()) == entry {
+			return nil // already present
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("scan %s: %w", path, err)
+	}
+
+	// Append entry
+	if _, err := f.WriteString("\n" + entry + "\n"); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}
+
+func (g *GitClient) Commit(file, msg string) error {
+	cmds := [][]string{
+		{"git", "add", file},
+		{"git", "commit", "-m", msg},
+	}
+
+	for _, args := range cmds {
+		cmd := exec.Command(args[0], args[1:]...)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("%s failed: %v\n%s", strings.Join(args, " "), err, string(out))
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
<!-- 
    🚨 ATTENTION! 🚨 
    
    This PR template is REQUIRED. PRs not following this format will be closed without review.
    
    Requirements:
    - PR title must follow commit conventions: https://www.conventionalcommits.org/en/v1.0.0/
    - Label your PR with the correct type (e.g., 🐛 Bug, ✨ Enhancement, 🧪 Test, etc.)
    - Provide clear and specific details in each section
-->

**Motivation:**
<!--
Explain here the context, and why you're making that change. What is the problem you're trying to solve.
-->
As a devkit user that wants to upgrade to the latest template changes, I want any temp directory that is created to hold the correct permissions so that I do not need any `$TMPDIR` workarounds.

**Modifications:**
<!--
Describe the modifications you've done from a high level. What are the key technical decisions and why were they made?
-->
- Creates upgrade temp directory in cwd under `temp_internal`
- Checks working tree is clean before upgrading
- Adds `temp_internal` entry to `.gitignore` if missing and commits changes

**Result:**
<!--
*After your change, what will change.
-->
- Successful upgrades within the cwd

**Testing:**
<!--
*List testing procedures taken and useful artifacts.
-->
- Unit tests pass and manually tested against VRF

**Open questions:**
<!--
(optional) Any open questions or feedback on design desired?
-->
- ~~We should perform an upgrade to ensure the temp directory we use is present in the projects `.gitignore`. If the `.gitignore` does not have the appropriate entry, upgrades will fail with `Uncommitted changes found`~~