### PR TITLE
fix: save anvil docker-compose.yaml to projects dir

### DIFF
--- a/docker/anvil/devnetembed.go
+++ b/docker/anvil/devnetembed.go
@@ -2,6 +2,7 @@ package assets
 
 import (
 	_ "embed"
+	"fmt"
 	"os"
 	"path/filepath"
 )
@@ -11,22 +12,20 @@ var DockerCompose []byte
 
 // WriteDockerComposeToPath writes docker-compose.yaml to a fixed path.
 func WriteDockerComposeToPath() (string, error) {
-	dir := filepath.Join(os.TempDir(), "devkit-compose")
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return "", err
+	// Get project's absolute path
+	absProjectPath, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("failed to get current working directory: %w", err)
 	}
+	// Store anvils docker-compose.yaml in devnet dir at project root
+	dir := filepath.Join(absProjectPath, "devnet")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", fmt.Errorf("failed to create %s: %w", dir, err)
+	}
+	// Write embed each devnet start to ensure any changes are propagated
 	path := filepath.Join(dir, "docker-compose.yaml")
-	err := os.WriteFile(path, DockerCompose, 0o644)
-	return path, err
-}
-
-
-// GetDockerComposePath returns the known path to docker-compose.yaml without writing.
-func GetDockerComposePath() string {
-	return filepath.Join(os.TempDir(), "devkit-compose", "docker-compose.yaml")
-}
-
-// GetStateJSONPath returns the known path to state.json without writing.
-func GetStateJSONPath() string {
-	return filepath.Join(os.TempDir(), "devkit-state", "state.json")
+	if err = os.WriteFile(path, DockerCompose, 0o644); err != nil {
+		return "", fmt.Errorf("failed to write %s: %w", path, err)
+	}
+	return path, nil
 }


### PR DESCRIPTION
<!-- 
    🚨 ATTENTION! 🚨 
    
    This PR template is REQUIRED. PRs not following this format will be closed without review.
    
    Requirements:
    - PR title must follow commit conventions: https://www.conventionalcommits.org/en/v1.0.0/
    - Label your PR with the correct type (e.g., 🐛 Bug, ✨ Enhancement, 🧪 Test, etc.)
    - Provide clear and specific details in each section
-->

**Motivation:**
<!--
Explain here the context, and why you're making that change. What is the problem you're trying to solve.
-->
As a devkit user, I want all temp dir usage to happen inside my project so that I do not need any `$TMPDIR` workarounds.

**Modifications:**
<!--
Describe the modifications you've done from a high level. What are the key technical decisions and why were they made?
-->
- Writes anvils devnet `docker-compose.yaml` to `./devnet/docker-compose.yaml`

**Result:**
<!--
*After your change, what will change.
-->
- All tmpdir usage is now pointing at the project root
