### PR TITLE
fix: skip ensure docker for L1 deploy outside of devnet

### DIFF
--- a/pkg/commands/deploy_actions.go
+++ b/pkg/commands/deploy_actions.go
@@ -235,12 +235,6 @@ func DeployL1ContractsAction(cCtx *cli.Context) error {
 	logger := common.LoggerFromContext(cCtx)
 	caser := cases.Title(language.English)
 
-	// Check if docker is running, else try to start it
-	err := common.EnsureDockerIsRunning(cCtx)
-	if err != nil {
-		return cli.Exit(err.Error(), 1)
-	}
-
 	// Start timing execution runtime
 	startTime := time.Now()
 
@@ -261,6 +255,7 @@ func DeployL1ContractsAction(cCtx *cli.Context) error {
 	contextName := cCtx.String("context")
 
 	// Check for context
+	var err error
 	var yamlPath string
 	var rootNode, contextNode *yaml.Node
 	if contextName == "" {

--- a/pkg/commands/devnet_actions.go
+++ b/pkg/commands/devnet_actions.go
@@ -330,6 +330,13 @@ func StartDevnetAction(cCtx *cli.Context) error {
 
 	// Deploy the contracts after starting devnet unless skipped
 	if !skipDeployContracts {
+		// Check if docker is running, else try to start it
+		err := common.EnsureDockerIsRunning(cCtx)
+		if err != nil {
+			return cli.Exit(err.Error(), 1)
+		}
+
+		// Call deploy L1 action within devnet context
 		if err := DeployL1ContractsAction(cCtx); err != nil {
 			return fmt.Errorf("deploy-contracts failed - please restart devnet and try again: %w", err)
 		}


### PR DESCRIPTION
<!-- 
    🚨 ATTENTION! 🚨 
    
    This PR template is REQUIRED. PRs not following this format will be closed without review.
    
    Requirements:
    - PR title must follow commit conventions: https://www.conventionalcommits.org/en/v1.0.0/
    - Label your PR with the correct type (e.g., 🐛 Bug, ✨ Enhancement, 🧪 Test, etc.)
    - Provide clear and specific details in each section
-->

**Motivation:**
<!--
Explain here the context, and why you're making that change. What is the problem you're trying to solve.
-->
As a devkit user deploying to testnet/mainnet, I do not need to have docker running and the deployment should not start docker for me.

**Modifications:**
<!--
Describe the modifications you've done from a high level. What are the key technical decisions and why were they made?
-->
- Moves `EnsureDockerIsRunning` call to devnet branches

**Result:**
<!--
*After your change, what will change.
-->
- Docker is only ensured for devnet deployments